### PR TITLE
Update JUnit and Maven Surefire plugin versions to fix Maven Unit Test run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <jersey.version>3.1.1</jersey.version>
         <jetty.version>11.0.16</jetty.version>
         <junit.jupiter.version>5.13.2</junit.jupiter.version>
+        <surefire.plugin.version>3.5.2</surefire.plugin.version>
     </properties>
 
     <dependencies>
@@ -279,7 +280,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>${surefire.plugin.version}</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <forkCount>1</forkCount>
@@ -327,7 +328,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>${surefire.plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Upgrade JUnit and Maven Surefire plugin to the latest stable releases for improved performance and compatibility.