### PR TITLE
Upgrade bcprov-jdk18on to 1.79 to address CVE-2025-8916

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -115,17 +115,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- this package is explicitly added to override the vulnerable version consumed by org.apache.hadoop:hadoop-common@3.4.1 -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.79</version>
-        </dependency>
         <!-- Sec Finding Override for hadoop-common: -->
         <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>10.4.2</version>
+        </dependency>
+        <!-- this package is explicitly added to override the vulnerable version consumed by org.apache.hadoop:hadoop-common@3.4.1 -->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.79</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Pinning the version of org.bouncycastle to address a security vulnerability.

