### PR TITLE
Update java and maven version in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,7 @@
                 "GitHub.copilot-chat"
             ],
             "settings": {
-                "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/17.0.14-ms"
+                "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/17.0.16-ms"
             }
         }
     },

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Stage 1: Build the application
 ##################################################
 ARG JAVA_VERSION=11
-ARG MAVEN_VERSION=3.8.7
+ARG MAVEN_VERSION=3.8.8
 
 FROM maven:${MAVEN_VERSION}-amazoncorretto-${JAVA_VERSION} AS build
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The script generates fake person data and optionally repeats a percentage of rec
 
 Prerequisites:
 - Java 11 SDK
-- Maven 3.8.7
+- Maven 3.8.8
 
 ```shell
 cd lib/java
@@ -312,7 +312,7 @@ For detailed instructions on using the development container, see the [Dev Conta
 The Dev Container provides:
 
 - Java 11 SDK pre-installed
-- Maven 3.8.7 pre-installed
+- Maven 3.8.8 pre-installed
 - All necessary dependencies configured
 - Git and other development tools
 - SSL certificate handling for corporate environments

--- a/lib/java/README.md
+++ b/lib/java/README.md
@@ -5,7 +5,7 @@ This is the Java implementation of the OpenToken library
 ## Prerequisites
 
 - Java 11 SDK or higher
-- Maven 3.8.7 or higher
+- Maven 3.8.8 or higher
 
 ## Installation
 


### PR DESCRIPTION
To set up the dev container locally, we need to install Java and Maven. However, the required versions are not available and must be updated to higher versions.