### PR TITLE
Fix Snyk finding: Upgrade jackson-core to 2.17.2

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -207,7 +207,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>[2.15.0,2.16.0)</version>
+            <version>2.17.2</version>
         </dependency>
         <!-- DNSJava for InetAddressResolverProvider -->
         <dependency>


### PR DESCRIPTION
Fixes Snyk security finding by pinning jackson-core to 2.17.2 (replacing version range [2.15.0,2.16.0)).

**Changes**

Updated [pom.xml](vscode-file://vscode-app/Users/saran/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): jackson-core version now explicitly set to 2.17.2