### PR TITLE
Align Maven publish workflow with Docker: support all release event types

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,7 +5,7 @@ name: Maven Package
 
 on:
   release:
-    types: [created]
+    types: [created, published, released]
 
 jobs:
   build:


### PR DESCRIPTION
Updated the Maven Package workflow to trigger on all GitHub release event types (created, published, released) to ensure consistent behavior across all publishing workflows and improve reliability regardless of how releases are created.