### PR TITLE
Fix Python wheel build: Add MANIFEST.in and pyproject.toml

### DIFF
--- a/lib/python/MANIFEST.in
+++ b/lib/python/MANIFEST.in
@@ -1,12 +1,10 @@
-# Include the root README
-include ../../README.md
-
-# Include license file
-include ../../LICENSE
-
-# Include requirements files
+# Include requirements files (must be in same directory as setup.py)
 include requirements.txt
 include dev-requirements.txt
+
+# Try to include root README and LICENSE
+include ../../README.md
+include ../../LICENSE
 
 # Include all Python source files
 recursive-include src *.py

--- a/lib/python/pyproject.toml
+++ b/lib/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Added Python package build configuration files (MANIFEST.in and pyproject.toml) to fix wheel generation errors and enable successful Python package publishing to Artifactory.

