### PR TITLE
fix: Update dependabot configuration for correct Maven and Python directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,16 @@
 version: 2
 updates:
   - package-ecosystem: "maven"
-    directory: "/"
+    directory: "lib/java"
     schedule:
       interval: "weekly"
 
   - package-ecosystem: "docker"
     directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "lib/python"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

This PR fixes the Dependabot configuration to correctly track dependencies in the OpenToken project's dual Java/Python structure.

## Changes

### Maven Directory Fix
- **Changed:** Maven package ecosystem directory from `/` to `lib/java`
- **Reason:** The `pom.xml` file is located in `lib/java/`, not at the repository root
- **Impact:** Dependabot will now correctly scan and update Maven dependencies

### Python Dependency Tracking
- **Added:** New pip package ecosystem configuration
- **Directory:** `lib/python` (where `requirements.txt` and `setup.py` are located)
- **Schedule:** Weekly updates (consistent with Maven configuration)
- **Impact:** Dependabot will now track and suggest updates for Python dependencies

## Benefits

- ✅ Automated security updates for both Java and Python dependencies
- ✅ Consistent weekly dependency scanning across both implementations
- ✅ Better security posture through timely vulnerability patches
- ✅ Reduced manual dependency management overhead

## Testing

- [x] Configuration syntax validated (YAML structure)
- [x] Directory paths verified against repository structure
- [x] Both `lib/java/pom.xml` and `lib/python/requirements.txt` exist at specified paths

## Checklist

- [x] Maven directory corrected to `lib/java`
- [x] Python pip ecosystem added
- [x] Weekly schedule configured for both ecosystems
- [x] Configuration follows Dependabot v2 schema