### PR TITLE
feat: Add Python package build and release workflow (superseded)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,6 @@ on:
   workflow_run:
     workflows: ["Create Release on Merge"]
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Closing in favor of new branch with correct naming convention: dev/mattwise-42/python-publish-workflow.

Superseded by new PR.