### PR TITLE
Fix bumpversion config duplicate entry

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -11,10 +11,6 @@ replace = <version>{new_version}</version>
 search = <version>{current_version}</version>
 replace = <version>{new_version}</version>
 
-[bumpversion:file:lib/java/opentoken-cli/pom.xml]
-search = <version>{current_version}</version>
-replace = <version>{new_version}</version>
-
 [bumpversion:file:Dockerfile]
 search = VERSION={current_version}
 replace = VERSION={new_version}


### PR DESCRIPTION
## Summary
- deduplicate bumpversion config for opentoken-pyspark setup.py to avoid duplicate section error

## Testing
- not run (config-only change)
