### PR TITLE
chore: update docs version references

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -66,3 +66,15 @@ replace = <version>{new_version}</version>
 [bumpversion:file:pages/reference/java-api.md]
 search = <version>{current_version}</version>
 replace = <version>{new_version}</version>
+
+[bumpversion:file:pages/reference/cli.md]
+search = "OpenTokenVersion": "{current_version}"
+replace = "OpenTokenVersion": "{new_version}"
+
+[bumpversion:file:pages/reference/metadata-format.md]
+search = "OpenTokenVersion": "{current_version}"
+replace = "OpenTokenVersion": "{new_version}"
+
+[bumpversion:file:pages/running-opentoken/index.md]
+search = "OpenTokenVersion": "{current_version}"
+replace = "OpenTokenVersion": "{new_version}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,61 +1,62 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
-    "name": "OpenToken",
-    "build": {
-        "context": "..",
-        "dockerfile": "Dockerfile",
-        "args": {
-            "JAVA_VERSION": "21"
-        }
+  "name": "OpenToken",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile",
+    "args": {
+      "JAVA_VERSION": "21"
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "configureZshAsDefaultShell": true
     },
-    "features": {
-        "ghcr.io/devcontainers/features/common-utils:2": {
-            "configureZshAsDefaultShell": true
-        },
-        "ghcr.io/devcontainers/features/java:1": {
-            "version": "21.0.9",
-            "installMaven": "true",
-            "mavenVersion": "3.8.8",
-            "installGradle": "false"
-        },
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-        "ghcr.io/devcontainers/features/git-lfs:1": {},
-        "ghcr.io/devcontainers/features/node:1": {},
-        "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "21.0.9",
+      "installMaven": "true",
+      "mavenVersion": "3.8.8",
+      "installGradle": "false"
     },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-azuretools.vscode-docker",
-                "streetsidesoftware.code-spell-checker",
-                "esbenp.prettier-vscode",
-                "DavidAnson.vscode-markdownlint",
-                "redhat.java",
-                "vscjava.vscode-java-pack",
-                "DotJoshJohnson.xml",
-                "yzhang.markdown-all-in-one",
-                "SonarSource.sonarlint-vscode",
-                "AdamViola.parquet-explorer",
-                "GitHub.vscode-pull-request-github",
-                "shengchen.vscode-checkstyle",
-                "GitHub.vscode-github-actions",
-                "GitHub.copilot-chat",
-                "ms-python.python",
-                "ms-toolsai.jupyter",
-                "mikoz.autoflake-extension"
-            ],
-            "settings": {
-                "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/21.0.9-ms"
-            }
-        }
-    },
-    "mounts": [
-        "type=volume,source=opentoken-venv,target=/workspaces/OpenToken/.venv"
-    ],
-    "containerEnv": {
-        "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell"
-    },
-    "postCreateCommand": "/bin/bash .devcontainer/scripts/setup_python_env.sh",
-    "postStartCommand": {}
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "streetsidesoftware.code-spell-checker",
+        "esbenp.prettier-vscode",
+        "DavidAnson.vscode-markdownlint",
+        "redhat.java",
+        "vscjava.vscode-java-pack",
+        "DotJoshJohnson.xml",
+        "yzhang.markdown-all-in-one",
+        "SonarSource.sonarlint-vscode",
+        "AdamViola.parquet-explorer",
+        "GitHub.vscode-pull-request-github",
+        "shengchen.vscode-checkstyle",
+        "GitHub.vscode-github-actions",
+        "GitHub.copilot-chat",
+        "ms-python.python",
+        "ms-toolsai.jupyter",
+        "mikoz.autoflake-extension"
+      ],
+      "settings": {
+        "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/21.0.9-ms"
+      }
+    }
+  },
+  "mounts": [
+    "type=volume,source=opentoken-venv,target=/workspaces/OpenToken/.venv"
+  ],
+  "containerEnv": {
+    "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell"
+  },
+  "postCreateCommand": "/bin/bash .devcontainer/scripts/setup_python_env.sh",
+  "postStartCommand": {}
 }

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -135,7 +135,7 @@ Every run generates a `.metadata.json` file:
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.12.2",
+  "OpenTokenVersion": "1.12.3",
   "TotalRows": 100,
   "TotalRowsWithInvalidAttributes": 3,
   "InvalidAttributesByType": {

--- a/pages/reference/metadata-format.md
+++ b/pages/reference/metadata-format.md
@@ -120,7 +120,7 @@ Extension: .metadata.json
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.12.2",
+  "OpenTokenVersion": "1.12.3",
   "TotalRows": 101,
   "TotalRowsWithInvalidAttributes": 9,
   "InvalidAttributesByType": {
@@ -148,7 +148,7 @@ Extension: .metadata.json
 {
   "Platform": "Python",
   "PythonVersion": "3.11.5",
-  "OpenTokenVersion": "1.12.2",
+  "OpenTokenVersion": "1.12.3",
   "TotalRows": 50,
   "TotalRowsWithInvalidAttributes": 2,
   "InvalidAttributesByType": {

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -133,7 +133,7 @@ record1,T2,pUxPgYL9+cMxkA+8928Pil+9W+dm9kISwHYPdkZS+I2nQ/bQ/8HyL3FOVf3NYPW5NKZZO
 ```json
 {
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.12.2",
+  "OpenTokenVersion": "1.12.3",
   "Platform": "Java",
   "TotalRows": 1,
   "TotalRowsWithInvalidAttributes": 0,


### PR DESCRIPTION
## Summary

Ensure bumpversion updates markdown version references and align docs to 1.12.3.

## Changes

- Add markdown files to bumpversion targets for OpenToken version references
- Update documentation examples to 1.12.3
- Refresh devcontainer configuration

## Testing

- [ ] Not run (docs/config changes only)

## Files Changed

- .bumpversion.cfg
- .devcontainer/devcontainer.json
- pages/reference/cli.md
- pages/reference/metadata-format.md
- pages/running-opentoken/index.md
