### PR TITLE
fix(deps): pin cryptography to 46.0.5

### DIFF
--- a/lib/python/opentoken-cli/requirements.txt
+++ b/lib/python/opentoken-cli/requirements.txt
@@ -7,4 +7,4 @@ pyarrow
 csv2parquet
 
 # Cryptography - mandate secure version to address CVE-2023-0286
-cryptography>=42.0.2
+cryptography==46.0.5

--- a/lib/python/opentoken/requirements.txt
+++ b/lib/python/opentoken/requirements.txt
@@ -1,2 +1,2 @@
 # Cryptography - mandate secure version to address CVE-2023-0286
-cryptography>=42.0.2
+cryptography==46.0.5


### PR DESCRIPTION
## Summary

Pin cryptography dependency to exact version 46.0.5 to address potential security vulnerabilities. Previous constraint (>=42.0.2) allowed any version above 42.0.2.

## Changes

- Pin `cryptography==46.0.5` in `lib/python/opentoken/requirements.txt`
- Pin `cryptography==46.0.5` in `lib/python/opentoken-cli/requirements.txt`

## Testing

- [x] Python core library tests pass (553 tests)
- [x] Cryptography version verified: 46.0.5
- [x] Installation successful for both opentoken and opentoken-cli

## Files Changed

- `lib/python/opentoken/requirements.txt` (1 line)
- `lib/python/opentoken-cli/requirements.txt` (1 line)