### PR TITLE
Release 1.12.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.12.4
+current_version = 1.12.5
 commit = False
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /app
 
 RUN addgroup --system appuser && adduser --system --no-create-home --ingroup appuser appuser
 
-ARG VERSION=1.12.4
+ARG VERSION=1.12.5
 COPY --from=build /app/opentoken-cli/target/opentoken-cli-${VERSION}.jar /usr/local/lib/opentoken.jar
 
 WORKDIR /app

--- a/demos/pprl-superhero-example/README.md
+++ b/demos/pprl-superhero-example/README.md
@@ -181,7 +181,7 @@ This demonstration shows how to properly compare tokens from two organizations t
 
 ### Prerequisites <!-- omit in toc -->
 
-- Java 11 or higher
+- Java 17 or higher
 - Maven 3.6 or higher
 - Python 3.7+ (for data generation and analysis)
 

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -56,7 +56,7 @@ This guide centralizes contributor-facing information. It covers local setup, la
 
 | Tool              | Recommended Version | Notes                                                                    |
 | ----------------- | ------------------- | ------------------------------------------------------------------------ |
-| Java JDK          | 21.x                | Required for Java module & CLI JAR (outputs Java 11 compatible bytecode) |
+| Java JDK          | 21.x                | Required for Java module & CLI JAR (outputs Java 17 compatible bytecode) |
 | Maven             | 3.8+                | Build Java artifacts (`mvn clean install`)                               |
 | Python            | 3.10+               | For Python implementation & scripts                                      |
 | pip / venv        | Latest              | Manage Python dependencies                                               |
@@ -90,7 +90,7 @@ This section combines the previous standalone Java and Python development sectio
 
 Prerequisites:
 
-- Java 21 SDK or higher (JAR output is Java 11 compatible)
+- Java 21 SDK or higher (JAR output is Java 17 compatible)
 - Maven 3.8.8 or higher
 
 Build all modules (from `lib/java`):

--- a/lib/java/opentoken-cli/pom.xml
+++ b/lib/java/opentoken-cli/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.82</version>
+            <version>1.83</version>
         </dependency>
 
         <dependency>

--- a/lib/java/opentoken-cli/pom.xml
+++ b/lib/java/opentoken-cli/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.truveta</groupId>
         <artifactId>opentoken-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>opentoken-cli</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
 
     <name>opentoken-cli</name>
     <description>OpenToken CLI - Command-line interface with CSV and Parquet support for token generation</description>

--- a/lib/java/opentoken/pom.xml
+++ b/lib/java/opentoken/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.truveta</groupId>
         <artifactId>opentoken-parent</artifactId>
-        <version>1.12.4</version>
+        <version>1.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>opentoken</artifactId>
     <packaging>jar</packaging>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
 
     <name>opentoken</name>
     <description>OpenToken Core Library - Privacy-preserving person matching using cryptographically secure token generation</description>

--- a/lib/java/opentoken/src/main/java/com/truveta/opentoken/Metadata.java
+++ b/lib/java/opentoken/src/main/java/com/truveta/opentoken/Metadata.java
@@ -25,7 +25,7 @@ public class Metadata {
     public static final String METADATA_FILE_EXTENSION = ".metadata.json";
     public static final String SYSTEM_JAVA_VERSION = System.getProperty("java.version");
 
-    public static final String DEFAULT_VERSION = "1.12.4";
+    public static final String DEFAULT_VERSION = "1.12.5";
 
     // Output format values
     public static final String OUTPUT_FORMAT_JSON = "JSON";

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.truveta</groupId>
     <artifactId>opentoken-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
 
     <name>opentoken-parent</name>
     <description>OpenToken Parent POM - Privacy-preserving person matching library</description>
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.truveta</groupId>
                 <artifactId>opentoken</artifactId>
-                <version>1.12.4</version>
+                <version>1.12.5</version>
             </dependency>
 
             <!-- JUnit 5 -->

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <junit.jupiter.version>6.0.2</junit.jupiter.version>
         <surefire.plugin.version>3.5.4</surefire.plugin.version>
         <mockito.version>5.21.0</mockito.version>

--- a/lib/python/opentoken-cli/requirements.txt
+++ b/lib/python/opentoken-cli/requirements.txt
@@ -1,5 +1,5 @@
 # Core opentoken dependency
-opentoken==1.12.4
+opentoken==1.12.5
 
 # Data processing for I/O formats
 pandas

--- a/lib/python/opentoken-cli/requirements.txt
+++ b/lib/python/opentoken-cli/requirements.txt
@@ -7,4 +7,4 @@ pyarrow
 csv2parquet
 
 # Cryptography - mandate secure version to address CVE-2023-0286
-cryptography>=42.0.2
+cryptography==46.0.5

--- a/lib/python/opentoken-cli/setup.py
+++ b/lib/python/opentoken-cli/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as
 
 setup(
     name="opentoken-cli",
-    version="1.12.4",
+    version="1.12.5",
     author="Truveta",
     description="OpenToken CLI - Command line interface for person matching",
     long_description=long_description,

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/__init__.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/__init__.py
@@ -7,5 +7,5 @@ This package provides the command line interface for tokenizing and processing
 person attributes using the OpenToken library.
 """
 
-__version__ = "1.12.4"
+__version__ = "1.12.5"
 __author__ = "Truveta"

--- a/lib/python/opentoken-pyspark/requirements.txt
+++ b/lib/python/opentoken-pyspark/requirements.txt
@@ -1,5 +1,5 @@
 # Core opentoken dependency
-opentoken==1.12.4
+opentoken==1.12.5
 
 # Cryptography for token decryption in overlap analysis
 pycryptodome>=3.18.0

--- a/lib/python/opentoken-pyspark/setup.py
+++ b/lib/python/opentoken-pyspark/setup.py
@@ -17,13 +17,13 @@ except FileNotFoundError:
 
 # Core dependencies (version-agnostic, no PySpark)
 core_requirements = [
-    "opentoken==1.12.4",
+    "opentoken==1.12.5",
     "pycryptodome>=3.18.0",
 ]
 
 setup(
     name="opentoken-pyspark",
-    version="1.12.4",
+    version="1.12.5",
     author="Truveta",
     description="OpenToken PySpark bridge for distributed token generation",
     long_description=long_description,

--- a/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/__init__.py
+++ b/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/__init__.py
@@ -4,7 +4,7 @@ Copyright (c) Truveta. All rights reserved.
 OpenToken PySpark Bridge - Distributed token generation for PySpark DataFrames.
 """
 
-__version__ = "1.12.4"
+__version__ = "1.12.5"
 
 from opentoken_pyspark.token_processor import OpenTokenProcessor
 from opentoken_pyspark.overlap_analyzer import OpenTokenOverlapAnalyzer

--- a/lib/python/opentoken/requirements.txt
+++ b/lib/python/opentoken/requirements.txt
@@ -1,2 +1,2 @@
 # Cryptography - mandate secure version to address CVE-2023-0286
-cryptography>=42.0.2
+cryptography==46.0.5

--- a/lib/python/opentoken/setup.py
+++ b/lib/python/opentoken/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as
 
 setup(
     name="opentoken",
-    version="1.12.4",
+    version="1.12.5",
     author="Truveta",
     description="OpenToken Python core library for person matching",
     long_description=long_description,

--- a/lib/python/opentoken/src/main/opentoken/__init__.py
+++ b/lib/python/opentoken/src/main/opentoken/__init__.py
@@ -7,7 +7,7 @@ This package provides utilities for tokenizing and processing person attributes
 using various cryptographic transformations.
 """
 
-__version__ = "1.12.4"
+__version__ = "1.12.5"
 __author__ = "Truveta"
 
 __all__ = [

--- a/lib/python/opentoken/src/main/opentoken/metadata.py
+++ b/lib/python/opentoken/src/main/opentoken/metadata.py
@@ -24,7 +24,7 @@ class Metadata:
     METADATA_FILE_EXTENSION = ".metadata.json"
     SYSTEM_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
-    DEFAULT_VERSION = "1.12.4"
+    DEFAULT_VERSION = "1.12.5"
 
     # Output format values
     OUTPUT_FORMAT_JSON = "JSON"

--- a/pages/dev-guide-development.md
+++ b/pages/dev-guide-development.md
@@ -54,7 +54,7 @@ This guide centralizes contributor-facing information. It covers local setup, la
 
 | Tool              | Recommended Version | Notes                                                                    |
 | ----------------- | ------------------- | ------------------------------------------------------------------------ |
-| Java JDK          | 21.x                | Required for Java module & CLI JAR (outputs Java 11 compatible bytecode) |
+| Java JDK          | 21.x                | Required for Java module & CLI JAR (outputs Java 17 compatible bytecode) |
 | Maven             | 3.8+                | Build Java artifacts (`mvn clean install`)                               |
 | Python            | 3.10+               | For Python implementation & scripts                                      |
 | pip / venv        | Latest              | Manage Python dependencies                                               |
@@ -88,7 +88,7 @@ This section combines the previous standalone Java and Python development sectio
 
 Prerequisites:
 
-- Java 21 SDK or higher (JAR output is Java 11 compatible)
+- Java 21 SDK or higher (JAR output is Java 17 compatible)
 - Maven 3.8.8 or higher
 
 Build all modules (from `lib/java`):

--- a/pages/quickstarts/java-quickstart.md
+++ b/pages/quickstarts/java-quickstart.md
@@ -156,7 +156,7 @@ To use OpenToken in your Java project:
 <dependency>
     <groupId>com.truveta</groupId>
     <artifactId>opentoken</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
 </dependency>
 ```
 

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -135,7 +135,7 @@ Every run generates a `.metadata.json` file:
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.12.4",
+  "OpenTokenVersion": "1.12.5",
   "TotalRows": 100,
   "TotalRowsWithInvalidAttributes": 3,
   "InvalidAttributesByType": {

--- a/pages/reference/java-api.md
+++ b/pages/reference/java-api.md
@@ -236,14 +236,14 @@ for (Map<Class<? extends Attribute>, String> personAttributes : persons) {
 <dependency>
     <groupId>com.truveta</groupId>
     <artifactId>opentoken</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
 </dependency>
 
 <!-- For CLI/IO classes -->
 <dependency>
     <groupId>com.truveta</groupId>
     <artifactId>opentoken-cli</artifactId>
-    <version>1.12.4</version>
+    <version>1.12.5</version>
 </dependency>
 ```
 

--- a/pages/reference/metadata-format.md
+++ b/pages/reference/metadata-format.md
@@ -120,7 +120,7 @@ Extension: .metadata.json
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.12.4",
+  "OpenTokenVersion": "1.12.5",
   "TotalRows": 101,
   "TotalRowsWithInvalidAttributes": 9,
   "InvalidAttributesByType": {
@@ -148,7 +148,7 @@ Extension: .metadata.json
 {
   "Platform": "Python",
   "PythonVersion": "3.11.5",
-  "OpenTokenVersion": "1.12.4",
+  "OpenTokenVersion": "1.12.5",
   "TotalRows": 50,
   "TotalRowsWithInvalidAttributes": 2,
   "InvalidAttributesByType": {

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -133,7 +133,7 @@ record1,T2,pUxPgYL9+cMxkA+8928Pil+9W+dm9kISwHYPdkZS+I2nQ/bQ/8HyL3FOVf3NYPW5NKZZO
 ```json
 {
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.12.4",
+  "OpenTokenVersion": "1.12.5",
   "Platform": "Java",
   "TotalRows": 1,
   "TotalRowsWithInvalidAttributes": 0,

--- a/tools/interoperability/README.md
+++ b/tools/interoperability/README.md
@@ -7,7 +7,7 @@ This directory contains tests that validate compatibility and consistency betwee
 - Python 3.10 or higher
 - pip (Python package installer)
 
-- Java 21 SDK or higher (JAR output compatible with Java 11)
+- Java 21 SDK or higher (JAR output compatible with Java 17)
 
 ## Test Categories
 


### PR DESCRIPTION
This pull request updates the project's Java compatibility from Java 11 to Java 17, ensures documentation reflects this change, and upgrades key cryptography dependencies for improved security. It also updates the Bouncy Castle dependency in the Java CLI module.

**Java Compatibility Updates:**

* Changed the Java bytecode compatibility from Java 11 to Java 17 in the main Maven configuration (`lib/java/pom.xml`) and updated the Java version requirements in all relevant documentation, including development guides and demos. [[1]](diffhunk://#diff-7f6d2f6e9e2063d0ca836be1ef35a7a5f35dbb0e01dff4d45cf17bf40a962d98L32-R32) [[2]](diffhunk://#diff-2d05f3d90f4bd7216eebdd8cd74355f6d5c0da21e6be20deeec82176b1d7692cL184-R184) [[3]](diffhunk://#diff-b8cd689f165b303f70e86198dd1b1c310d134c15e0ab0a6ced4b0e365c6ae2b4L59-R59) [[4]](diffhunk://#diff-b8cd689f165b303f70e86198dd1b1c310d134c15e0ab0a6ced4b0e365c6ae2b4L93-R93) [[5]](diffhunk://#diff-7ad092509ada6baa7f792bbd599fc919f02832a8602ae8271033b4574b4fdf45L57-R57) [[6]](diffhunk://#diff-7ad092509ada6baa7f792bbd599fc919f02832a8602ae8271033b4574b4fdf45L91-R91) [[7]](diffhunk://#diff-f1357a5749d724c9d48491c9a412c272b0a4af1fb38a2cc77fa206b371fee05dL10-R10)

**Dependency Upgrades:**

* Upgraded the `bcprov-jdk18on` (Bouncy Castle) dependency from version 1.82 to 1.83 in the Java CLI module (`lib/java/opentoken-cli/pom.xml`).
* Pinned the `cryptography` Python package to version 46.0.5 in both the CLI and core requirements files for enhanced security. [[1]](diffhunk://#diff-d42bd40e89183386e74d5e1cf3c7d4bb0362d0c950fc52f16cfd8369807e89a7L10-R10) [[2]](diffhunk://#diff-7505b0eb136cc9ba255bd82f8e645a1455f78b136d30696f0dd801c539c66517L2-R2)