### PR TITLE
dep(cli): override aircompressor dependency to v3.5

### DIFF
--- a/lib/java/opentoken-cli/pom.xml
+++ b/lib/java/opentoken-cli/pom.xml
@@ -45,6 +45,11 @@
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>
+                <artifactId>aircompressor</artifactId>
+                <version>2.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.airlift</groupId>
                 <artifactId>aircompressor-v3</artifactId>
                 <version>3.5</version>
             </dependency>
@@ -94,6 +99,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>1.14.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>aircompressor-v3</artifactId>
         </dependency>
 
         <!-- Parquet/Hadoop -->
@@ -162,6 +172,10 @@
             <artifactId>parquet-hadoop</artifactId>
             <version>1.17.0</version>
             <exclusions>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>aircompressor</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-client-runtime</artifactId>

--- a/lib/java/opentoken-cli/pom.xml
+++ b/lib/java/opentoken-cli/pom.xml
@@ -45,8 +45,8 @@
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>
-                <artifactId>aircompressor</artifactId>
-                <version>2.0.2</version>
+                <artifactId>aircompressor-v3</artifactId>
+                <version>3.5</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Summary

Override the CLI transitive compression dependency to use the v3 artifact and version requested.

## Changes

- Replaced `io.airlift:aircompressor` with `io.airlift:aircompressor-v3` in CLI `dependencyManagement`
- Set override version to `3.5`
- Kept the change scoped to the CLI Maven module

## Testing

- [x] `cd lib/java && mvn clean install`
- [x] Verify dependency tree resolves `io.airlift:aircompressor-v3:3.5`

## Files Changed

- `lib/java/opentoken-cli/pom.xml` (2 lines changed)