### PR TITLE
feat: add --demo-mode flag to tokenize subcommand (Java + Python)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,9 @@
       "installGradle": "false"
     },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-    "ghcr.io/devcontainers/features/git-lfs:1": {}
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/copilot-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {
     "vscode": {
@@ -48,13 +50,19 @@
     }
   },
   "mounts": [
-    "type=volume,source=opentoken-venv,target=/workspaces/OpenToken/.venv"
+    "type=volume,source=opentoken-venv,target=${containerWorkspaceFolder}/.venv",
+    "type=volume,source=opentoken-copilot,target=/home/vscode/.copilot"
   ],
   "containerEnv": {
-    "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell"
+    "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell",
+    "TMPDIR": "/workspaces/${localWorkspaceFolderBasename}/.tmp"
   },
   "postCreateCommand": {
-    "setup-py-env": "/bin/bash .devcontainer/scripts/setup_python_env.sh"
+    "setup-py-env": "/bin/bash .devcontainer/scripts/setup_python_env.sh",
+    "clone-superpowers": "git clone --branch main --single-branch https://github.com/jsloat/superpowers-for-copilot.git ~/.copilot/superpowers-skills",
+    "create-tmp-dir": "mkdir -p \"$TMPDIR\""
   },
-  "postStartCommand": {}
+  "postStartCommand": {
+    "fix-mount-permissions": "for d in /home/vscode/.copilot; do [ -d \"$d\" ] || continue; sudo chown -R vscode:vscode \"$d\"; done"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,7 +45,7 @@
         "dbaeumer.vscode-eslint"
       ],
       "settings": {
-        "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/21.0.9-ms"
+        "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/21.0.10-ms"
       }
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
       "configureZshAsDefaultShell": true
     },
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "21.0.9",
+      "version": "21.0.10",
       "installMaven": "true",
       "mavenVersion": "3.8.8",
       "installGradle": "false"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,9 @@
       "mavenVersion": "3.8.8",
       "installGradle": "false"
     },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20.12.0"
+    },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/copilot-cli:1": {},
@@ -54,15 +57,13 @@
     "type=volume,source=opentoken-copilot,target=/home/vscode/.copilot"
   ],
   "containerEnv": {
-    "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell",
-    "TMPDIR": "/workspaces/${localWorkspaceFolderBasename}/.tmp"
+    "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell"
   },
   "postCreateCommand": {
-    "setup-py-env": "/bin/bash .devcontainer/scripts/setup_python_env.sh",
-    "clone-superpowers": "git clone --branch main --single-branch https://github.com/jsloat/superpowers-for-copilot.git ~/.copilot/superpowers-skills",
-    "create-tmp-dir": "mkdir -p \"$TMPDIR\""
+    "setup-py-env": "/bin/bash .devcontainer/scripts/setup_python_env.sh"
   },
   "postStartCommand": {
-    "fix-mount-permissions": "for d in /home/vscode/.copilot; do [ -d \"$d\" ] || continue; sudo chown -R vscode:vscode \"$d\"; done"
+    "fix-mount-permissions": "for d in /home/vscode/.copilot; do [ -d \"$d\" ] || continue; sudo chown -R vscode:vscode \"$d\"; done",
+    "clone-superpowers": "[ ! -d ~/.copilot/superpowers-skills ] && mkdir -p ~/.copilot && curl -L https://github.com/jsloat/superpowers-for-copilot/archive/refs/heads/main.tar.gz | tar -xz -C ~/.copilot -f - && mv ~/.copilot/superpowers-for-copilot-main ~/.copilot/superpowers-skills || true"
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,7 @@ This document provides comprehensive guidance for AI coding agents working on th
 
 ## Architecture Overview
 
-**OpenToken** is a dual-implementation (Java/Python) library for privacy-preserving person matching using cryptographically secure token generation. Tokens are generated from deterministic person attributes (name, birthdate, SSN, etc.) using 5 distinct token rules (T1-T5). Both implementations must produce **identical tokens** for the same normalized input.
+**OpenToken** is a dual-implementation (Java/Python) library for privacy-preserving record linkage using cryptographically secure token generation. Tokens are generated from deterministic person attributes (name, birthdate, SSN, etc.) using 5 distinct token rules (T1-T5). Both implementations must produce **identical tokens** for the same normalized input.
 
 ### Core Components
 

--- a/.github/workflows/multi-language-sync.yml
+++ b/.github/workflows/multi-language-sync.yml
@@ -40,11 +40,15 @@ jobs:
           BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
           echo "Checking sync requirements against base branch: origin/$BASE_BRANCH"
 
-          # Generate sync report with completion tracking using full PR context
+          # Generate sync report with completion tracking using full PR context.
+          # Disable exit-on-error so a non-zero exit (sync incomplete) doesn't
+          # abort the step before we can capture and report the result.
+          set +e
           SYNC_REPORT=$(python3 tools/multi_language_syncer.py \
             --format github-checklist \
             --since "origin/$BASE_BRANCH" 2>&1)
           SYNC_EXIT_CODE=$?
+          set -e
 
           echo "SYNC_REPORT<<EOF" >> $GITHUB_OUTPUT
           echo "$SYNC_REPORT" >> $GITHUB_OUTPUT
@@ -55,7 +59,7 @@ jobs:
           if echo "$SYNC_REPORT" | grep -q "completed)"; then
             COMPLETION_STATUS=$(echo "$SYNC_REPORT" | grep -o "([0-9]*/[0-9]* completed)" | head -1)
             echo "COMPLETION_STATUS=$COMPLETION_STATUS" >> $GITHUB_OUTPUT
-            
+
             # Extract numbers for progress calculation
             COMPLETED=$(echo "$COMPLETION_STATUS" | sed -nE 's/^\(([0-9]+)\/[0-9]+.*$/\1/p')
             if [ -z "$COMPLETED" ]; then
@@ -67,7 +71,7 @@ jobs:
             fi
             echo "COMPLETED=$COMPLETED" >> $GITHUB_OUTPUT
             echo "TOTAL=$TOTAL" >> $GITHUB_OUTPUT
-            
+
             if [ "$COMPLETED" -eq "$TOTAL" ]; then
               echo "SYNC_COMPLETE=true" >> $GITHUB_OUTPUT
             else
@@ -102,24 +106,24 @@ jobs:
               if (completed > 0) {
                 finalStatusLine = `**Final Status**: ${completionStatus}`;
               }
-              
+
               commentBody = `${SYNC_MARKER}
               ## Multi-Language Sync Status: Complete! ✅
               All changes in this PR are properly synchronized across Java, Python, and other implementations.
               ` + finalStatusLine;
-            } else {            
+            } else {
               commentBody = `${SYNC_MARKER}
               ## 🔄 Multi-Language Sync Progress ${completionStatus}
               ${syncReport}
               ### 📋 How to use this checklist:
               - **✓🔄** = File exists and was recently updated ✅ **COMPLETED**
-              - **✓⏳** = File exists but needs updates ⏳ **PENDING** 
+              - **✓⏳** = File exists but needs updates ⏳ **PENDING**
               - **✗⏳** = File missing and needs to be created ⏳ **PENDING**
-              
+
               ### 🌐 Languages:
               - **Java** → Python
               - **Python** → Java
-              
+
               ### Multi-commit workflow support:
               This sync tracker monitors your progress across **all commits in this PR**. As you update files, they'll automatically show as 🔄 completed in subsequent workflow runs!
               **Next steps**: Update the ⏳ pending files to complete the sync.`;
@@ -132,8 +136,8 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const syncComments = comments.data.filter(comment => 
-              comment.user.type === 'Bot' && 
+            const syncComments = comments.data.filter(comment =>
+              comment.user.type === 'Bot' &&
               comment.body.includes(SYNC_MARKER)
             );
 

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tools/sync-report-*.json
 demos/pprl-superhero-example/outputs/
 demos/pprl-superhero-example/datasets/
 .worktrees/
+.tmp/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,6 @@
   "[markdown]": {
     "editor.defaultFormatter": "yzhang.markdown-all-in-one"
   },
-  "chat.useAgentSkills": true
+  "chat.useAgentSkills": true,
+  "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/current"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,5 @@
   "[markdown]": {
     "editor.defaultFormatter": "yzhang.markdown-all-in-one"
   },
-  "chat.useAgentSkills": true,
-  "sonarlint.ls.javaHome": "/usr/local/sdkman/candidates/java/current"
+  "chat.useAgentSkills": true
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Privacy-preserving tokenization and matching library for secure PII-based person
 
 ## Introduction
 
-Our approach to person matching relies on building a set of matching tokens (or token signatures) per person which are derived from deterministic person data but preserve privacy by using cryptographically secure hashing algorithms.
+Our approach to record linkage relies on building a set of matching tokens (or token signatures) per person which are derived from deterministic person data but preserve privacy by using cryptographically secure hashing algorithms.
 
 - [OpenToken](#opentoken)
   - [Introduction](#introduction)

--- a/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/commands/OpenTokenCommand.java
+++ b/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/commands/OpenTokenCommand.java
@@ -20,7 +20,7 @@ import picocli.CommandLine.HelpCommand;
  * Main entry point command for OpenToken CLI with subcommands.
  * Provides modern, subcommand-based interface for token operations.
  */
-@Command(name = "opentoken", description = "Privacy-preserving person matching via cryptographic tokens", mixinStandardHelpOptions = true, version = OpenTokenCommand.CLI_VERSION, subcommands = {
+@Command(name = "opentoken", description = "Privacy-preserving record linkage via cryptographic tokens", mixinStandardHelpOptions = true, version = OpenTokenCommand.CLI_VERSION, subcommands = {
         HelpCommand.class,
         TokenizeCommand.class,
         EncryptCommand.class,
@@ -31,7 +31,7 @@ public class OpenTokenCommand implements Callable<Integer> {
 
     private static final String VERSION = Metadata.DEFAULT_VERSION;
     public static final String CLI_VERSION = "OpenToken " + VERSION;
-    private static final String BANNER_SUBTITLE = "Privacy-Preserving Person Matching v" + VERSION;
+    private static final String BANNER_SUBTITLE = "Privacy-Preserving Record Linkage v" + VERSION;
 
     private static final Logger logger = LoggerFactory.getLogger(OpenTokenCommand.class);
 
@@ -108,7 +108,7 @@ public class OpenTokenCommand implements Callable<Integer> {
     /**
      * Execute the CLI without calling System.exit().
      * Useful for testing or when embedding the CLI in another application.
-     * 
+     *
      * @param args command-line arguments
      * @return exit code (0 for success, non-zero for errors)
      */

--- a/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/commands/TokenizeCommand.java
+++ b/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/commands/TokenizeCommand.java
@@ -67,7 +67,7 @@ public class TokenizeCommand implements Callable<Integer> {
     private String outputType;
 
     @Option(names = {
-            "--demo-mode" }, description = "Enable demo mode: output plain SHA-256 hex tokens without HMAC hashing."
+            "--demo-mode" }, description = "Enable demo mode: output raw pipe-separated attribute signature strings with no hashing."
                     + " --hashingsecret is not required in this mode."
                     + " Demo output is NOT suitable for production or cross-organisation exchange.")
     private boolean demoMode;
@@ -85,7 +85,7 @@ public class TokenizeCommand implements Callable<Integer> {
     @Override
     public Integer call() {
         if (demoMode) {
-            logger.warn("Running in DEMO MODE - tokens are plain SHA-256 hex strings, not HMAC-hashed."
+            logger.warn("Running in DEMO MODE - tokens are raw attribute signature strings with no hashing."
                     + " Do not use demo-mode output in production or share it externally.");
         } else {
             logger.info("Running tokenize command (normal mode)");

--- a/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/commands/TokenizeCommand.java
+++ b/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/commands/TokenizeCommand.java
@@ -25,67 +25,85 @@ import com.truveta.opentoken.cli.processor.PersonAttributesProcessor;
 import com.truveta.opentoken.cli.util.StringMaskingUtil;
 import com.truveta.opentoken.tokentransformer.HashTokenTransformer;
 import com.truveta.opentoken.tokentransformer.TokenTransformer;
+import com.truveta.opentoken.tokens.tokenizer.PassthroughTokenizer;
 
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
- * Tokenize command - generates hashed tokens from person attributes.
- * This is hash-only mode without encryption.
+ * Tokenize command - generates tokens from person attributes.
+ *
+ * <p>Normal mode (default): applies SHA-256 then HMAC-SHA256 hashing on the token
+ * signature, producing opaque base64 tokens. {@code --hashingsecret} is required.
+ *
+ * <p>Demo mode ({@code --demo-mode}): skips all hashing so tokens are the raw
+ * pipe-separated attribute signature strings. No secret is needed, making it easy
+ * to explore the output without managing secrets. Demo-mode output is
+ * <strong>not</strong> suitable for production or cross-organisation exchange.
  */
-@Command(
-    name = "tokenize",
-    description = "Generate hashed tokens from person attributes (hash-only mode)"
-)
+@Command(name = "tokenize", description = {
+        "Generate tokens from person attributes.",
+        "",
+        "Normal mode: tokens are HMAC-SHA256 hashed (--hashingsecret required).",
+        "Demo mode (--demo-mode): tokens are plain attribute signature strings; no secret needed."
+})
 public class TokenizeCommand implements Callable<Integer> {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(TokenizeCommand.class);
     private static final String TYPE_CSV = "csv";
     private static final String TYPE_PARQUET = "parquet";
-    
-    @Option(names = {"-i", "--input"}, required = true, 
-            description = "Input file path")
+
+    @Option(names = { "-i", "--input" }, required = true, description = "Input file path")
     private String inputPath;
-    
-    @Option(names = {"-o", "--output"}, required = true,
-            description = "Output file path")
+
+    @Option(names = { "-o", "--output" }, required = true, description = "Output file path")
     private String outputPath;
-    
-    @Option(names = {"-t", "--input-type"}, required = true,
-            description = "Input file type: csv or parquet")
+
+    @Option(names = { "-t", "--input-type" }, required = true, description = "Input file type: csv or parquet")
     private String inputType;
-    
-    @Option(names = {"-ot", "--output-type"}, 
-            description = "Output file type (defaults to input type): csv or parquet")
+
+    @Option(names = { "-ot",
+            "--output-type" }, description = "Output file type (defaults to input type): csv or parquet")
     private String outputType;
-    
-    @Option(names = {"-h", "--hashingsecret"}, required = true,
-            description = "Hashing secret for token generation")
+
+    @Option(names = {
+            "--demo-mode" }, description = "Enable demo mode: output plain SHA-256 hex tokens without HMAC hashing."
+                    + " --hashingsecret is not required in this mode."
+                    + " Demo output is NOT suitable for production or cross-organisation exchange.")
+    private boolean demoMode;
+
+    @Option(names = { "-h",
+            "--hashingsecret" }, description = "Hashing secret for HMAC-SHA256 token generation (required in normal mode)")
     private String hashingSecret;
-    
-    @Option(names = {"--help"}, usageHelp = true,
-            description = "Show this help message and exit")
+
+    @Option(names = { "--help" }, usageHelp = true, description = "Show this help message and exit")
     private boolean helpRequested;
-    
-    @Option(names = {"-V", "--version"}, versionHelp = true,
-            description = "Print version information and exit")
+
+    @Option(names = { "-V", "--version" }, versionHelp = true, description = "Print version information and exit")
     private boolean versionRequested;
-    
+
     @Override
     public Integer call() {
-        logger.info("Running tokenize command (hash-only mode)");
-        
+        if (demoMode) {
+            logger.warn("Running in DEMO MODE - tokens are plain SHA-256 hex strings, not HMAC-hashed."
+                    + " Do not use demo-mode output in production or share it externally.");
+        } else {
+            logger.info("Running tokenize command (normal mode)");
+        }
+
         // Default output type to input type if not specified
         if (outputType == null || outputType.isEmpty()) {
             outputType = inputType;
         }
-        
-        // Log parameters (mask secret)
+
+        // Log parameters (mask secret only when present)
         logger.info("Input: {} ({})", inputPath, inputType);
         logger.info("Output: {} ({})", outputPath, outputType);
-        logger.info("Hashing Secret: {}", maskString(hashingSecret));
-        
-        // Validate types
+        if (!demoMode && logger.isInfoEnabled()) {
+            logger.info("Hashing Secret: {}", maskString(hashingSecret));
+        }
+
+        // Validate file types
         if (!isValidType(inputType)) {
             logger.error("Invalid input type: {}. Must be 'csv' or 'parquet'", inputType);
             return 1;
@@ -94,13 +112,13 @@ public class TokenizeCommand implements Callable<Integer> {
             logger.error("Invalid output type: {}. Must be 'csv' or 'parquet'", outputType);
             return 1;
         }
-        
-        // Validate secret
-        if (hashingSecret == null || hashingSecret.isBlank()) {
-            logger.error("Hashing secret is required");
+
+        // --hashingsecret is required in normal mode only
+        if (!demoMode && (hashingSecret == null || hashingSecret.isBlank())) {
+            logger.error("--hashingsecret is required in normal mode. Use --demo-mode to skip hashing.");
             return 1;
         }
-        
+
         try {
             processTokens();
             logger.info("Token generation completed successfully");
@@ -110,38 +128,41 @@ public class TokenizeCommand implements Callable<Integer> {
             return 1;
         }
     }
-    
+
     private void processTokens() throws IOException {
-        List<TokenTransformer> transformers = new ArrayList<>();
-        
-        try {
-            // Add only hash transformer (no encryption in tokenize mode)
-            transformers.add(new HashTokenTransformer(hashingSecret));
-        } catch (Exception e) {
-            logger.error("Error initializing hash transformer", e);
-            throw new RuntimeException("Failed to initialize transformer", e);
-        }
-        
+        Metadata metadata = new Metadata();
+        Map<String, Object> metadataMap = metadata.initialize();
+
         try (PersonAttributesReader reader = createReader(inputPath, inputType);
-             PersonAttributesWriter writer = createWriter(outputPath, outputType)) {
-            
-            // Create metadata
-            Metadata metadata = new Metadata();
-            Map<String, Object> metadataMap = metadata.initialize();
-            metadata.addHashedSecret(Metadata.HASHING_SECRET_HASH, hashingSecret);
-            
-            // Process data
-            PersonAttributesProcessor.process(reader, writer, transformers, metadataMap);
-            
-            // Write metadata
+                PersonAttributesWriter writer = createWriter(outputPath, outputType)) {
+
+            if (demoMode) {
+                // Skip SHA-256 and HMAC: use PassthroughTokenizer so tokens are the
+                // raw pipe-separated attribute signature strings.
+                PersonAttributesProcessor.process(reader, writer,
+                        new PassthroughTokenizer(List.of()), metadataMap);
+            } else {
+                // Only record the hashing-secret hash in normal mode
+                metadata.addHashedSecret(Metadata.HASHING_SECRET_HASH, hashingSecret);
+                PersonAttributesProcessor.process(reader, writer, buildHashTransformers(), metadataMap);
+            }
             MetadataWriter metadataWriter = new MetadataJsonWriter(outputPath);
             metadataWriter.write(metadataMap);
         } catch (Exception e) {
-            logger.error("Error processing tokens", e);
             throw new IOException("Failed to process tokens", e);
         }
     }
-    
+
+    private List<TokenTransformer> buildHashTransformers() throws IOException {
+        List<TokenTransformer> transformers = new ArrayList<>();
+        try {
+            transformers.add(new HashTokenTransformer(hashingSecret));
+        } catch (Exception e) {
+            throw new IOException("Failed to initialize hash transformer", e);
+        }
+        return transformers;
+    }
+
     private PersonAttributesReader createReader(String path, String type) throws IOException {
         return switch (type.toLowerCase()) {
             case TYPE_CSV -> new PersonAttributesCSVReader(path);
@@ -149,7 +170,7 @@ public class TokenizeCommand implements Callable<Integer> {
             default -> throw new IllegalArgumentException("Unsupported input type: " + type);
         };
     }
-    
+
     private PersonAttributesWriter createWriter(String path, String type) throws IOException {
         return switch (type.toLowerCase()) {
             case TYPE_CSV -> new PersonAttributesCSVWriter(path);
@@ -157,11 +178,11 @@ public class TokenizeCommand implements Callable<Integer> {
             default -> throw new IllegalArgumentException("Unsupported output type: " + type);
         };
     }
-    
+
     private boolean isValidType(String type) {
         return TYPE_CSV.equalsIgnoreCase(type) || TYPE_PARQUET.equalsIgnoreCase(type);
     }
-    
+
     private String maskString(String input) {
         return StringMaskingUtil.maskString(input);
     }

--- a/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/processor/PersonAttributesProcessor.java
+++ b/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/processor/PersonAttributesProcessor.java
@@ -26,6 +26,7 @@ import com.truveta.opentoken.tokens.TokenDefinition;
 import com.truveta.opentoken.tokens.TokenGenerator;
 import com.truveta.opentoken.tokens.TokenGeneratorResult;
 import com.truveta.opentoken.tokens.tokenizer.SHA256Tokenizer;
+import com.truveta.opentoken.tokens.tokenizer.Tokenizer;
 import com.truveta.opentoken.tokentransformer.JweMatchTokenFormatter;
 import com.truveta.opentoken.tokentransformer.TokenTransformer;
 
@@ -52,7 +53,7 @@ public final class PersonAttributesProcessor {
      * Reads person attributes from the input data source, generates token, and
      * write the result back to the output data source. The tokens can be optionally
      * transformed before writing.
-     * 
+     *
      * @param reader               the reader initialized with the input data
      *                             source.
      * @param writer               the writer initialized with the output data
@@ -60,7 +61,7 @@ public final class PersonAttributesProcessor {
      * @param tokenTransformerList a list of token transformers.
      * @param metadataMap          the metadata map to populate with processing statistics.
      * @throws IOException if an I/O error occurs during processing.
-     * 
+     *
      * @see com.truveta.opentoken.cli.io.PersonAttributesReader PersonAttributesReader
      * @see com.truveta.opentoken.cli.io.PersonAttributesWriter PersonAttributesWriter
      * @see com.truveta.opentoken.tokentransformer.TokenTransformer TokenTransformer
@@ -71,10 +72,29 @@ public final class PersonAttributesProcessor {
     }
 
     /**
+     * Reads person attributes from the input data source, generates tokens using
+     * the provided tokenizer, and writes the result to the output data source.
+     *
+     * <p>Use this overload when you need full control over the tokenization strategy,
+     * for example passing a {@link com.truveta.opentoken.tokens.tokenizer.PassthroughTokenizer}
+     * for demo mode.
+     *
+     * @param reader      the reader initialized with the input data source.
+     * @param writer      the writer initialized with the output data source.
+     * @param tokenizer   the tokenizer to use (e.g. SHA256Tokenizer or PassthroughTokenizer).
+     * @param metadataMap the metadata map to populate with processing statistics.
+     * @throws IOException if an I/O error occurs during processing.
+     */
+    public static void process(PersonAttributesReader reader, PersonAttributesWriter writer,
+            Tokenizer tokenizer, Map<String, Object> metadataMap) throws IOException {
+        processWithTokenizer(reader, writer, tokenizer, metadataMap, null, null);
+    }
+
+    /**
      * Reads person attributes from the input data source, generates token, and
      * write the result back to the output data source. The tokens can be optionally
      * transformed before writing and wrapped in JWE format if ring ID is provided.
-     * 
+     *
      * @param reader               the reader initialized with the input data
      *                             source.
      * @param writer               the writer initialized with the output data
@@ -84,7 +104,7 @@ public final class PersonAttributesProcessor {
      * @param encryptionKey        the encryption key for JWE wrapping (optional, null to skip JWE).
      * @param ringId               the ring ID for JWE wrapping (optional, null to skip JWE).
      * @throws IOException if an I/O error occurs during processing.
-     * 
+     *
      * @see com.truveta.opentoken.cli.io.PersonAttributesReader PersonAttributesReader
      * @see com.truveta.opentoken.cli.io.PersonAttributesWriter PersonAttributesWriter
      * @see com.truveta.opentoken.tokentransformer.TokenTransformer TokenTransformer
@@ -92,10 +112,16 @@ public final class PersonAttributesProcessor {
     public static void process(PersonAttributesReader reader, PersonAttributesWriter writer,
             List<TokenTransformer> tokenTransformerList, Map<String, Object> metadataMap,
             String encryptionKey, String ringId) throws IOException {
+        processWithTokenizer(reader, writer, new SHA256Tokenizer(tokenTransformerList),
+                metadataMap, encryptionKey, ringId);
+    }
+
+    private static void processWithTokenizer(PersonAttributesReader reader, PersonAttributesWriter writer,
+            Tokenizer tokenizer, Map<String, Object> metadataMap,
+            String encryptionKey, String ringId) throws IOException {
 
         TokenDefinition tokenDefinition = new TokenDefinition();
-        TokenGenerator tokenGenerator = new TokenGenerator(tokenDefinition,
-                new SHA256Tokenizer(tokenTransformerList));
+        TokenGenerator tokenGenerator = new TokenGenerator(tokenDefinition, tokenizer);
 
         Map<Class<? extends Attribute>, String> row;
         TokenGeneratorResult tokenGeneratorResult;
@@ -225,7 +251,7 @@ public final class PersonAttributesProcessor {
 
     /**
      * Initialize the invalid attribute count map with attributes used in the token definition set to 0.
-     * This ensures that all attribute types used in token generation appear in the metadata 
+     * This ensures that all attribute types used in token generation appear in the metadata
      * even in happy path scenarios.
      *
      * @param tokenDefinition the token definition containing all token rules and their attribute expressions

--- a/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/processor/PersonAttributesProcessor.java
+++ b/lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/processor/PersonAttributesProcessor.java
@@ -82,7 +82,7 @@ public final class PersonAttributesProcessor {
      * @param reader      the reader initialized with the input data source.
      * @param writer      the writer initialized with the output data source.
      * @param tokenizer   the tokenizer to use (e.g. SHA256Tokenizer or PassthroughTokenizer).
-     * @param metadataMap the metadata map to populate with processing statistics.
+     * @param metadataMap optional metadata map to update with processing statistics.
      * @throws IOException if an I/O error occurs during processing.
      */
     public static void process(PersonAttributesReader reader, PersonAttributesWriter writer,

--- a/lib/java/opentoken-cli/src/test/java/com/truveta/opentoken/cli/commands/TokenizeCommandDemoModeTest.java
+++ b/lib/java/opentoken-cli/src/test/java/com/truveta/opentoken/cli/commands/TokenizeCommandDemoModeTest.java
@@ -1,0 +1,370 @@
+/**
+ * Copyright (c) Truveta. All rights reserved.
+ */
+package com.truveta.opentoken.cli.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.truveta.opentoken.Metadata;
+
+/**
+ * Targeted tests for {@code tokenize --demo-mode} mode selection, validation,
+ * and output shape.
+ *
+ * <p>Normal mode requires {@code --hashingsecret} and produces HMAC-SHA256 base64 tokens.
+ * Demo mode skips all hashing (SHA-256 and HMAC), producing the raw pipe-separated
+ * attribute signature strings and excluding the hashing-secret hash from metadata.
+ */
+class TokenizeCommandDemoModeTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path inputCsv;
+    private Path outputCsv;
+
+    private static final String HASHING_SECRET = "TestHashingSecret";
+
+    /** Two-record input covering all token-rule attributes. */
+    private static final String CSV_CONTENT = """
+            RecordId,FirstName,LastName,PostalCode,Sex,BirthDate,SocialSecurityNumber
+            test-001,John,Doe,98004,Male,2000-01-15,123-45-6789
+            test-002,Jane,Smith,90210,Female,1985-07-22,234-56-7890
+            """;
+
+    /**
+     * Pattern for HMAC-SHA256 base64 output produced in normal mode.
+     * HMAC-SHA256 always produces 32 bytes → base64 → exactly 44 chars.
+     */
+    private static final int NORMAL_MODE_TOKEN_LENGTH = 44;
+
+    /**
+     * Sentinel value written by the tokenizer when no valid attributes are available
+     * for a rule. Matches {@code Token.BLANK} in the core library.
+     */
+    private static final String BLANK_TOKEN = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        inputCsv = tempDir.resolve("input.csv");
+        outputCsv = tempDir.resolve("output.csv");
+        Files.writeString(inputCsv, CSV_CONTENT);
+    }
+
+    // -------------------------------------------------------------------------
+    // Mode-selection: which transformer path is chosen
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testDemoMode_SucceedsWithoutHashingSecret() {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--demo-mode"
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertEquals(0, exitCode, "Demo mode should succeed without --hashingsecret");
+        assertTrue(Files.exists(outputCsv), "Output file should be created in demo mode");
+    }
+
+    @Test
+    void testNormalMode_SucceedsWithHashingSecret() {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--hashingsecret", HASHING_SECRET
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertEquals(0, exitCode, "Normal mode should succeed with --hashingsecret");
+        assertTrue(Files.exists(outputCsv), "Output file should be created in normal mode");
+    }
+
+    @Test
+    void testDemoMode_AcceptsHashingSecretWithoutError() {
+        // --hashingsecret is ignored in demo mode, but providing it must not fail
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--demo-mode",
+                "--hashingsecret", HASHING_SECRET
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertEquals(0, exitCode, "Demo mode should accept a --hashingsecret without error");
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation: flag-combination guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testNormalMode_FailsWithoutHashingSecret() {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString()
+                // --hashingsecret intentionally omitted
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertNotEquals(0, exitCode,
+                "Normal mode must exit non-zero when --hashingsecret is missing");
+    }
+
+    @Test
+    void testNormalMode_FailsWithBlankHashingSecret() {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--hashingsecret", "   "
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertNotEquals(0, exitCode,
+                "Normal mode must exit non-zero when --hashingsecret is blank");
+    }
+
+    @Test
+    void testDemoMode_FailsWithInvalidInputType() {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "xml",
+                "-o", outputCsv.toString(),
+                "--demo-mode"
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertNotEquals(0, exitCode,
+                "Demo mode should still reject an invalid --type value");
+    }
+
+    @Test
+    void testDemoMode_FailsWithInvalidOutputType() {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "-ot", "json",
+                "--demo-mode"
+        };
+
+        int exitCode = OpenTokenCommand.execute(args);
+        assertNotEquals(0, exitCode,
+                "Demo mode should still reject an invalid --output-type value");
+    }
+
+    // -------------------------------------------------------------------------
+    // Output shape: token value format
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testDemoMode_TokensArePlainSignatureStrings() throws IOException {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--demo-mode"
+        };
+
+        OpenTokenCommand.execute(args);
+
+        List<String> nonBlankTokens = extractTokenValues(outputCsv);
+        assertFalse(nonBlankTokens.isEmpty(), "Expected at least one non-blank token in demo mode");
+
+        // Multi-attribute rules (T1-T4) produce pipe-separated signatures
+        assertTrue(nonBlankTokens.stream().anyMatch(t -> t.contains("|")),
+                "At least one demo-mode token must be a pipe-separated signature (T1-T4 rules)");
+
+        // HMAC-SHA256 base64 output is always exactly 44 chars; raw signatures never are
+        for (String token : nonBlankTokens) {
+            assertNotEquals(NORMAL_MODE_TOKEN_LENGTH, token.length(),
+                    "Demo-mode tokens must not be 44-char HMAC base64 strings, but got: " + token);
+        }
+    }
+
+    @Test
+    void testNormalMode_TokensAreBase64HmacStrings() throws IOException {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--hashingsecret", HASHING_SECRET
+        };
+
+        OpenTokenCommand.execute(args);
+
+        List<String> nonBlankTokens = extractTokenValues(outputCsv);
+        assertFalse(nonBlankTokens.isEmpty(), "Expected at least one non-blank token in normal mode");
+        for (String token : nonBlankTokens) {
+            // HMAC-SHA256 base64 tokens are always exactly 44 chars
+            assertEquals(NORMAL_MODE_TOKEN_LENGTH, token.length(),
+                    "Normal-mode tokens must be 44-char HMAC base64 strings but got: " + token);
+        }
+    }
+
+    @Test
+    void testDemoMode_AndNormalMode_ProduceDifferentTokensForSameInput() throws IOException {
+        Path outputDemo = tempDir.resolve("output_demo.csv");
+        Path outputNormal = tempDir.resolve("output_normal.csv");
+
+        OpenTokenCommand.execute(new String[] {
+                "tokenize", "-i", inputCsv.toString(), "-t", "csv",
+                "-o", outputDemo.toString(), "--demo-mode"
+        });
+        OpenTokenCommand.execute(new String[] {
+                "tokenize", "-i", inputCsv.toString(), "-t", "csv",
+                "-o", outputNormal.toString(), "--hashingsecret", HASHING_SECRET
+        });
+
+        List<String> demoTokens = extractTokenValues(outputDemo);
+        List<String> normalTokens = extractTokenValues(outputNormal);
+
+        assertFalse(demoTokens.isEmpty(), "Demo output must contain tokens");
+        assertFalse(normalTokens.isEmpty(), "Normal output must contain tokens");
+        assertNotEquals(demoTokens, normalTokens,
+                "Demo-mode and normal-mode must produce different token values for the same input");
+    }
+
+    /**
+     * Reads the output CSV at {@code path}, locates the "Token" column via the header row,
+     * and returns all non-empty token values.
+     */
+    private List<String> extractTokenValues(Path path) throws IOException {
+        String[] lines = Files.readString(path).strip().split("\n");
+        assertTrue(lines.length > 1, "Output CSV should contain a header and at least one data row");
+
+        // Locate the Token column index from the header row
+        String[] headers = lines[0].split(",");
+        int tokenColIdx = -1;
+        for (int c = 0; c < headers.length; c++) {
+            if ("Token".equalsIgnoreCase(headers[c].trim())) {
+                tokenColIdx = c;
+                break;
+            }
+        }
+        assertTrue(tokenColIdx >= 0, "Output CSV header must contain a 'Token' column");
+
+        List<String> tokens = new ArrayList<>();
+        for (int i = 1; i < lines.length; i++) {
+            String[] cols = lines[i].split(",");
+            if (cols.length > tokenColIdx) {
+                String token = cols[tokenColIdx].trim();
+                // Skip empty strings and the BLANK sentinel (64-zero placeholder for
+                // token rules where no valid attributes were available)
+                if (!token.isEmpty() && !token.equals(BLANK_TOKEN)) {
+                    tokens.add(token);
+                }
+            }
+        }
+        return tokens;
+    }
+
+    // -------------------------------------------------------------------------
+    // Metadata: hashing-secret hash presence
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testDemoMode_MetadataOmitsHashingSecretHash() throws IOException {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--demo-mode"
+        };
+
+        OpenTokenCommand.execute(args);
+
+        Path metadataPath = tempDir.resolve("output.metadata.json");
+        assertTrue(Files.exists(metadataPath), "Metadata file should be created in demo mode");
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(metadataPath.toFile());
+
+        assertFalse(root.has(Metadata.HASHING_SECRET_HASH),
+                "Demo-mode metadata must not contain " + Metadata.HASHING_SECRET_HASH);
+    }
+
+    @Test
+    void testNormalMode_MetadataContainsHashingSecretHash() throws IOException {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--hashingsecret", HASHING_SECRET
+        };
+
+        OpenTokenCommand.execute(args);
+
+        Path metadataPath = tempDir.resolve("output.metadata.json");
+        assertTrue(Files.exists(metadataPath), "Metadata file should be created in normal mode");
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(metadataPath.toFile());
+
+        assertTrue(root.has(Metadata.HASHING_SECRET_HASH),
+                "Normal-mode metadata must contain " + Metadata.HASHING_SECRET_HASH);
+        assertFalse(root.get(Metadata.HASHING_SECRET_HASH).asText().isEmpty(),
+                "HashingSecretHash must not be empty in normal mode");
+    }
+
+    @Test
+    void testDemoMode_MetadataContainsProcessingCounters() throws IOException {
+        var args = new String[] {
+                "tokenize",
+                "-i", inputCsv.toString(),
+                "-t", "csv",
+                "-o", outputCsv.toString(),
+                "--demo-mode"
+        };
+
+        OpenTokenCommand.execute(args);
+
+        Path metadataPath = tempDir.resolve("output.metadata.json");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(metadataPath.toFile());
+
+        // Processing counters must still be present regardless of mode
+        assertTrue(root.has("TotalRows"), "Metadata must contain TotalRows");
+        assertTrue(root.has("TotalRowsWithInvalidAttributes"),
+                "Metadata must contain TotalRowsWithInvalidAttributes");
+        assertTrue(root.has("InvalidAttributesByType"),
+                "Metadata must contain InvalidAttributesByType");
+        assertTrue(root.has("BlankTokensByRule"),
+                "Metadata must contain BlankTokensByRule");
+
+        assertEquals(2, root.get("TotalRows").asInt(),
+                "TotalRows should match the number of rows in the input file");
+    }
+}

--- a/lib/java/opentoken/pom.xml
+++ b/lib/java/opentoken/pom.xml
@@ -16,7 +16,7 @@
     <version>2.0.0-alpha</version>
 
     <name>opentoken</name>
-    <description>OpenToken Core Library - Privacy-preserving person matching using cryptographically secure token generation</description>
+    <description>OpenToken Core Library - Privacy-preserving record linkage using cryptographically secure token generation</description>
     <url>http://www.truveta.com</url>
 
     <properties>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -10,7 +10,7 @@
     <version>2.0.0-alpha</version>
 
     <name>opentoken-parent</name>
-    <description>OpenToken Parent POM - Privacy-preserving person matching library</description>
+    <description>OpenToken Parent POM - Privacy-preserving record linkage library</description>
     <url>http://www.truveta.com</url>
 
     <modules>

--- a/lib/python/opentoken-cli/pyproject.toml
+++ b/lib/python/opentoken-cli/pyproject.toml
@@ -1,3 +1,11 @@
 [build-system]
 requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+# Prepend local source directories so edits in this worktree take priority
+# over whatever version of the package is installed in the shared venv.
+pythonpath = [
+  "src/main",
+  "../opentoken/src/main",
+]

--- a/lib/python/opentoken-cli/setup.py
+++ b/lib/python/opentoken-cli/setup.py
@@ -1,29 +1,38 @@
 #!/usr/bin/env python3
 """Setup script for OpenToken CLI package."""
 
-from setuptools import setup, find_packages
 import os
+
+from setuptools import find_packages, setup
 
 # Read the contents of the project README file.
 this_directory = os.path.abspath(os.path.dirname(__file__))
-root_readme = os.path.abspath(os.path.join(this_directory, "..", "..", "..", "README.md"))
-readme_path = root_readme if os.path.exists(root_readme) else os.path.join(this_directory, "README.md")
+root_readme = os.path.abspath(
+    os.path.join(this_directory, "..", "..", "..", "README.md")
+)
+readme_path = (
+    root_readme
+    if os.path.exists(root_readme)
+    else os.path.join(this_directory, "README.md")
+)
 try:
     with open(readme_path, encoding="utf-8") as f:
         long_description = f.read()
 except FileNotFoundError:
     # Fallback to a short description if README is unavailable
-    long_description = "OpenToken CLI - Command line interface for person matching."
+    long_description = "OpenToken CLI - Command line interface for record linkage."
 
 # Read requirements from requirements.txt
 with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as f:
-    requirements = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+    requirements = [
+        line.strip() for line in f if line.strip() and not line.startswith("#")
+    ]
 
 setup(
     name="opentoken-cli",
     version="2.0.0-alpha",
     author="Truveta",
-    description="OpenToken CLI - Command line interface for person matching",
+    description="OpenToken CLI - Command line interface for record linkage",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Truveta/OpenToken",
@@ -40,9 +49,7 @@ setup(
             "pytest",
             "pytest-cov",
         ],
-        "test": [
-            "pytest"
-        ],
+        "test": ["pytest"],
     },
     entry_points={
         "console_scripts": [

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/open_token_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/open_token_command.py
@@ -56,7 +56,7 @@ class OpenTokenCommand:
             f"{cyan}| |_| | |_) |  __/ | | | | (_) |   <  __/ | | |{reset}\n"
             f"{cyan} \\___/| .__/ \\___|_| |_|_|\\___/|_|\\_\\___|_| |_|{reset}\n"
             f"{cyan}      |_|                                       {reset}\n"
-            f"{blue}Privacy-Preserving Person Matching v{OpenTokenCommand.VERSION}{reset}\n"
+            f"{blue}Privacy-Preserving Record Linkage v{OpenTokenCommand.VERSION}{reset}\n"
         )
 
     @staticmethod
@@ -64,12 +64,14 @@ class OpenTokenCommand:
         """Create the main argument parser with subcommands."""
         parser = argparse.ArgumentParser(
             prog="opentoken",
-            description="Privacy-preserving person matching via cryptographic tokens",
+            description="Privacy-preserving record linkage via cryptographic tokens",
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 
         parser.add_argument(
-            "--version", action="version", version=f"OpenToken {OpenTokenCommand.VERSION}"
+            "--version",
+            action="version",
+            version=f"OpenToken {OpenTokenCommand.VERSION}",
         )
 
         subparsers = parser.add_subparsers(
@@ -80,11 +82,11 @@ class OpenTokenCommand:
         )
 
         # Import command modules here to avoid circular imports
-        from opentoken_cli.commands.tokenize_command import TokenizeCommand
-        from opentoken_cli.commands.encrypt_command import EncryptCommand
         from opentoken_cli.commands.decrypt_command import DecryptCommand
-        from opentoken_cli.commands.package_command import PackageCommand
+        from opentoken_cli.commands.encrypt_command import EncryptCommand
         from opentoken_cli.commands.help_command import HelpCommand
+        from opentoken_cli.commands.package_command import PackageCommand
+        from opentoken_cli.commands.tokenize_command import TokenizeCommand
 
         # Register subcommands
         HelpCommand.register_subcommand(subparsers)
@@ -99,13 +101,13 @@ class OpenTokenCommand:
     def main(args=None):
         """Main entry point for the command-line application."""
         parser = OpenTokenCommand.create_parser()
-        
+
         # Show banner for interactive runs (not for --help or piped output)
         # Show when no args provided OR when it's not a help request
         argv = sys.argv if args is None else args
         if len(argv) == 0 or not OpenTokenCommand._is_help_request(argv):
             OpenTokenCommand.show_banner()
-        
+
         try:
             parsed_args = parser.parse_args(args)
         except SystemExit as error:
@@ -128,10 +130,10 @@ class OpenTokenCommand:
         """
         Execute the CLI without calling sys.exit().
         Useful for testing or when embedding the CLI in another application.
-        
+
         Args:
             args: Command-line arguments as a list
-            
+
         Returns:
             Exit code (0 for success, non-zero for errors)
         """

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/tokenize_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/tokenize_command.py
@@ -102,7 +102,7 @@ class TokenizeCommand:
             default=False,
             dest="demo_mode",
             help=(
-                "Enable demo mode: output plain attribute signature strings without any hashing. "
+                "Enable demo mode: output raw pipe-separated attribute signature strings with no hashing. "
                 "--hashingsecret is not required in this mode. "
                 "Demo output is NOT suitable for production or cross-organisation exchange."
             ),
@@ -126,7 +126,7 @@ class TokenizeCommand:
 
         if demo_mode:
             logger.warning(
-                "Running in DEMO MODE - tokens are plain attribute signature strings, not HMAC-hashed. "
+                "Running in DEMO MODE - tokens are raw attribute signature strings with no hashing. "
                 "Do not use demo-mode output in production or share it externally."
             )
         else:

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/tokenize_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/tokenize_command.py
@@ -6,23 +6,37 @@ import logging
 from typing import List
 
 from opentoken.metadata import Metadata
+from opentoken.tokens.tokenizer.passthrough_tokenizer import PassthroughTokenizer
 from opentoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from opentoken.tokentransformer.token_transformer import TokenTransformer
 from opentoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
 from opentoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
-from opentoken_cli.util import StringMaskingUtil
 from opentoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
-from opentoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
-from opentoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
-from opentoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+from opentoken_cli.io.parquet.person_attributes_parquet_reader import (
+    PersonAttributesParquetReader,
+)
+from opentoken_cli.io.parquet.person_attributes_parquet_writer import (
+    PersonAttributesParquetWriter,
+)
+from opentoken_cli.processor.person_attributes_processor import (
+    PersonAttributesProcessor,
+)
+from opentoken_cli.util import StringMaskingUtil
 
 logger = logging.getLogger(__name__)
 
 
 class TokenizeCommand:
     """
-    Tokenize command - generates hashed tokens from person attributes.
-    This is hash-only mode without encryption.
+    Tokenize command - generates tokens from person attributes.
+
+    Normal mode (default): applies SHA-256 then HMAC-SHA256 hashing on the token
+    signature, producing opaque base64 tokens. ``--hashingsecret`` is required.
+
+    Demo mode (``--demo-mode``): skips all hashing so tokens are the raw
+    pipe-separated attribute signature strings. No secret is needed, making it easy
+    to explore the output without managing secrets. Demo-mode output is
+    **not** suitable for production or cross-organisation exchange.
     """
 
     TYPE_CSV = "csv"
@@ -33,8 +47,12 @@ class TokenizeCommand:
         """Register the tokenize subcommand with the argument parser."""
         parser = subparsers.add_parser(
             "tokenize",
-            help="Generate hashed tokens from person attributes (hash-only mode)",
-            description="Generate hashed tokens from person attributes without encryption",
+            help="Generate tokens from person attributes (normal mode: HMAC-SHA256; demo mode: plain signatures)",
+            description=(
+                "Generate tokens from person attributes.\n\n"
+                "Normal mode: tokens are HMAC-SHA256 hashed (--hashingsecret required).\n"
+                "Demo mode (--demo-mode): tokens are plain attribute signature strings; no secret needed."
+            ),
             add_help=False,  # Disable automatic -h for help to allow -h for hashingsecret
         )
 
@@ -79,11 +97,24 @@ class TokenizeCommand:
         )
 
         parser.add_argument(
+            "--demo-mode",
+            action="store_true",
+            default=False,
+            dest="demo_mode",
+            help=(
+                "Enable demo mode: output plain attribute signature strings without any hashing. "
+                "--hashingsecret is not required in this mode. "
+                "Demo output is NOT suitable for production or cross-organisation exchange."
+            ),
+        )
+
+        # Optional in demo mode; required at runtime in normal mode
+        parser.add_argument(
             "-h",
             "--hashingsecret",
-            required=True,
+            required=False,
             dest="hashing_secret",
-            help="Hashing secret for token generation",
+            help="Hashing secret for HMAC-SHA256 token generation (required in normal mode, ignored in demo mode)",
         )
 
         parser.set_defaults(func=TokenizeCommand.execute)
@@ -91,29 +122,50 @@ class TokenizeCommand:
     @staticmethod
     def execute(args):
         """Execute the tokenize command."""
-        logger.info("Running tokenize command (hash-only mode)")
+        demo_mode = getattr(args, "demo_mode", False)
+
+        if demo_mode:
+            logger.warning(
+                "Running in DEMO MODE - tokens are plain attribute signature strings, not HMAC-hashed. "
+                "Do not use demo-mode output in production or share it externally."
+            )
+        else:
+            logger.info("Running tokenize command (normal mode)")
 
         # Default output type to input type if not specified
         output_type = args.output_type if args.output_type else args.input_type
 
-        # Log parameters (mask secret)
         logger.info(f"Input: {args.input_path} ({args.input_type})")
         logger.info(f"Output: {args.output_path} ({output_type})")
-        logger.info(f"Hashing Secret: {StringMaskingUtil.mask_string(args.hashing_secret)}")
+        if not demo_mode:
+            logger.info(
+                f"Hashing Secret: {StringMaskingUtil.mask_string(args.hashing_secret)}"
+            )
 
-        # Validate secret
-        if not args.hashing_secret or not args.hashing_secret.strip():
-            logger.error("Hashing secret is required")
-            return 1
+        # --hashingsecret is required in normal mode only
+        if not demo_mode:
+            if not args.hashing_secret or not args.hashing_secret.strip():
+                logger.error(
+                    "--hashingsecret is required in normal mode. Use --demo-mode to skip hashing."
+                )
+                return 1
 
         try:
-            TokenizeCommand._process_tokens(
-                args.input_path,
-                args.output_path,
-                args.input_type,
-                output_type,
-                args.hashing_secret,
-            )
+            if demo_mode:
+                TokenizeCommand._process_tokens_demo(
+                    args.input_path,
+                    args.output_path,
+                    args.input_type,
+                    output_type,
+                )
+            else:
+                TokenizeCommand._process_tokens(
+                    args.input_path,
+                    args.output_path,
+                    args.input_type,
+                    output_type,
+                    args.hashing_secret,
+                )
             logger.info("Token generation completed successfully")
             return 0
         except Exception as e:
@@ -128,7 +180,7 @@ class TokenizeCommand:
         output_type: str,
         hashing_secret: str,
     ):
-        """Process tokens from person attributes."""
+        """Process tokens in normal mode using SHA-256 + HMAC-SHA256."""
         token_transformer_list: List[TokenTransformer] = []
 
         try:
@@ -141,22 +193,52 @@ class TokenizeCommand:
         try:
             with TokenizeCommand._create_reader(
                 input_path, input_type
-            ) as reader, TokenizeCommand._create_writer(output_path, output_type) as writer:
+            ) as reader, TokenizeCommand._create_writer(
+                output_path, output_type
+            ) as writer:
 
-                # Create metadata
                 metadata = Metadata()
                 metadata_map = metadata.initialize()
+                # Only record the hashing-secret hash in normal mode
                 metadata.add_hashed_secret(Metadata.HASHING_SECRET_HASH, hashing_secret)
 
-                # Process data
-                PersonAttributesProcessor.process(reader, writer, token_transformer_list, metadata_map)
+                PersonAttributesProcessor.process(
+                    reader, writer, token_transformer_list, metadata_map
+                )
 
-                # Write metadata
-                metadata_writer = MetadataJsonWriter(output_path)
-                metadata_writer.write(metadata_map)
+                MetadataJsonWriter(output_path).write(metadata_map)
 
         except Exception as e:
             logger.error("Error processing tokens", exc_info=e)
+            raise
+
+    @staticmethod
+    def _process_tokens_demo(
+        input_path: str,
+        output_path: str,
+        input_type: str,
+        output_type: str,
+    ):
+        """Process tokens in demo mode using PassthroughTokenizer (no hashing)."""
+        try:
+            with TokenizeCommand._create_reader(
+                input_path, input_type
+            ) as reader, TokenizeCommand._create_writer(
+                output_path, output_type
+            ) as writer:
+
+                metadata = Metadata()
+                metadata_map = metadata.initialize()
+                # Deliberately omit add_hashed_secret — no secret used in demo mode
+
+                PersonAttributesProcessor.process_with_tokenizer(
+                    reader, writer, PassthroughTokenizer([]), metadata_map
+                )
+
+                MetadataJsonWriter(output_path).write(metadata_map)
+
+        except Exception as e:
+            logger.error("Error processing tokens in demo mode", exc_info=e)
             raise
 
     @staticmethod

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/processor/person_attributes_processor.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/processor/person_attributes_processor.py
@@ -4,19 +4,20 @@ Copyright (c) Truveta. All rights reserved.
 
 import logging
 import uuid
-from typing import Dict, List, Type, Any, Set
+from typing import Any, Dict, List, Set, Type
 
 from opentoken.attributes.attribute import Attribute
 from opentoken.attributes.general.record_id_attribute import RecordIdAttribute
-from opentoken_cli.io.person_attributes_reader import PersonAttributesReader
-from opentoken_cli.io.person_attributes_writer import PersonAttributesWriter
-from opentoken_cli.processor.token_constants import TokenConstants
 from opentoken.tokens.token_definition import TokenDefinition
 from opentoken.tokens.token_generator import TokenGenerator
 from opentoken.tokens.token_generator_result import TokenGeneratorResult
+from opentoken.tokens.tokenizer.sha256_tokenizer import SHA256Tokenizer
+from opentoken.tokens.tokenizer.tokenizer import Tokenizer
 from opentoken.tokentransformer.jwe_match_token_formatter import JweMatchTokenFormatter
 from opentoken.tokentransformer.token_transformer import TokenTransformer
-
+from opentoken_cli.io.person_attributes_reader import PersonAttributesReader
+from opentoken_cli.io.person_attributes_writer import PersonAttributesWriter
+from opentoken_cli.processor.token_constants import TokenConstants
 
 logger = logging.getLogger(__name__)
 
@@ -39,12 +40,14 @@ class PersonAttributesProcessor:
         """Private constructor to prevent instantiation."""
 
     @staticmethod
-    def process(reader: PersonAttributesReader,
-                writer: PersonAttributesWriter,
-                token_transformer_list: List[TokenTransformer],
-                metadata_map: Dict[str, Any] = None,
-                encryption_key: str = None,
-                ring_id: str = None) -> None:
+    def process(
+        reader: PersonAttributesReader,
+        writer: PersonAttributesWriter,
+        token_transformer_list: List[TokenTransformer],
+        metadata_map: Dict[str, Any] = None,
+        encryption_key: str = None,
+        ring_id: str = None,
+    ) -> None:
         """
         Read person attributes from the input data source, generate tokens, and
         write the result back to the output data source. The tokens can be optionally
@@ -60,11 +63,76 @@ class PersonAttributesProcessor:
         """
         # TokenGenerator code
         token_definition = TokenDefinition()
-        token_generator = TokenGenerator.from_transformers(token_definition, token_transformer_list)
+        PersonAttributesProcessor._process_with_tokenizer(
+            reader,
+            writer,
+            SHA256Tokenizer(token_transformer_list),
+            token_definition,
+            metadata_map,
+            encryption_key,
+            ring_id,
+        )
+
+    @staticmethod
+    def process_with_tokenizer(
+        reader: PersonAttributesReader,
+        writer: PersonAttributesWriter,
+        tokenizer: Tokenizer,
+        metadata_map: Dict[str, Any] = None,
+    ) -> None:
+        """
+        Read person attributes from the input data source, generate tokens using
+        the provided tokenizer, and write the result to the output data source.
+
+        Use this overload when full control over the tokenization strategy is needed,
+        for example passing a PassthroughTokenizer for demo mode.
+
+        Args:
+            reader: The reader initialized with the input data source.
+            writer: The writer initialized with the output data source.
+            tokenizer: The tokenizer to use (e.g. SHA256Tokenizer or PassthroughTokenizer).
+            metadata_map: Optional metadata map to update with processing statistics.
+        """
+        token_definition = TokenDefinition()
+        PersonAttributesProcessor._process_with_tokenizer(
+            reader, writer, tokenizer, token_definition, metadata_map
+        )
+
+    @staticmethod
+    def _process_with_tokenizer(
+        reader: PersonAttributesReader,
+        writer: PersonAttributesWriter,
+        tokenizer: Tokenizer,
+        token_definition: TokenDefinition,
+        metadata_map: Dict[str, Any] = None,
+        encryption_key: str = None,
+        ring_id: str = None,
+    ) -> None:
+        """
+        Core row-processing logic shared by all process() overloads.
+
+        Args:
+            reader: The reader initialized with the input data source.
+            writer: The writer initialized with the output data source.
+            tokenizer: The tokenizer instance to use.
+            token_definition: The token definition instance.
+            metadata_map: Optional metadata map to update with processing statistics.
+            encryption_key: Optional encryption key for JWE wrapping.
+            ring_id: Optional ring ID for JWE wrapping.
+        """
+        token_generator = TokenGenerator(token_definition, tokenizer)
 
         row_counter = 0
-        invalid_attribute_count: Dict[str, int] = PersonAttributesProcessor._initialize_invalid_attribute_count(token_definition)
-        blank_tokens_by_rule_count: Dict[str, int] = PersonAttributesProcessor._initialize_blank_tokens_by_rule_count(token_definition)
+        invalid_attribute_count: Dict[str, int] = (
+            PersonAttributesProcessor._initialize_invalid_attribute_count(
+                token_definition
+            )
+        )
+        blank_tokens_by_rule_count: Dict[str, int] = (
+            PersonAttributesProcessor._initialize_blank_tokens_by_rule_count(
+                token_definition
+            )
+        )
 
         # Cache JWE formatters if encryption is enabled
         jwe_formatters: Dict[str, JweMatchTokenFormatter] = {}
@@ -75,7 +143,9 @@ class PersonAttributesProcessor:
                         encryption_key, ring_id, token_id, "truveta.opentoken"
                     )
                 except Exception as e:
-                    error_msg = f"Failed to initialize JWE formatter for token rule {token_id}"
+                    error_msg = (
+                        f"Failed to initialize JWE formatter for token rule {token_id}"
+                    )
                     logger.error(error_msg, exc_info=True)
                     raise RuntimeError(error_msg) from e
 
@@ -95,7 +165,13 @@ class PersonAttributesProcessor:
                 )
 
                 PersonAttributesProcessor._write_tokens(
-                    writer, row, row_counter, token_generator_result, encryption_key, ring_id, jwe_formatters
+                    writer,
+                    row,
+                    row_counter,
+                    token_generator_result,
+                    encryption_key,
+                    ring_id,
+                    jwe_formatters,
                 )
 
                 if row_counter % 10000 == 0:
@@ -109,10 +185,14 @@ class PersonAttributesProcessor:
 
         # Log invalid attribute statistics in alphabetical order
         for attribute_name, count in sorted(invalid_attribute_count.items()):
-            logger.info(f"Total invalid Attribute count for [{attribute_name}]: {count:,}")
+            logger.info(
+                f"Total invalid Attribute count for [{attribute_name}]: {count:,}"
+            )
 
         total_invalid_records = sum(invalid_attribute_count.values())
-        logger.info(f"Total number of records with invalid attributes: {total_invalid_records:,}")
+        logger.info(
+            f"Total number of records with invalid attributes: {total_invalid_records:,}"
+        )
 
         # Log blank token statistics in alphabetical order
         for rule_id, count in sorted(blank_tokens_by_rule_count.items()):
@@ -124,19 +204,27 @@ class PersonAttributesProcessor:
         # Update metadata if provided
         if metadata_map is not None:
             metadata_map[PersonAttributesProcessor.TOTAL_ROWS] = row_counter
-            metadata_map[PersonAttributesProcessor.TOTAL_ROWS_WITH_INVALID_ATTRIBUTES] = total_invalid_records
+            metadata_map[
+                PersonAttributesProcessor.TOTAL_ROWS_WITH_INVALID_ATTRIBUTES
+            ] = total_invalid_records
             # Alphabetize attribute and token rule keys for deterministic metadata output
-            metadata_map[PersonAttributesProcessor.INVALID_ATTRIBUTES_BY_TYPE] = dict(sorted(invalid_attribute_count.items()))
-            metadata_map[PersonAttributesProcessor.BLANK_TOKENS_BY_RULE] = dict(sorted(blank_tokens_by_rule_count.items()))
+            metadata_map[PersonAttributesProcessor.INVALID_ATTRIBUTES_BY_TYPE] = dict(
+                sorted(invalid_attribute_count.items())
+            )
+            metadata_map[PersonAttributesProcessor.BLANK_TOKENS_BY_RULE] = dict(
+                sorted(blank_tokens_by_rule_count.items())
+            )
 
     @staticmethod
-    def _write_tokens(writer: PersonAttributesWriter,
-                      row: Dict[Type[Attribute], str],
-                      row_counter: int,
-                      token_generator_result: TokenGeneratorResult,
-                      encryption_key: str = None,
-                      ring_id: str = None,
-                      jwe_formatters: Dict[str, JweMatchTokenFormatter] = None) -> None:
+    def _write_tokens(
+        writer: PersonAttributesWriter,
+        row: Dict[Type[Attribute], str],
+        row_counter: int,
+        token_generator_result: TokenGeneratorResult,
+        encryption_key: str = None,
+        ring_id: str = None,
+        jwe_formatters: Dict[str, JweMatchTokenFormatter] = None,
+    ) -> None:
         """
         Write tokens to the output writer. Optionally wraps tokens in JWE format.
 
@@ -153,12 +241,12 @@ class PersonAttributesProcessor:
 
         # Generate a UUID for RecordId if it's not present in the input data
         record_id = row.get(RecordIdAttribute)
-        if record_id is None or record_id == '':
+        if record_id is None or record_id == "":
             record_id = str(uuid.uuid4())
 
         for token_id in token_ids:
             token = token_generator_result.tokens[token_id]
-            
+
             # Apply JWE wrapping if encryption key and ring ID are provided
             if encryption_key and ring_id and token:
                 jwe_formatter = (jwe_formatters or {}).get(token_id)
@@ -169,22 +257,27 @@ class PersonAttributesProcessor:
                         error_msg = f"Error wrapping token in JWE format for row {row_counter:,}, rule {token_id}"
                         logger.error(error_msg, exc_info=True)
                         raise RuntimeError(error_msg) from e
-            
+
             row_result = {
                 TokenConstants.RULE_ID: token_id,
                 TokenConstants.TOKEN: token,
-                TokenConstants.RECORD_ID: record_id
+                TokenConstants.RECORD_ID: record_id,
             }
 
             try:
                 writer.write_attributes(row_result)
             except IOError:
-                logger.error(f"Error writing attributes to file for row {row_counter:,}", exc_info=True)
+                logger.error(
+                    f"Error writing attributes to file for row {row_counter:,}",
+                    exc_info=True,
+                )
 
     @staticmethod
-    def _keep_track_of_invalid_attributes(token_generator_result: TokenGeneratorResult,
-                                          row_counter: int,
-                                          invalid_attribute_count: Dict[str, int]) -> None:
+    def _keep_track_of_invalid_attributes(
+        token_generator_result: TokenGeneratorResult,
+        row_counter: int,
+        invalid_attribute_count: Dict[str, int],
+    ) -> None:
         """
         Keep track of invalid attributes for logging purposes.
 
@@ -202,9 +295,11 @@ class PersonAttributesProcessor:
                 invalid_attribute_count[invalid_attribute] += 1
 
     @staticmethod
-    def _keep_track_of_blank_tokens(token_generator_result: TokenGeneratorResult,
-                                    row_counter: int,
-                                    blank_tokens_by_rule_count: Dict[str, int]) -> None:
+    def _keep_track_of_blank_tokens(
+        token_generator_result: TokenGeneratorResult,
+        row_counter: int,
+        blank_tokens_by_rule_count: Dict[str, int],
+    ) -> None:
         """
         Keep track of blank tokens for logging purposes.
 
@@ -222,10 +317,12 @@ class PersonAttributesProcessor:
                 blank_tokens_by_rule_count[rule_id] += 1
 
     @staticmethod
-    def _initialize_invalid_attribute_count(token_definition: TokenDefinition) -> Dict[str, int]:
+    def _initialize_invalid_attribute_count(
+        token_definition: TokenDefinition,
+    ) -> Dict[str, int]:
         """
         Initialize the invalid attribute count dictionary with attributes used in the token definition set to 0.
-        This ensures that all attribute types used in token generation appear in the metadata 
+        This ensures that all attribute types used in token generation appear in the metadata
         even in happy path scenarios.
 
         Args:
@@ -236,26 +333,30 @@ class PersonAttributesProcessor:
         """
         invalid_attribute_count: Dict[str, int] = {}
         attribute_classes: Set[Type[Attribute]] = set()
-        
+
         # Collect all unique attribute classes from all token definitions
         for token_id in token_definition.get_token_identifiers():
             expressions = token_definition.get_token_definition(token_id)
             if expressions:
                 for expr in expressions:
                     attribute_classes.add(expr.attribute_class)
-        
+
         # Create instances and get names
         for attr_class in attribute_classes:
             try:
                 attribute = attr_class()
                 invalid_attribute_count[attribute.get_name()] = 0
             except Exception as e:
-                logger.warning(f"Failed to instantiate attribute class: {attr_class.__name__}: {e}")
-        
+                logger.warning(
+                    f"Failed to instantiate attribute class: {attr_class.__name__}: {e}"
+                )
+
         return invalid_attribute_count
 
     @staticmethod
-    def _initialize_blank_tokens_by_rule_count(token_definition: TokenDefinition) -> Dict[str, int]:
+    def _initialize_blank_tokens_by_rule_count(
+        token_definition: TokenDefinition,
+    ) -> Dict[str, int]:
         """
         Initialize the blank tokens by rule count dictionary with all token identifiers set to 0.
         This ensures that all token rules appear in the metadata even in happy path scenarios.

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/tokenize_command_demo_mode_test.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/tokenize_command_demo_mode_test.py
@@ -1,0 +1,326 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from opentoken_cli.commands.open_token_command import OpenTokenCommand
+
+# HMAC-SHA256 over 32 bytes → base64 → always exactly 44 characters
+NORMAL_MODE_TOKEN_LENGTH = 44
+
+# Token.BLANK sentinel written when a rule cannot produce a valid token
+BLANK_TOKEN = "0" * 64
+
+
+class TestTokenizeCommandDemoMode:
+    """Tests for the --demo-mode flag on the tokenize subcommand."""
+
+    HASHING_SECRET = "TestHashingSecret"
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        """Create a temporary directory with a two-row CSV input."""
+        input_csv = tmp_path / "input.csv"
+        input_csv.write_text(
+            "RecordId,FirstName,LastName,PostalCode,Sex,BirthDate,SocialSecurityNumber\n"
+            "test-001,John,Doe,98004,Male,2000-01-15,123-45-6789\n"
+            "test-002,Jane,Smith,12345,Female,1990-05-20,234-56-7890\n"
+        )
+        return tmp_path
+
+    # ------------------------------------------------------------------
+    # Mode selection
+    # ------------------------------------------------------------------
+
+    def test_demo_mode_succeeds_without_hashing_secret(self, temp_dir: Path):
+        """Demo mode should not require --hashingsecret."""
+        args = [
+            "tokenize",
+            "-i",
+            str(temp_dir / "input.csv"),
+            "-t",
+            "csv",
+            "-o",
+            str(temp_dir / "output.csv"),
+            "--demo-mode",
+        ]
+        exit_code = OpenTokenCommand.execute(args)
+        assert exit_code == 0
+
+    def test_normal_mode_fails_without_hashing_secret(self, temp_dir: Path):
+        """Normal mode must reject execution when --hashingsecret is absent."""
+        args = [
+            "tokenize",
+            "-i",
+            str(temp_dir / "input.csv"),
+            "-t",
+            "csv",
+            "-o",
+            str(temp_dir / "output.csv"),
+        ]
+        exit_code = OpenTokenCommand.execute(args)
+        assert exit_code != 0
+
+    def test_demo_mode_accepts_optional_hashing_secret(self, temp_dir: Path):
+        """Demo mode should succeed even when --hashingsecret is provided (ignored)."""
+        args = [
+            "tokenize",
+            "-i",
+            str(temp_dir / "input.csv"),
+            "-t",
+            "csv",
+            "-o",
+            str(temp_dir / "output.csv"),
+            "--demo-mode",
+            "--hashingsecret",
+            self.HASHING_SECRET,
+        ]
+        exit_code = OpenTokenCommand.execute(args)
+        assert exit_code == 0
+
+    def test_normal_mode_succeeds_with_hashing_secret(self, temp_dir: Path):
+        """Normal mode should succeed when --hashingsecret is provided."""
+        args = [
+            "tokenize",
+            "-i",
+            str(temp_dir / "input.csv"),
+            "-t",
+            "csv",
+            "-o",
+            str(temp_dir / "output.csv"),
+            "--hashingsecret",
+            self.HASHING_SECRET,
+        ]
+        exit_code = OpenTokenCommand.execute(args)
+        assert exit_code == 0
+
+    # ------------------------------------------------------------------
+    # Input validation
+    # ------------------------------------------------------------------
+
+    def test_normal_mode_fails_with_blank_hashing_secret(self, temp_dir: Path):
+        """A blank (whitespace-only) hashing secret must be rejected in normal mode."""
+        args = [
+            "tokenize",
+            "-i",
+            str(temp_dir / "input.csv"),
+            "-t",
+            "csv",
+            "-o",
+            str(temp_dir / "output.csv"),
+            "--hashingsecret",
+            "   ",
+        ]
+        exit_code = OpenTokenCommand.execute(args)
+        assert exit_code != 0
+
+    def test_invalid_input_type_rejected(self, temp_dir: Path):
+        """An unrecognised -t value should always be rejected."""
+        args = [
+            "tokenize",
+            "-i",
+            str(temp_dir / "input.csv"),
+            "-t",
+            "json",
+            "-o",
+            str(temp_dir / "output.csv"),
+            "--demo-mode",
+        ]
+        exit_code = OpenTokenCommand.execute(args)
+        assert exit_code != 0
+
+    # ------------------------------------------------------------------
+    # Output shape
+    # ------------------------------------------------------------------
+
+    def test_demo_mode_tokens_are_not_hmac_base64(self, temp_dir: Path):
+        """
+        Demo tokens use PassthroughTokenizer so they are never 44-char HMAC base64.
+        Multi-attribute rules (T1-T4) produce pipe-separated signatures; at least
+        one such token must appear in the output.
+        """
+        output_csv = temp_dir / "output.csv"
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(output_csv),
+                "--demo-mode",
+            ]
+        )
+
+        tokens = _extract_tokens(output_csv)
+        assert tokens, "Expected at least one non-blank token in demo mode"
+
+        # At least one multi-attribute rule should produce a pipe-separated token
+        assert any(
+            "|" in t for t in tokens
+        ), "Expected at least one pipe-separated signature token (T1-T4 rules)"
+
+        # None of the tokens should be a 44-char HMAC-SHA256 base64 string
+        for token in tokens:
+            assert (
+                len(token) != NORMAL_MODE_TOKEN_LENGTH
+            ), f"Demo-mode token must not be a 44-char HMAC base64 string, got: {token}"
+
+    def test_normal_mode_tokens_are_44_char_hmac_base64(self, temp_dir: Path):
+        """Normal mode tokens are HMAC-SHA256 base64, always exactly 44 characters."""
+        output_csv = temp_dir / "output.csv"
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(output_csv),
+                "--hashingsecret",
+                self.HASHING_SECRET,
+            ]
+        )
+
+        tokens = _extract_tokens(output_csv)
+        assert tokens, "Expected at least one non-blank token in normal mode"
+
+        for token in tokens:
+            assert (
+                len(token) == NORMAL_MODE_TOKEN_LENGTH
+            ), f"Normal-mode token must be a 44-char HMAC base64 string, got: {token!r}"
+
+    def test_demo_and_normal_mode_produce_different_tokens(self, temp_dir: Path):
+        """Demo-mode and normal-mode outputs must differ for the same input."""
+        demo_output = temp_dir / "demo_output.csv"
+        normal_output = temp_dir / "normal_output.csv"
+
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(demo_output),
+                "--demo-mode",
+            ]
+        )
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(normal_output),
+                "--hashingsecret",
+                self.HASHING_SECRET,
+            ]
+        )
+
+        assert demo_output.read_text() != normal_output.read_text()
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def test_demo_mode_metadata_omits_hashing_secret_hash(self, temp_dir: Path):
+        """Demo mode must not write HashingSecretHash to the metadata file."""
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(temp_dir / "output.csv"),
+                "--demo-mode",
+            ]
+        )
+
+        metadata = _read_metadata(temp_dir / "output.metadata.json")
+        assert (
+            "HashingSecretHash" not in metadata
+        ), "Demo mode must not include HashingSecretHash in metadata"
+
+    def test_normal_mode_metadata_contains_hashing_secret_hash(self, temp_dir: Path):
+        """Normal mode must write HashingSecretHash to the metadata file."""
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(temp_dir / "output.csv"),
+                "--hashingsecret",
+                self.HASHING_SECRET,
+            ]
+        )
+
+        metadata = _read_metadata(temp_dir / "output.metadata.json")
+        assert (
+            "HashingSecretHash" in metadata
+        ), "Normal mode must include HashingSecretHash in metadata"
+
+    def test_demo_mode_metadata_contains_processing_counters(self, temp_dir: Path):
+        """Demo mode metadata must still record row and attribute statistics."""
+        OpenTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-t",
+                "csv",
+                "-o",
+                str(temp_dir / "output.csv"),
+                "--demo-mode",
+            ]
+        )
+
+        metadata = _read_metadata(temp_dir / "output.metadata.json")
+        assert (
+            metadata.get("TotalRows") == 2
+        ), f"Expected TotalRows=2 but got {metadata.get('TotalRows')}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_tokens(csv_path: Path) -> list[str]:
+    """Return non-blank, non-sentinel token values from the Token column of a CSV."""
+    lines = csv_path.read_text().splitlines()
+    if not lines:
+        return []
+
+    headers = [h.strip() for h in lines[0].split(",")]
+    try:
+        token_col = headers.index("Token")
+    except ValueError:
+        return []
+
+    tokens = []
+    for line in lines[1:]:
+        cols = line.split(",")
+        if len(cols) > token_col:
+            token = cols[token_col].strip()
+            if token and token != BLANK_TOKEN:
+                tokens.append(token)
+    return tokens
+
+
+def _read_metadata(path: Path) -> dict:
+    """Read and parse a metadata JSON file."""
+    return json.loads(path.read_text())

--- a/lib/python/opentoken-pyspark/README.md
+++ b/lib/python/opentoken-pyspark/README.md
@@ -1,10 +1,10 @@
 # OpenToken PySpark Bridge
 
-A PySpark integration for the OpenToken library, enabling distributed privacy-preserving token generation for large-scale person matching workflows.
+A PySpark integration for the OpenToken library, enabling distributed privacy-preserving token generation for large-scale record linkage workflows.
 
 ## Overview
 
-The OpenToken PySpark Bridge provides a seamless interface between PySpark DataFrames and the OpenToken library, allowing you to generate cryptographically secure tokens for person matching in a distributed computing environment.
+The OpenToken PySpark Bridge provides a seamless interface between PySpark DataFrames and the OpenToken library, allowing you to generate cryptographically secure tokens for record linkage in a distributed computing environment.
 
 ## Features
 
@@ -33,7 +33,8 @@ OpenToken PySpark supports multiple Spark versions to accommodate different Java
 | 3.5.x         | >=3.5.0, <3.6   | >=15.0.0, <20   | >=1.5, <2.3    | 8-17         | `[spark35]`                   |
 | 3.4.x         | >=3.4.0, <3.5   | >=10.0.0, <15   | >=1.5, <2.2    | 8-17         | `[spark34]`                   |
 
-**Important:** 
+**Important:**
+
 - PySpark 3.5.x and earlier are **NOT compatible** with Java 21
 - If you're using Java 21, you **must** use PySpark 4.0.x+ or 4.1.x+ (Spark 4.0.x recommended)
 - For managed clusters (Databricks, EMR, Azure Synapse), PySpark is typically pre-installed
@@ -242,18 +243,21 @@ For more examples and interactive experimentation with custom tokens, see the [C
 See the included Jupyter notebooks for complete examples:
 
 **Basic Usage:**
+
 ```bash
 cd notebooks
 jupyter notebook OpenToken_PySpark_Example.ipynb
 ```
 
 **Custom Token Definitions:**
+
 ```bash
 cd notebooks
 jupyter notebook Custom_Token_Definition_Guide.ipynb
 ```
 
 **Dataset Overlap Analysis:**
+
 ```bash
 cd notebooks
 jupyter notebook Dataset_Overlap_Analysis_Guide.ipynb

--- a/lib/python/opentoken/setup.py
+++ b/lib/python/opentoken/setup.py
@@ -1,29 +1,36 @@
 #!/usr/bin/env python3
 """Setup script for OpenToken Python package."""
 
-from setuptools import setup, find_packages
 import os
+
+from setuptools import find_packages, setup
 
 # Read the contents of the project README file.
 this_directory = os.path.abspath(os.path.dirname(__file__))
 root_readme = os.path.abspath(os.path.join(this_directory, "..", "..", "README.md"))
-readme_path = root_readme if os.path.exists(root_readme) else os.path.join(this_directory, "README.md")
+readme_path = (
+    root_readme
+    if os.path.exists(root_readme)
+    else os.path.join(this_directory, "README.md")
+)
 try:
     with open(readme_path, encoding="utf-8") as f:
         long_description = f.read()
 except FileNotFoundError:
     # Fallback to a short description if README is unavailable
-    long_description = "OpenToken Python implementation for person matching."
+    long_description = "OpenToken Python implementation for record linkage."
 
 # Read requirements from requirements.txt
 with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as f:
-    requirements = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+    requirements = [
+        line.strip() for line in f if line.strip() and not line.startswith("#")
+    ]
 
 setup(
     name="opentoken",
     version="2.0.0-alpha",
     author="Truveta",
-    description="OpenToken Python core library for person matching",
+    description="OpenToken Python core library for record linkage",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Truveta/OpenToken",
@@ -40,8 +47,6 @@ setup(
             "cryptography",
             "pycryptodome",
         ],
-        "test": [
-            "pytest"
-        ],
+        "test": ["pytest"],
     },
 )

--- a/pages/concepts/index.md
+++ b/pages/concepts/index.md
@@ -7,7 +7,7 @@ title: Concepts
 
 Learn about the core concepts behind OpenToken.
 
-- [Matching Model](matching-model.md) — How OpenToken approaches person matching
+- [Matching Model](matching-model.md) — How OpenToken approaches record linkage
 - [Token Rules](token-rules.md) — The 5 distinct token rules (T1–T5)
 - [Match Token Format](match-token-format.md) — Self-contained token format with versioning and cryptographic metadata
 - [Normalization and Validation](normalization-and-validation.md) — How attributes are processed

--- a/pages/concepts/matching-model.md
+++ b/pages/concepts/matching-model.md
@@ -4,7 +4,7 @@ layout: default
 
 # Matching Model
 
-OpenToken uses a multi-rule tokenization strategy to enable privacy-preserving person matching across datasets that contain PII.
+OpenToken uses a multi-rule tokenization strategy to enable privacy-preserving record linkage across datasets that contain PII.
 
 ---
 
@@ -270,7 +270,7 @@ For detailed rule compositions, see [Token Rules](token-rules.md).
 | T1   | `OREILLY\|T\|M\|1995-11-03`        | `RHZiTmNYemFRd0VyWnR...` |
 | T2   | `OREILLY\|THOMAS\|1995-11-03\|303` | `S2p1aHlHdEZyRGVWd1h...` |
 | T3   | `OREILLY\|THOMAS\|M\|1995-11-03`   | `VXl0ckVXcUFzRGZHaEp...` |
-| T4   | — (SSN missing)                    | *Not generated*          |
+| T4   | — (SSN missing)                    | _Not generated_          |
 | T5   | `OREILLY\|THO\|M`                  | `QmFzZTY0UExhY2Vob2w...` |
 
 **Observation:** HOS-102 and CLN-202 can match on **T1** (first initial) even though the full first name differs (TOM vs THOMAS). They do **not** match on rules that require the full first name, and they cannot generate T4 because the SSN is missing.
@@ -279,8 +279,8 @@ For detailed rule compositions, see [Token Rules](token-rules.md).
 
 When comparing hash-only (or decrypted) token values across the two systems:
 
-| Record Pair       | T1  | T2  | T3  | T4  | T5  | Match?                |
-| ----------------- | --- | --- | --- | --- | --- | --------------------- |
+| Record Pair        | T1  | T2  | T3  | T4  | T5  | Match?                |
+| ------------------ | --- | --- | --- | --- | --- | --------------------- |
 | HOS-101 ↔ CLN-201 | ✓   | ✓   | ✓   | ✓   | ✓   | **Yes** (all rules)   |
 | HOS-102 ↔ CLN-202 | ✓   | ✗   | ✗   | —   | ✗   | **Depends** (T1 only) |
 | HOS-101 ↔ HOS-102 | ✗   | ✗   | ✗   | ✗   | ✗   | No                    |

--- a/pages/dev-guide-development.md
+++ b/pages/dev-guide-development.md
@@ -76,6 +76,7 @@ resources/             # Sample and test data
 tools/                 # Utility scripts (hash calculator, mock data, etc.)
 docs/                  # All developer documentation (this file!)
 ```
+
 Key Docs:
 
 - Development processes below
@@ -354,6 +355,7 @@ pytest src/test
 Notebook Guides:
 
 - See `lib/python/opentoken-pyspark/notebooks/` for example workflows (custom tokens & overlap analysis).
+
 ### Multi-Language Sync Tool
 
 The sync tool ([tools/multi_language_syncer.py](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/multi_language_syncer.py)) detects changes across all supported languages (Java, Python, Node.js) and produces a cross-language checklist showing which corresponding files need updating. It is bidirectional — changes originating in any language trigger sync items for the others.
@@ -394,11 +396,11 @@ Maintain the same functional behavior and normalization between languages.
 
 OpenToken supports three processing modes across Java, Python, and the PySpark bridge. These modes determine how raw token signatures are transformed:
 
-| Mode      | Secrets Required                     | Transform Pipeline                                | Output Example (T1)                  | Deterministic Across Runs | Recommended Use                                                   |
-| --------- | ------------------------------------ | ------------------------------------------------- | ------------------------------------ | ------------------------- | ----------------------------------------------------------------- |
-| Plain     | None (not currently exposed via CLI) | Concatenate normalized attribute expressions only | `DOE\|JOHN\|1990-01-15\|MALE\|98101` | Yes (given same input)    | Debugging, rule design, docs demos                                |
-| Tokenize  | Hashing secret only                  | HMAC-SHA256(signature)                            | 64 hex chars (SHA-256 digest)        | Yes                       | Internal overlap analysis against decrypted partner token outputs |
-| Encrypted | Hashing secret + encryption key      | HMAC-SHA256 → AES-256-GCM (random IV per token)   | Base64 blob (length varies)          | Yes (post-decrypt hash)   | Production / privacy-preserving use and external token exchange   |
+| Mode      | Secrets Required                | Transform Pipeline                                | Output Example (T1)                  | Deterministic Across Runs | Recommended Use                                                   |
+| --------- | ------------------------------- | ------------------------------------------------- | ------------------------------------ | ------------------------- | ----------------------------------------------------------------- |
+| Plain     | None (`tokenize --demo-mode`)   | Concatenate normalized attribute expressions only | `DOE\|JOHN\|1990-01-15\|MALE\|98101` | Yes (given same input)    | Debugging, rule design, docs demos                                |
+| Tokenize  | Hashing secret only             | HMAC-SHA256(signature)                            | 64 hex chars (SHA-256 digest)        | Yes                       | Internal overlap analysis against decrypted partner token outputs |
+| Encrypted | Hashing secret + encryption key | HMAC-SHA256 → AES-256-GCM (random IV per token)   | Base64 blob (length varies)          | Yes (post-decrypt hash)   | Production / privacy-preserving use and external token exchange   |
 
 Notes:
 
@@ -586,6 +588,6 @@ Before opening a PR:
 | Token mismatch between languages | Verify hashing & encryption secrets are identical and normalization logic unchanged |
 | Build fails on Checkstyle        | Run `mvn -q checkstyle:check` locally & fix warnings                                |
 
-
 ---
+
 Maintainers: Keep this guide updated when changing build, versioning, or extension workflows.

--- a/pages/index.md
+++ b/pages/index.md
@@ -8,7 +8,7 @@ OpenToken is a privacy-preserving tokenization and matching library for secure p
 
 ## What is OpenToken?
 
-OpenToken is a library and CLI tool for generating cryptographically secure matching tokens from person attributes. It enables privacy-preserving person matching by comparing tokens across datasets instead of directly comparing names, birthdates, SSNs, and other sensitive identifiers. It’s designed for any domain that needs deterministic, auditable linkage while minimizing exposure of raw PII.
+OpenToken is a library and CLI tool for generating cryptographically secure matching tokens from person attributes. It enables privacy-preserving record linkage by comparing tokens across datasets instead of directly comparing names, birthdates, SSNs, and other sensitive identifiers. It’s designed for any domain that needs deterministic, auditable linkage while minimizing exposure of raw PII.
 
 Matching is foundational for analytics, operations, and research, but traditional record linkage relies on handling raw identifiers that are both highly sensitive and frequently messy (typos, nicknames, missing values, inconsistent formats). OpenToken provides a deterministic, standards-driven tokenization pipeline (normalize → validate → generate T1–T5 signatures → hash/encrypt) so matching can be performed with minimized identifier exposure and with predictable behavior across environments.
 

--- a/pages/matching-concepts/index.md
+++ b/pages/matching-concepts/index.md
@@ -4,7 +4,7 @@ layout: default
 
 # Matching Concepts
 
-Understand how OpenToken tokens work for person matching and the strategies behind the 5 token rules.
+Understand how OpenToken tokens work for record linkage and the strategies behind the 5 token rules.
 
 ## Token Generation Rules
 
@@ -25,6 +25,7 @@ OpenToken generates **5 distinct tokens (T1–T5)** per person, each combining d
 ### Example
 
 Given a person:
+
 ```
 FirstName: John
 LastName: Doe
@@ -68,12 +69,14 @@ Using **5 rules increases match confidence** by capturing different attribute co
 Suppose you have two datasets and want to find matching persons:
 
 ### Dataset A
+
 ```
 RecordId: A1, Name: John Doe, BirthDate: 2000-01-01, ...
 RecordId: A2, Name: Jane Smith, BirthDate: 1985-06-15, ...
 ```
 
 ### Dataset B
+
 ```
 RecordId: B1, Name: Jon Doe, BirthDate: 2000-01-01, ...     # Same person as A1 (typo in name)
 RecordId: B2, Name: Jane Smith, BirthDate: 1985-06-15, ...   # Same person as A2
@@ -102,10 +105,12 @@ Token(A2, T1) != Token(B3, T1)  ✗ No match for all rules
 ### Matching Strategy
 
 A **match is confirmed** when:
+
 - Tokens match across **multiple rules** (not just one)
 - The matching rules provide **high discriminative power** (not just sex + birthdate, which is common)
 
 This approach handles:
+
 - **Typos and name variations**: T3 and T5 allow first name differences
 - **Data completeness**: T4 works even if SSN is unavailable (use T1–T3 instead)
 - **High confidence**: Matching on multiple rules reduces false positives

--- a/pages/operations/sharing-tokenized-data.md
+++ b/pages/operations/sharing-tokenized-data.md
@@ -4,7 +4,7 @@ layout: default
 
 # Sharing Tokenized Data Between Organizations
 
-How to securely exchange OpenToken outputs for cross-organization person matching.
+How to securely exchange OpenToken outputs for cross-organization record linkage.
 
 ---
 
@@ -227,9 +227,9 @@ See [Decrypting Tokens](decrypting-tokens.md) for details.
 
 Encrypted mode (`-e` flag) adds AES-256-GCM encryption on top of HMAC-SHA256:
 
-| Mode      | External Sharing   | Defense in Depth | Reversible              |
-| --------- | ------------------ | ---------------- | ----------------------- |
-| Encrypted | ✓ Recommended      | Yes              | To HMAC hash (with key) |
+| Mode      | External Sharing    | Defense in Depth | Reversible              |
+| --------- | ------------------- | ---------------- | ----------------------- |
+| Encrypted | ✓ Recommended       | Yes              | To HMAC hash (with key) |
 | Tokenize  | ⚠ Use with caution | No               | Not reversible          |
 
 Encrypted tokens provide an additional security layer if token files are intercepted.

--- a/pages/operations/tokenize.md
+++ b/pages/operations/tokenize.md
@@ -10,15 +10,23 @@ How to generate tokens using HMAC-SHA256 without AES encryption.
 
 ## Overview
 
-The `tokenize` subcommand generates deterministic tokens without AES encryption:
+The `tokenize` subcommand supports two modes:
 
-```
+**Normal mode** (default) — applies SHA-256 and HMAC-SHA256 to produce opaque, secret-keyed tokens:
+
+```text
 Token Signature → SHA-256 Hash → HMAC-SHA256(hash, secret) → Base64 Encode
 ```
 
-Compared to encryption mode:
+**Demo mode** (`--demo-mode`) — skips all hashing and outputs the raw pipe-separated attribute signature string:
 
+```text
+Token Signature → (passthrough) → Raw attribute signature string
 ```
+
+For reference, the full encryption pipeline used by `package` is:
+
+```text
 Token Signature → SHA-256 Hash → HMAC-SHA256(hash, secret) → AES-256-GCM Encrypt → Base64 Encode
 ```
 
@@ -28,11 +36,19 @@ Token Signature → SHA-256 Hash → HMAC-SHA256(hash, secret) → AES-256-GCM E
 
 The `tokenize` subcommand is primarily used to support **overlap analysis workflows** where you receive **encrypted tokens from an external partner** and want to build an internal dataset that can be joined against those tokens.
 
-**Use `tokenize` when:**
+**Use `tokenize` (normal mode) when:**
 
 - You are creating an internal tokenized dataset that will be matched against **encrypted tokens received from an external partner** (after decrypting their tokens to their unencrypted equivalent)
 - You need faster processing or smaller token size for **internal analytics and overlap reporting**
 - Raw data and tokens are already protected at rest within your environment
+
+**Use `tokenize --demo-mode` when:**
+
+- Exploring which attributes contribute to each token rule without managing secrets
+- Writing documentation or conducting interactive demonstrations
+- Debugging attribute normalisation or token rule logic
+
+> ⚠️ Demo mode output is **not** suitable for production or cross-organisation exchange. See [Demo Mode](#demo-mode---demo-mode) below.
 
 **Use `package` when:**
 
@@ -45,9 +61,11 @@ The `tokenize` subcommand is primarily used to support **overlap analysis workfl
 
 ## CLI Usage
 
+### Normal Mode
+
 Use the `tokenize` subcommand. Only the hashing secret is required (no encryption key).
 
-### Java
+#### Normal Mode — Java
 
 ```bash
 java -jar opentoken-cli/target/opentoken-cli-*.jar tokenize \
@@ -57,7 +75,7 @@ java -jar opentoken-cli/target/opentoken-cli-*.jar tokenize \
   -h "HashingKey"
 ```
 
-### Python
+#### Normal Mode — Python
 
 ```bash
 python -m opentoken_cli.main tokenize \
@@ -67,7 +85,7 @@ python -m opentoken_cli.main tokenize \
   -h "HashingKey"
 ```
 
-### Docker
+#### Normal Mode — Docker
 
 ```bash
 docker run --rm -v $(pwd)/resources:/app/resources \
@@ -77,6 +95,54 @@ docker run --rm -v $(pwd)/resources:/app/resources \
   -o /app/resources/hashed-output.csv \
   -h "HashingKey"
 ```
+
+### Demo Mode (`--demo-mode`)
+
+In demo mode the full hashing pipeline is skipped. No `--hashingsecret` is required.
+
+#### Demo Mode — Java
+
+```bash
+java -jar opentoken-cli/target/opentoken-cli-*.jar tokenize \
+  -i ../../resources/sample.csv \
+  -t csv \
+  -o ../../resources/demo-output.csv \
+  --demo-mode
+```
+
+#### Demo Mode — Python
+
+```bash
+python -m opentoken_cli.main tokenize \
+  -i ../../../resources/sample.csv \
+  -t csv \
+  -o ../../../resources/demo-output.csv \
+  --demo-mode
+```
+
+#### Demo Mode — Docker
+
+```bash
+docker run --rm -v $(pwd)/resources:/app/resources \
+  opentoken:latest tokenize \
+  -i /app/resources/sample.csv \
+  -t csv \
+  -o /app/resources/demo-output.csv \
+  --demo-mode
+```
+
+#### Demo Output Example
+
+For a record with first name `John`, last name `Doe`, and birth date `1980-01-15`:
+
+```csv
+RecordId,RuleId,Token
+ID001,T1,JOHN|DOE|19800115
+ID001,T2,JOHN|DOE|19800115|M
+ID001,T5,123456789
+```
+
+Each token is the raw pipe-separated list of normalised attribute values that compose that token rule — making it easy to see exactly which attributes contributed to each rule.
 
 ---
 
@@ -121,18 +187,29 @@ Tokenized (unencrypted) tokens are shorter because they don't include the AES in
 
 No `EncryptionSecretHash` field is present when using `tokenize`.
 
+### `tokenize --demo-mode` Metadata
+
+```json
+{
+  "TotalRows": 10
+}
+```
+
+neither `HashingSecretHash` nor `EncryptionSecretHash` appears in demo-mode metadata — no secret is used.
+
 ---
 
 ## Security Trade-offs
 
-| Aspect               | `package`                       | `tokenize`          |
-| -------------------- | ------------------------------- | ------------------- |
-| **Token length**     | ~80-100 chars                   | ~44-64 chars        |
-| **Processing speed** | Slower                          | Faster              |
-| **Secret required**  | Hashing secret + encryption key | Hashing secret only |
-| **Reversibility**    | Decryptable (to HMAC hash)      | Not decryptable     |
-| **External sharing** | Recommended                     | Not recommended     |
-| **Defense in depth** | Yes                             | No                  |
+| Aspect               | `package`                       | `tokenize`          | `tokenize --demo-mode`         |
+| -------------------- | ------------------------------- | ------------------- | ------------------------------ |
+| **Token length**     | ~80-100 chars                   | 44 chars (base64)   | Varies (plain text)            |
+| **Processing speed** | Slower                          | Faster              | Fastest                        |
+| **Secret required**  | Hashing secret + encryption key | Hashing secret only | None                           |
+| **Reversibility**    | Decryptable (to HMAC hash)      | Not decryptable     | Directly readable (plain text) |
+| **External sharing** | Recommended                     | Not recommended     | Never — contains raw PII       |
+| **Defense in depth** | Yes                             | No                  | No                             |
+| **Use case**         | Production / sharing            | Internal analysis   | Exploration / debugging only   |
 
 ### Security Notes
 
@@ -160,6 +237,7 @@ WHERE a.RuleId = 'T1';
 ```
 
 For encrypted tokens, either:
+
 1. Decrypt both datasets first, then match
 2. Use the same encryption key for both datasets and match encrypted tokens directly
 
@@ -172,6 +250,7 @@ For encrypted tokens, either:
 **Cause:** Different hashing secrets.
 
 **Solution:** Verify the same hashing secret is used for both runs:
+
 ```bash
 # Check metadata for secret hash
 cat output.metadata.json | jq '.HashingSecretHash'
@@ -182,6 +261,7 @@ cat output.metadata.json | jq '.HashingSecretHash'
 **Cause:** Attribute normalization differences or encoding issues.
 
 **Solution:**
+
 1. Verify secrets match exactly (including whitespace)
 2. Run the interoperability test:
    ```bash
@@ -195,6 +275,7 @@ cat output.metadata.json | jq '.HashingSecretHash'
 **Cause:** Using package mode without an encryption key.
 
 **Solution:** Use the `tokenize` subcommand to skip encryption:
+
 ```bash
 java -jar opentoken-cli-*.jar tokenize -i data.csv -t csv -o out.csv -h "Key"
 ```
@@ -206,3 +287,4 @@ java -jar opentoken-cli-*.jar tokenize -i data.csv -t csv -o out.csv -h "Key"
 - **`package` (encrypt) mode**: [Decrypting Tokens](decrypting-tokens.md)
 - **Batch processing**: [Running Batch Jobs](running-batch-jobs.md)
 - **Security guidance**: [Security](../security.md)
+- **Full flag reference**: [CLI Reference — tokenize](../reference/cli.md#tokenize)

--- a/pages/overview/index.md
+++ b/pages/overview/index.md
@@ -110,7 +110,7 @@ OpenToken is implemented in **Java and Python**. Both produce **byte-identical d
 
 ## Who Uses OpenToken?
 
-- **Data Engineers**: Building person matching pipelines
+- **Data Engineers**: Building record linkage pipelines
 - **Privacy/Infra Engineers**: Securing sensitive data in regulated systems
 - **Data/Platform Teams**: Linking records across datasets while preserving privacy
 - **Researchers**: Linking datasets for cohort studies without exposing raw identifiers

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -151,7 +151,7 @@ patient_002,Jane,Smith,1975-03-22,Female,90210,987-65-4321
 **Command:**
 
 ```bash
-java -jar opentoken-cli-*.jar tokenize \
+java -jar opentoken-cli-*.jar package \
   -i sample.csv \
   -t csv \
   -o tokens.csv \

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -69,6 +69,7 @@ cd opentoken-cli-2.0.0-alpha-windows-x64
 ### Verifying the Executable
 
 The self-contained executable includes:
+
 - Python 3.11 runtime (bundled)
 - All dependencies (pyarrow, pandas, cryptography)
 - OpenToken CLI and core library
@@ -109,26 +110,29 @@ cd C:\path\to\OpenToken
 
 The CLI is organized into subcommands. Choose the one that matches your workflow:
 
-| Subcommand | Description                                             | Requires   |
-| ---------- | ------------------------------------------------------- | ---------- |
-| `package`  | Tokenize and encrypt in one step — use for data sharing | `-h`, `-e` |
-| `tokenize` | Tokenize without encryption — use for internal analysis | `-h`       |
-| `encrypt`  | Encrypt previously tokenized (hashed) output            | `-e`       |
-| `decrypt`  | Decrypt encrypted tokens back to hashed form            | `-e`       |
+| Subcommand             | Description                                             | Requires   |
+| ---------------------- | ------------------------------------------------------- | ---------- |
+| `package`              | Tokenize and encrypt in one step — use for data sharing | `-h`, `-e` |
+| `tokenize`             | Tokenize without encryption — use for internal analysis | `-h`       |
+| `tokenize --demo-mode` | Output plain attribute signatures — use for exploration | none       |
+| `encrypt`              | Encrypt previously tokenized (hashed) output            | `-e`       |
+| `decrypt`              | Decrypt encrypted tokens back to hashed form            | `-e`       |
 
 For most use cases, `package` is the right starting point.
+Use `tokenize --demo-mode` to explore token output without managing secrets.
 
 ## Common Arguments
 
 These arguments are shared across all subcommands:
 
-| Argument          | Short | Description                         |
-| ----------------- | ----- | ----------------------------------- |
-| `--input`         | `-i`  | Input file path (CSV or Parquet)    |
-| `--output`        | `-o`  | Output file path                    |
-| `--type`          | `-t`  | File type: `csv` or `parquet`       |
-| `--hashingsecret` | `-h`  | Secret key for HMAC hashing         |
-| `--encryptionkey` | `-e`  | 32-character key for AES encryption |
+| Argument          | Short | Description                                                         |
+| ----------------- | ----- | ------------------------------------------------------------------- |
+| `--input`         | `-i`  | Input file path (CSV or Parquet)                                    |
+| `--output`        | `-o`  | Output file path                                                    |
+| `--type`          | `-t`  | File type: `csv` or `parquet`                                       |
+| `--hashingsecret` | `-h`  | Secret key for HMAC hashing (required unless `--demo-mode`)         |
+| `--encryptionkey` | `-e`  | 32-character key for AES encryption                                 |
+| `--demo-mode`     |       | Skip all hashing; output plain attribute signatures (tokenize only) |
 
 ## `package` Command
 
@@ -147,7 +151,7 @@ patient_002,Jane,Smith,1975-03-22,Female,90210,987-65-4321
 **Command:**
 
 ```bash
-java -jar opentoken-cli-*.jar package \
+java -jar opentoken-cli-*.jar tokenize \
   -i sample.csv \
   -t csv \
   -o tokens.csv \

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -35,6 +35,7 @@ The `tokenize` subcommand is primarily used to build **internal overlap-analysis
 ## Command Syntax
 
 **Linux/macOS (Bash):**
+
 ```bash
 # Self-contained executable
 ./opentoken [OPTIONS]
@@ -47,6 +48,7 @@ python -m opentoken_cli.main <subcommand> [OPTIONS]
 ```
 
 **Windows (PowerShell):**
+
 ```powershell
 # Self-contained executable
 .\opentoken.exe [OPTIONS]
@@ -73,13 +75,14 @@ python -m opentoken_cli.main <subcommand> [OPTIONS]
 
 ### `tokenize` (Hashed Tokens Only)
 
-| Argument          | Short | Required | Description                              |
-| ----------------- | ----- | -------- | ---------------------------------------- |
-| `--input`         | `-i`  | Yes      | Path to input file (CSV or Parquet)      |
-| `--output`        | `-o`  | Yes      | Path to output file                      |
-| `--type`          | `-t`  | Yes      | File type: `csv` or `parquet`            |
-| `--hashingsecret` | `-h`  | Yes      | Secret key for HMAC-SHA256 hashing       |
-| `--output-type`   | `-ot` | No       | Output file type if different from input |
+| Argument          | Short | Required         | Description                                              |
+| ----------------- | ----- | ---------------- | -------------------------------------------------------- |
+| `--input`         | `-i`  | Yes              | Path to input file (CSV or Parquet)                      |
+| `--output`        | `-o`  | Yes              | Path to output file                                      |
+| `--type`          | `-t`  | Yes              | File type: `csv` or `parquet`                            |
+| `--hashingsecret` | `-h`  | Normal mode only | Secret key for HMAC-SHA256 hashing                       |
+| `--demo-mode`     |       | No               | No hashing; outputs raw attribute signatures (see below) |
+| `--output-type`   | `-ot` | No               | Output file type if different from input                 |
 
 ### `encrypt` (Encrypt Input Tokens)
 
@@ -115,6 +118,7 @@ java -jar opentoken-cli-*.jar package \
 ```
 
 **Token Pipeline:**
+
 ```
 Signature → SHA-256 → HMAC-SHA256 → AES-256-GCM → Base64
 ```
@@ -131,9 +135,48 @@ java -jar opentoken-cli-*.jar tokenize \
 ```
 
 **Token Pipeline:**
+
 ```
 Signature → SHA-256 → HMAC-SHA256 → Base64
 ```
+
+### Demo Mode (`tokenize --demo-mode`)
+
+Outputs raw attribute signature strings without any hashing. Both the SHA-256 and HMAC
+steps are skipped. No `--hashingsecret` is required, making it easy to inspect which
+attribute values compose each token for development, testing, or demos.
+
+> ⚠️ **Demo-mode output must not be used in production or shared externally.** The raw
+> signatures expose the normalised attribute values directly and provide no privacy
+> protection across trust boundaries.
+
+```bash
+java -jar opentoken-cli-*.jar tokenize \
+  -i input.csv -t csv -o output.csv \
+  --demo-mode
+```
+
+**Token Pipeline:**
+
+```text
+Signature → (passthrough) → Raw pipe-separated string
+```
+
+**Example demo token** (T1 rule, first name + last name + birth date):
+
+```text
+JOHN|DOE|19800115
+```
+
+**Differences from normal `tokenize`:**
+
+| Aspect                          | Normal mode                    | Demo mode                                  |
+| ------------------------------- | ------------------------------ | ------------------------------------------ |
+| `--hashingsecret`               | Required                       | Not required (ignored if supplied)         |
+| Token pipeline                  | SHA-256 → HMAC-SHA256 → Base64 | Passthrough → raw signature string         |
+| Token format                    | Base64-encoded HMAC-SHA256     | Pipe-separated normalised attribute values |
+| `HashingSecretHash` in metadata | Present                        | Absent                                     |
+| Safe to share                   | No (internal only)             | No (never suitable for exchange)           |
 
 ## File Format Examples
 
@@ -171,7 +214,8 @@ patient_001,T5,QpBpGBqaMhagfcHGZhVavn23ko03jkyS9Vo4...
 ### Parquet Schema
 
 **Input:**
-```
+
+```text
 RecordId: string
 FirstName: string
 LastName: string
@@ -182,7 +226,8 @@ SSN: string
 ```
 
 **Output:**
-```
+
+```text
 RecordId: string
 RuleId: string
 Token: string

--- a/pages/security.md
+++ b/pages/security.md
@@ -4,13 +4,14 @@ layout: default
 
 # Security
 
-Cryptographic building blocks, key management expectations, and security considerations for privacy-preserving person matching.
+Cryptographic building blocks, key management expectations, and security considerations for privacy-preserving record linkage.
 
 ## Overview
 
-OpenToken generates cryptographically secure tokens for privacy-preserving person matching across datasets. The system uses deterministic hashing and optional encryption to prevent re-identification while enabling matching on identical person attributes.
+OpenToken generates cryptographically secure tokens for privacy-preserving record linkage across datasets. The system uses deterministic hashing and optional encryption to prevent re-identification while enabling matching on identical person attributes.
 
 **Key security properties:**
+
 - Tokens are one-way (cannot reverse to original data without secrets)
 - Same input produces same token (deterministic matching)
 - Metadata tracks processing statistics without exposing person data
@@ -24,6 +25,7 @@ OpenToken generates cryptographically secure tokens for privacy-preserving perso
 OpenToken transforms person attributes through multiple layers:
 
 **Encryption mode (default):**
+
 ```
 Token Signature (normalized attributes)
   ↓
@@ -37,6 +39,7 @@ Base64 Encode (storable format)
 ```
 
 **`tokenize` subcommand (alternative):**
+
 ```
 Token Signature
   ↓
@@ -55,6 +58,7 @@ Base64 Encode
 - **Purpose**: Convert variable-length token signatures to fixed-size digests
 
 **Properties:**
+
 - One-way function (cannot reverse hash to input)
 - Avalanche effect (small input change produces completely different hash)
 - Deterministic (same input always produces same hash)
@@ -67,11 +71,13 @@ Base64 Encode
 - **Purpose**: Prevent rainbow table attacks and verify secret usage
 
 **Security benefits:**
+
 - Requires secret key to generate matching hashes
 - Prevents pre-computation of token values
 - Different secret produces completely different output for same input
 
 **Formula:**
+
 ```
 HMAC-SHA256(message, key) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || message))
 ```
@@ -84,12 +90,14 @@ HMAC-SHA256(message, key) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || me
 - **Purpose**: Encrypt tokens to prevent re-identification
 
 **Technical details:**
+
 - **Initialization Vector (IV)**: 12 bytes, randomly generated per token
 - **Authentication tag**: 128-bit (16-byte) GCM tag for integrity
 - **Padding**: NoPadding (GCM mode handles message length)
 - **Algorithm**: `AES/GCM/NoPadding`
 
 **Security properties:**
+
 - Authenticated encryption (detects tampering)
 - Unique IV per token prevents pattern analysis
 - Computationally infeasible to brute-force (2^256 possible keys)
@@ -228,11 +236,13 @@ python tools/hash_calculator.py \
 ### What OpenToken Protects Against
 
 **✓ Re-identification without secrets:**
+
 - Encrypted tokens cannot be reversed without encryption key
 - Hashed tokens cannot be reversed (one-way HMAC-SHA256)
 - Attacker with tokens alone cannot recover person data
 
 **✓ Rainbow table attacks:**
+
 - HMAC-SHA256 with secret prevents pre-computed lookup tables
 - Different secret produces different tokens for same input
 
@@ -242,18 +252,22 @@ Metadata captures processing statistics; data quality guidance lives in the conc
 ### What OpenToken Does NOT Protect Against
 
 **✗ Compromise of secrets:**
+
 - If attacker obtains hashing secret + encryption key, they can regenerate tokens from known person data
 - Token security depends entirely on secret protection
 
 **✗ Side-channel attacks:**
+
 - Timing attacks, memory access patterns not specifically mitigated
 - Use secure execution environments for sensitive workloads
 
 **✗ Statistical analysis with auxiliary data:**
+
 - If attacker has auxiliary demographic data and token frequency distributions, statistical attacks may be possible
 - Consider differential privacy techniques for high-risk scenarios
 
 **✗ Token distribution analysis:**
+
 - Tokens are deterministic (same person always produces same token)
 - Frequency analysis may reveal population patterns
 - Mitigate by limiting token distribution and enforcing access controls
@@ -272,12 +286,14 @@ OpenToken provides cryptographic primitives but **users are responsible for:**
 ### Threat Model Assumptions
 
 **Assumptions:**
+
 - Secrets are stored securely and not accessible to unauthorized parties
 - Execution environment is trusted (no malware or unauthorized access)
 - Token outputs are protected with access controls
 - Users validate data quality before token generation
 
 **Out of scope:**
+
 - Protection against compromised execution environments
 - Protection after decryption (decrypted tokens are plaintext hashes)
 - Protection against authorized users misusing tokens

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -6,9 +6,10 @@ layout: default
 
 ## Overview
 
-OpenToken is a privacy-preserving token generation system for deterministic person matching across datasets. This specification defines the scope, inputs, processing steps, and outputs of the token generation pipeline.
+OpenToken is a privacy-preserving token generation system for deterministic record linkage across datasets. This specification defines the scope, inputs, processing steps, and outputs of the token generation pipeline.
 
 **Purpose:** Generate cryptographically secure tokens from person attributes such that:
+
 - Identical inputs always produce identical deterministic matching values (hash-only or decrypted)
 - Tokens reveal nothing about the underlying data (one-way)
 - Matching can occur on different attribute combinations via 5 distinct token rules (T1–T5)
@@ -43,6 +44,7 @@ OpenToken is a privacy-preserving token generation system for deterministic pers
 ### File Formats
 
 **Supported input formats:**
+
 - CSV (comma-separated values, with header row)
 - Parquet (columnar binary format)
 
@@ -51,11 +53,13 @@ OpenToken is a privacy-preserving token generation system for deterministic pers
 OpenToken is designed for **streaming-style** processing: it reads records, normalizes/validates, emits up to 5 tokens, and writes output without needing to hold the full dataset in memory.
 
 **Practical constraints:**
+
 - There is **no fixed maximum file size** imposed by OpenToken itself; limits are driven by your machine/cluster resources (CPU, memory, disk) and the underlying CSV/Parquet libraries.
 - Output size is roughly **5× the number of input rows** (one row per rule per record) plus metadata.
 - For Parquet, performance and memory usage depend on row group sizing and the reader implementation.
 
 **Recommendations:**
+
 - Prefer **Parquet** for large jobs (faster parsing, smaller I/O, better parallelism).
 - Ensure disk space for outputs (tokens + `.metadata.json`).
 - For very large datasets, use the **PySpark** integration to scale horizontally.
@@ -157,6 +161,7 @@ Signature → SHA-256 → HMAC-SHA256 → Base64
 ```
 
 **Parameters required:**
+
 - `hashing_secret`: String (8+ characters recommended) used for HMAC
 - `encryption_key`: String exactly 32 characters long (or byte array 32 bytes) used for AES-256 encryption
 
@@ -183,11 +188,13 @@ Metadata is written to `.metadata.json` alongside output files.
 ### Token Output (CSV)
 
 **Schema:**
+
 ```
 RecordId,RuleId,Token
 ```
 
 **Columns:**
+
 - `RecordId`: From input (or auto-generated if omitted)
 - `RuleId`: T1, T2, T3, T4, or T5
 - `Token`: Encrypted `ot.V1.<JWE>` token in encrypted mode, or base64 HMAC token in hash-only/decrypted mode (or empty string if validation failed)
@@ -195,6 +202,7 @@ RecordId,RuleId,Token
 **Rows per input record:** 5 (one per rule); may be fewer if errors occur
 
 **Example:**
+
 ```csv
 RecordId,RuleId,Token
 ID001,T1,aB7c9Dz1e4...
@@ -221,12 +229,14 @@ Parquet format includes compression and is suitable for large datasets.
 **Filename:** `<output_basename>.metadata.json`
 
 **Contents:**
+
 - Processing statistics (record counts, invalid attributes, blank tokens)
 - System information (platform, versions, timestamps)
 - Secret hashes (SHA-256 of hashing secret and encryption key)
 - File paths (input, output, metadata)
 
 **Example:**
+
 ```json
 {
   "Platform": "Java",
@@ -281,6 +291,7 @@ This section is **non-normative** (informational) and describes likely evolution
 ### Breaking Changes
 
 Any changes to:
+
 - Normalization rules
 - Token rule definitions
 - Cryptographic algorithms

--- a/tools/multi-language-mapping.json
+++ b/tools/multi-language-mapping.json
@@ -1,13 +1,17 @@
 {
-    "ignore_patterns": [
-        "**/package-info.java",
-        "**/target/**",
-        "**/*.class",
-        "**/.*",
-        "**/properties/**",
-        "**/*.properties",
-        "**/resources/**",
-        "**/__pycache__/**",
-        "**/*.pyc"
-    ]
+  "ignore_patterns": [
+    "**/package-info.java",
+    "**/target/**",
+    "**/*.class",
+    "**/.*",
+    "**/properties/**",
+    "**/*.properties",
+    "**/resources/**",
+    "**/__pycache__/**",
+    "**/*.pyc",
+    "**/opentoken/cli/commands/**",
+    "**/opentoken/cli/processor/**",
+    "**/opentoken_cli/commands/**",
+    "**/opentoken_cli/processor/**"
+  ]
 }

--- a/tools/multi-language-mapping.json
+++ b/tools/multi-language-mapping.json
@@ -8,10 +8,6 @@
     "**/*.properties",
     "**/resources/**",
     "**/__pycache__/**",
-    "**/*.pyc",
-    "**/opentoken/cli/commands/**",
-    "**/opentoken/cli/processor/**",
-    "**/opentoken_cli/commands/**",
-    "**/opentoken_cli/processor/**"
+    "**/*.pyc"
   ]
 }

--- a/tools/multi_language_syncer.py
+++ b/tools/multi_language_syncer.py
@@ -5,58 +5,63 @@ Detects changes in any language (Java, Python, Node.js) and creates correspondin
 for the other languages.
 """
 
+import argparse
 import fnmatch
 import json
 import re
 import subprocess
-import argparse
 import sys
 from pathlib import Path
 
+
 class MultiLanguageSyncer:
     """Syncer that handles Java, Python, and Node.js implementations"""
-    
+
     # Language configuration
     LANGUAGES = {
-        'java': {
-            'path': 'lib/java/opentoken/src/main/java/com/truveta/opentoken/',
-            'extension': '.java',
-            'naming': 'PascalCase'
+        "java": {
+            "path": "lib/java/opentoken/src/main/java/com/truveta/opentoken/",
+            "extension": ".java",
+            "naming": "PascalCase",
+            "group": "core",
         },
-        'java-cli': {
-            'path': 'lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/',
-            'extension': '.java',
-            'naming': 'PascalCase'
+        "java-cli": {
+            "path": "lib/java/opentoken-cli/src/main/java/com/truveta/opentoken/cli/",
+            "extension": ".java",
+            "naming": "PascalCase",
+            "group": "cli",
         },
-        'python': {
-            'path': 'lib/python/opentoken/src/main/opentoken/',
-            'extension': '.py',
-            'naming': 'snake_case'
+        "python": {
+            "path": "lib/python/opentoken/src/main/opentoken/",
+            "extension": ".py",
+            "naming": "snake_case",
+            "group": "core",
         },
-        'python-cli': {
-            'path': 'lib/python/opentoken-cli/src/main/opentoken_cli/',
-            'extension': '.py',
-            'naming': 'snake_case'
+        "python-cli": {
+            "path": "lib/python/opentoken-cli/src/main/opentoken_cli/",
+            "extension": ".py",
+            "naming": "snake_case",
+            "group": "cli",
         },
     }
-    
+
     FALLBACK_MAPPINGS = {
         "critical_files": {},
         "directory_mappings": {},
         "ignore_patterns": [],
-        "auto_generate_unmapped": True
+        "auto_generate_unmapped": True,
     }
 
     def __init__(self, mapping_file="tools/multi-language-mapping.json"):
         self.root_dir = Path(__file__).parent.parent
         self.mapping_file = self.root_dir / mapping_file
-        
+
         self.load_mappings()
         self._discover_active_languages()
 
     def _discover_active_languages(self):
         """Discover which languages have existing paths in the repository.
-        
+
         Filters LANGUAGES to only include entries whose configured path exists
         on disk. This prevents spurious missing-sync tasks for languages that
         have not yet been implemented in this repository.
@@ -64,7 +69,7 @@ class MultiLanguageSyncer:
         discovered = {
             lang: config
             for lang, config in self.LANGUAGES.items()
-            if (self.root_dir / config['path']).is_dir()
+            if (self.root_dir / config["path"]).is_dir()
         }
         if discovered:
             self.LANGUAGES = discovered
@@ -76,7 +81,7 @@ class MultiLanguageSyncer:
     def load_mappings(self):
         """Load the multi-language file mappings"""
         try:
-            with open(self.mapping_file, 'r') as f:
+            with open(self.mapping_file, "r") as f:
                 self.mappings = json.load(f)
         except FileNotFoundError:
             print(f"Warning: Mapping file not found: {self.mapping_file}")
@@ -87,27 +92,40 @@ class MultiLanguageSyncer:
 
     def get_changes_for_language(self, language, since_commit="HEAD~1"):
         """Get list of changed files for a specific language
-        
+
         Args:
             language: The language to check ('java', 'python', or 'nodejs')
             since_commit: The commit to compare against
-            
+
         Returns:
             A list of changed files for that language
         """
         if language not in self.LANGUAGES:
             return []
-        
+
         lang_config = self.LANGUAGES[language]
-        lang_path = lang_config['path']
-        
+        lang_path = lang_config["path"]
+
         try:
-            result = subprocess.run([
-                'git', 'diff', '--name-only', f'{since_commit}', 'HEAD', '--', lang_path
-            ], capture_output=True, text=True, cwd=self.root_dir)
+            result = subprocess.run(
+                [
+                    "git",
+                    "diff",
+                    "--name-only",
+                    f"{since_commit}",
+                    "HEAD",
+                    "--",
+                    lang_path,
+                ],
+                capture_output=True,
+                text=True,
+                cwd=self.root_dir,
+            )
 
             if result.returncode == 0:
-                all_files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+                all_files = [
+                    line.strip() for line in result.stdout.splitlines() if line.strip()
+                ]
                 return self._filter_ignored_files(all_files)
             return []
         except subprocess.CalledProcessError:
@@ -117,51 +135,63 @@ class MultiLanguageSyncer:
         """Filter out files that match ignore patterns"""
         ignore_patterns = self.mappings.get("ignore_patterns", [])
         filtered_files = []
-        
+
         for file in files:
             should_ignore = False
             for pattern in ignore_patterns:
                 if fnmatch.fnmatch(file, pattern):
                     should_ignore = True
                     break
-            
+
             if not should_ignore:
                 filtered_files.append(file)
-        
+
         return filtered_files
 
     def get_file_last_modified_commit(self, file_path, since_commit="HEAD~1"):
         """Get the most recent commit that modified a specific file"""
         try:
-            result = subprocess.run([
-                'git', 'log', '-1', '--format=%H %ct', f'{since_commit}..HEAD', '--', file_path
-            ], capture_output=True, text=True, cwd=self.root_dir)
-            
+            result = subprocess.run(
+                [
+                    "git",
+                    "log",
+                    "-1",
+                    "--format=%H %ct",
+                    f"{since_commit}..HEAD",
+                    "--",
+                    file_path,
+                ],
+                capture_output=True,
+                text=True,
+                cwd=self.root_dir,
+            )
+
             if result.returncode == 0 and result.stdout.strip():
                 commit_hash, timestamp = result.stdout.strip().split()
-                return {
-                    'commit': commit_hash,
-                    'timestamp': int(timestamp)
-                }
+                return {"commit": commit_hash, "timestamp": int(timestamp)}
             return None
         except subprocess.CalledProcessError:
             return None
 
     def is_file_up_to_date(self, source_file, target_file, since_commit="HEAD~1"):
         """Check if target file is up-to-date relative to source file changes"""
-        source_last_modified = self.get_file_last_modified_commit(source_file, since_commit)
-        target_last_modified = self.get_file_last_modified_commit(target_file, since_commit)
-        
+        source_last_modified = self.get_file_last_modified_commit(
+            source_file, since_commit
+        )
+        target_last_modified = self.get_file_last_modified_commit(
+            target_file, since_commit
+        )
+
         # If source file wasn't modified at all in this PR, no sync needed
         if not source_last_modified:
             return True
-            
+
         # If target file wasn't modified at all in this PR, it's out of date
         if not target_last_modified:
             return False
-            
+
         # Target is up-to-date if it was modified after the source file
-        return target_last_modified['timestamp'] >= source_last_modified['timestamp']
+        return target_last_modified["timestamp"] >= source_last_modified["timestamp"]
 
     def check_file_exists(self, file_path):
         """Check if a file exists"""
@@ -172,24 +202,24 @@ class MultiLanguageSyncer:
         # Remove extension
         base_name = filename
         for lang_config in self.LANGUAGES.values():
-            if filename.endswith(lang_config['extension']):
-                base_name = filename[:-len(lang_config['extension'])]
+            if filename.endswith(lang_config["extension"]):
+                base_name = filename[: -len(lang_config["extension"])]
                 break
-        
+
         # Convert naming convention
-        if from_naming == 'PascalCase' and to_naming == 'snake_case':
+        if from_naming == "PascalCase" and to_naming == "snake_case":
             # Convert PascalCase to snake_case
-            base_name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', base_name)
-            base_name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', base_name).lower()
-        elif from_naming == 'snake_case' and to_naming == 'PascalCase':
+            base_name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", base_name)
+            base_name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", base_name).lower()
+        elif from_naming == "snake_case" and to_naming == "PascalCase":
             # Convert snake_case to PascalCase
-            base_name = ''.join(word.capitalize() for word in base_name.split('_'))
-        
+            base_name = "".join(word.capitalize() for word in base_name.split("_"))
+
         return base_name
 
     def get_corresponding_files(self, source_file, source_lang, active_languages=None):
         """Get corresponding files in other languages
-        
+
         Args:
             source_file: Path to the source file
             source_lang: Language of the source file
@@ -197,123 +227,150 @@ class MultiLanguageSyncer:
                               Defaults to all LANGUAGES when None.
         """
         corresponding = {}
-        
+
         # Extract relative path within language directory
         lang_config = self.LANGUAGES[source_lang]
-        source_path = source_file.replace(lang_config['path'], '')
-        
-        # Try to map to other languages
-        target_pool = active_languages if active_languages is not None else self.LANGUAGES
+        source_path = source_file.replace(lang_config["path"], "")
+
+        # Try to map to other languages in the same group only (e.g. cli→cli, core→core).
+        # This prevents CLI command/processor files from being projected onto core library
+        # paths where they don't belong, which would generate false-positive sync tasks.
+        source_group = lang_config.get("group")
+        target_pool = (
+            active_languages if active_languages is not None else self.LANGUAGES
+        )
         for target_lang, target_config in target_pool.items():
             if target_lang == source_lang:
+                continue
+            if source_group and target_config.get("group") != source_group:
                 continue
 
             # Convert directory structure (usually similar)
             target_path = source_path
-            path_parts = target_path.split('/')
+            path_parts = target_path.split("/")
             if path_parts:
                 filename = path_parts[-1]
                 converted = self.convert_filename(
-                    filename,
-                    lang_config['naming'],
-                    target_config['naming']
+                    filename, lang_config["naming"], target_config["naming"]
                 )
-                path_parts[-1] = converted + target_config['extension']
-                target_path = '/'.join(path_parts)
-            
-            target_file = target_config['path'] + target_path
+                path_parts[-1] = converted + target_config["extension"]
+                target_path = "/".join(path_parts)
+
+            target_file = target_config["path"] + target_path
             corresponding[target_lang] = target_file
-        
+
         return corresponding
 
     def run_health_check(self):
         """Run a health check to validate tool configuration and environment
-        
+
         Returns:
             A tuple of (passed: bool, report: str)
         """
         issues = []
         checks = []
-        
+
         # Check 1: Git is available
         try:
-            result = subprocess.run(['git', '--version'], capture_output=True, text=True)
+            result = subprocess.run(
+                ["git", "--version"], capture_output=True, text=True
+            )
             if result.returncode == 0:
-                checks.append(('✓', 'Git', f'available ({result.stdout.strip()})'))
+                checks.append(("✓", "Git", f"available ({result.stdout.strip()})"))
             else:
-                issues.append('Git is not properly configured')
-                checks.append(('✗', 'Git', 'not available'))
+                issues.append("Git is not properly configured")
+                checks.append(("✗", "Git", "not available"))
         except FileNotFoundError:
-            issues.append('Git command not found on PATH')
-            checks.append(('✗', 'Git', 'not found'))
-        
+            issues.append("Git command not found on PATH")
+            checks.append(("✗", "Git", "not found"))
+
         # Check 2: Root directory is a git repository
         try:
             result = subprocess.run(
-                ['git', 'rev-parse', '--git-dir'],
-                capture_output=True, text=True, cwd=self.root_dir
+                ["git", "rev-parse", "--git-dir"],
+                capture_output=True,
+                text=True,
+                cwd=self.root_dir,
             )
             if result.returncode == 0:
-                checks.append(('✓', 'Git Repository', f'found at {self.root_dir}'))
+                checks.append(("✓", "Git Repository", f"found at {self.root_dir}"))
             else:
-                issues.append(f'Root directory {self.root_dir} is not a git repository')
-                checks.append(('✗', 'Git Repository', 'not found'))
+                issues.append(f"Root directory {self.root_dir} is not a git repository")
+                checks.append(("✗", "Git Repository", "not found"))
         except subprocess.CalledProcessError:
-            issues.append(f'Cannot verify git repository at {self.root_dir}')
-            checks.append(('✗', 'Git Repository', 'verification failed'))
-        
+            issues.append(f"Cannot verify git repository at {self.root_dir}")
+            checks.append(("✗", "Git Repository", "verification failed"))
+
         # Check 3: Language paths exist
         for lang, config in self.LANGUAGES.items():
-            lang_path = self.root_dir / config['path']
+            lang_path = self.root_dir / config["path"]
             if lang_path.exists() and lang_path.is_dir():
-                checks.append(('✓', f'{lang.upper()} Path', str(config['path'])))
+                checks.append(("✓", f"{lang.upper()} Path", str(config["path"])))
             else:
                 issues.append(f'{lang.upper()} path does not exist: {config["path"]}')
-                checks.append(('✗', f'{lang.upper()} Path', str(config['path'])))
-        
+                checks.append(("✗", f"{lang.upper()} Path", str(config["path"])))
+
         # Check 4: Mapping file
         if self.mapping_file.exists():
             try:
-                with open(self.mapping_file, 'r') as f:
+                with open(self.mapping_file, "r") as f:
                     json.load(f)
-                checks.append(('✓', 'Mapping File', f'{self.mapping_file.name} (valid JSON)'))
+                checks.append(
+                    ("✓", "Mapping File", f"{self.mapping_file.name} (valid JSON)")
+                )
             except json.JSONDecodeError as e:
-                issues.append(f'Mapping file contains invalid JSON: {e}')
-                checks.append(('✗', 'Mapping File', f'{self.mapping_file.name} (invalid JSON)'))
+                issues.append(f"Mapping file contains invalid JSON: {e}")
+                checks.append(
+                    ("✗", "Mapping File", f"{self.mapping_file.name} (invalid JSON)")
+                )
         else:
-            checks.append(('⚠', 'Mapping File', f'not found at {self.mapping_file} (using defaults)'))
-        
+            checks.append(
+                (
+                    "⚠",
+                    "Mapping File",
+                    f"not found at {self.mapping_file} (using defaults)",
+                )
+            )
+
         # Check 5: Ignore patterns in mapping
-        ignore_patterns = self.mappings.get('ignore_patterns', [])
+        ignore_patterns = self.mappings.get("ignore_patterns", [])
         if ignore_patterns:
-            checks.append(('✓', 'Ignore Patterns', f'{len(ignore_patterns)} pattern(s) configured'))
+            checks.append(
+                (
+                    "✓",
+                    "Ignore Patterns",
+                    f"{len(ignore_patterns)} pattern(s) configured",
+                )
+            )
         else:
-            checks.append(('ℹ', 'Ignore Patterns', 'none configured'))
-        
+            checks.append(("ℹ", "Ignore Patterns", "none configured"))
+
         # Check 6: Can execute git commands
         try:
             result = subprocess.run(
-                ['git', 'status', '--porcelain'],
-                capture_output=True, text=True, cwd=self.root_dir
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                cwd=self.root_dir,
             )
             if result.returncode == 0:
-                checks.append(('✓', 'Git Commands', 'working'))
+                checks.append(("✓", "Git Commands", "working"))
             else:
-                issues.append('Cannot execute git commands')
-                checks.append(('✗', 'Git Commands', 'failed'))
+                issues.append("Cannot execute git commands")
+                checks.append(("✗", "Git Commands", "failed"))
         except subprocess.CalledProcessError:
-            issues.append('Failed to execute git commands')
-            checks.append(('✗', 'Git Commands', 'failed'))
-        
+            issues.append("Failed to execute git commands")
+            checks.append(("✗", "Git Commands", "failed"))
+
         # Format report
         output = "Multi-Language Sync Tool - Health Check Report\n"
         output += "=" * 60 + "\n\n"
-        
+
         for symbol, name, status in checks:
             output += f"{symbol} {name:.<20} {status}\n"
-        
+
         output += "\n" + "=" * 60 + "\n"
-        
+
         if issues:
             output += f"⚠️  {len(issues)} issue(s) found:\n\n"
             for i, issue in enumerate(issues, 1):
@@ -324,14 +381,16 @@ class MultiLanguageSyncer:
             output += "Status: ✅ PASSED\n"
             return (True, output)
 
-    def generate_sync_report(self, output_format="console", since_commit="HEAD~1", languages=None):
+    def generate_sync_report(
+        self, output_format="console", since_commit="HEAD~1", languages=None
+    ):
         """Generate a report of files that need syncing across all languages
-        
+
         Returns:
             A tuple of (report: str, is_complete: bool) where is_complete indicates
             whether all syncs are up-to-date. Returns (report, True) when no changes
             are detected (nothing to do).
-        
+
         Args:
             output_format: One of 'console', 'json', or 'github-checklist'
             since_commit: The commit to compare against
@@ -340,94 +399,118 @@ class MultiLanguageSyncer:
                        only the specified languages. Defaults to all languages.
         """
         active_languages = {
-            k: v for k, v in self.LANGUAGES.items()
+            k: v
+            for k, v in self.LANGUAGES.items()
             if languages is None or k in languages
         }
-        
+
         # Get changes for each active language
         all_changes = {}
         for lang in active_languages:
             all_changes[lang] = self.get_changes_for_language(lang, since_commit)
-        
+
         # Check if any changes were made
         total_changes = sum(len(changes) for changes in all_changes.values())
         if total_changes == 0:
             if output_format == "github-checklist":
-                return ("✅ All changes appear to be in sync across Java, Python, and Node.js!", True)
+                return (
+                    "✅ All changes appear to be in sync across Java, Python, and Node.js!",
+                    True,
+                )
             else:
                 return ("No changes detected in any language.", True)
-        
+
         # Build sync requirements
         sync_requirements = []
-        
+
         for source_lang, changed_files in all_changes.items():
             for source_file in changed_files:
-                corresponding = self.get_corresponding_files(source_file, source_lang, active_languages)
-                sync_requirements.append({
-                    'source_lang': source_lang,
-                    'source_file': source_file,
-                    'corresponding': corresponding
-                })
-        
-        report = self.format_output(sync_requirements, all_changes, output_format, since_commit)
+                corresponding = self.get_corresponding_files(
+                    source_file, source_lang, active_languages
+                )
+                sync_requirements.append(
+                    {
+                        "source_lang": source_lang,
+                        "source_file": source_file,
+                        "corresponding": corresponding,
+                    }
+                )
+
+        report = self.format_output(
+            sync_requirements, all_changes, output_format, since_commit
+        )
         is_complete = self._check_sync_complete(sync_requirements, since_commit)
-        
+
         return (report, is_complete)
 
-    def format_output(self, sync_requirements, all_changes, output_format="console", since_commit="HEAD~1"):
+    def format_output(
+        self,
+        sync_requirements,
+        all_changes,
+        output_format="console",
+        since_commit="HEAD~1",
+    ):
         """Format the output based on the specified format"""
         if output_format == "github-checklist":
-            return self.format_github_checklist(sync_requirements, all_changes, since_commit)
+            return self.format_github_checklist(
+                sync_requirements, all_changes, since_commit
+            )
         elif output_format == "json":
-            return json.dumps({
-                "sync_requirements": sync_requirements,
-                "all_changes": all_changes
-            }, indent=2)
+            return json.dumps(
+                {"sync_requirements": sync_requirements, "all_changes": all_changes},
+                indent=2,
+            )
         else:
             return self.format_console(sync_requirements, all_changes, since_commit)
 
     def _check_sync_complete(self, sync_requirements, since_commit="HEAD~1"):
         """Check if all sync requirements are complete (up-to-date)
-        
+
         Returns:
             True if all corresponding files are up-to-date, False otherwise
         """
         for req in sync_requirements:
-            for target_lang, target_file in req['corresponding'].items():
-                if not self.is_file_up_to_date(req['source_file'], target_file, since_commit):
+            for target_lang, target_file in req["corresponding"].items():
+                if not self.is_file_up_to_date(
+                    req["source_file"], target_file, since_commit
+                ):
                     return False
         return True
 
     def format_github_checklist(self, sync_requirements, all_changes, since_commit):
         """Format output as GitHub markdown checklist"""
         if not sync_requirements:
-            return "✅ All changes appear to be in sync across Java, Python, and Node.js!"
-        
+            return (
+                "✅ All changes appear to be in sync across Java, Python, and Node.js!"
+            )
+
         total_items = 0
         completed_items = 0
-        
+
         output = "## Multi-Language Sync Required\n\n"
-        
+
         # Group by source language
         by_lang = {}
         for req in sync_requirements:
-            lang = req['source_lang']
+            lang = req["source_lang"]
             if lang not in by_lang:
                 by_lang[lang] = []
             by_lang[lang].append(req)
-        
+
         for source_lang in sorted(by_lang.keys()):
             output += f"### 🔹 From {source_lang.upper()}\n\n"
-            
+
             for req in by_lang[source_lang]:
-                source_file = req['source_file']
+                source_file = req["source_file"]
                 output += f"#### 📁 `{source_file}`\n"
-                
-                for target_lang, target_file in sorted(req['corresponding'].items()):
+
+                for target_lang, target_file in sorted(req["corresponding"].items()):
                     total_items += 1
                     exists = self.check_file_exists(target_file)
-                    is_up_to_date = self.is_file_up_to_date(source_file, target_file, since_commit)
-                    
+                    is_up_to_date = self.is_file_up_to_date(
+                        source_file, target_file, since_commit
+                    )
+
                     if is_up_to_date:
                         checkbox = "- [x]"
                         status = "✓🔄"
@@ -438,77 +521,87 @@ class MultiLanguageSyncer:
                     else:
                         checkbox = "- [ ]"
                         status = "✗⏳"
-                    
+
                     output += f"{checkbox} **{status} {target_lang.upper()}**: `{target_file}`\n"
-                
+
                 output += "\n"
-        
+
         # Update the header with completion count
         output = output.replace(
             "## Multi-Language Sync Required\n\n",
-            f"## Multi-Language Sync Required ({completed_items}/{total_items} completed)\n\n"
+            f"## Multi-Language Sync Required ({completed_items}/{total_items} completed)\n\n",
         )
-        
+
         if completed_items > 0:
-            output += f"✅ **Progress**: {completed_items} of {total_items} items completed\n"
-        
+            output += (
+                f"✅ **Progress**: {completed_items} of {total_items} items completed\n"
+            )
+
         return output
 
     def format_console(self, sync_requirements, all_changes, since_commit):
         """Format output for console"""
         output = "Multi-Language Sync Report\n"
         output += "=" * 60 + "\n\n"
-        
+
         for lang, changes in all_changes.items():
             if changes:
                 output += f"{lang.upper()}: {len(changes)} files changed\n"
-        
+
         output += "\n" + "=" * 60 + "\n"
         output += "Sync Requirements:\n\n"
-        
+
         for req in sync_requirements:
             output += f"Source: {req['source_file']}\n"
-            for target_lang, target_file in req['corresponding'].items():
+            for target_lang, target_file in req["corresponding"].items():
                 exists = "✓" if self.check_file_exists(target_file) else "✗"
                 output += f"  → {target_lang}: {exists} {target_file}\n"
             output += "\n"
-        
+
         return output
 
 
 def main():
     """Main entry point
-    
+
     Returns:
         0 if successful (health check passed or sync is complete)
         1 if sync is incomplete (corresponding files not updated)
     """
-    parser = argparse.ArgumentParser(description='Multi-language sync checker')
-    parser.add_argument('--format', choices=['console', 'json', 'github-checklist'],
-                       default='console', help='Output format')
-    parser.add_argument('--since', default='HEAD~1',
-                       help='Compare since this commit')
-    parser.add_argument('--languages',
-                       help='Comma-separated list of languages to check (e.g., java,python)')
-    parser.add_argument('--health-check', action='store_true',
-                       help='Run health check')
-    
+    parser = argparse.ArgumentParser(description="Multi-language sync checker")
+    parser.add_argument(
+        "--format",
+        choices=["console", "json", "github-checklist"],
+        default="console",
+        help="Output format",
+    )
+    parser.add_argument("--since", default="HEAD~1", help="Compare since this commit")
+    parser.add_argument(
+        "--languages",
+        help="Comma-separated list of languages to check (e.g., java,python)",
+    )
+    parser.add_argument("--health-check", action="store_true", help="Run health check")
+
     args = parser.parse_args()
-    
-    languages = [l.strip() for l in args.languages.split(',')] if args.languages else None
-    
+
+    languages = (
+        [lang.strip() for lang in args.languages.split(",")] if args.languages else None
+    )
+
     syncer = MultiLanguageSyncer()
-    
+
     if args.health_check:
         passed, report = syncer.run_health_check()
         print(report)
         sys.exit(0 if passed else 1)
-    
-    report, is_complete = syncer.generate_sync_report(args.format, args.since, languages)
-    
+
+    report, is_complete = syncer.generate_sync_report(
+        args.format, args.since, languages
+    )
+
     if report:
         print(report)
-    
+
     sys.exit(0 if is_complete else 1)
 
 


### PR DESCRIPTION
## Summary

Adds a `--demo-mode` flag to the `tokenize` subcommand in both the Java and Python CLIs. In demo mode the entire hashing pipeline (SHA-256 + HMAC-SHA256) is skipped and tokens are the raw pipe-separated attribute signature strings (e.g. `JOHN|DOE|19800115`). This makes it easy to explore tokenisation output without managing secrets, while keeping normal-mode behaviour completely unchanged.

> ⚠️ Demo-mode output is **not** suitable for production or cross-organisation exchange.

## Changes

### Java (`lib/java/opentoken-cli`)

- **`TokenizeCommand.java`** – add `--demo-mode` boolean flag; make `--hashingsecret` optional in the parser (validated at runtime in normal mode); route demo path through `PassthroughTokenizer(List.of())`; normal path uses `buildHashTransformers()` helper; `HashingSecretHash` omitted from metadata in demo mode.
- **`PersonAttributesProcessor.java`** – add `process(reader, writer, Tokenizer, Map)` overload accepting any `Tokenizer`; refactor core row-processing loop into `private processWithTokenizer()`; existing `List<TokenTransformer>` overload unchanged.
- **`TokenizeCommandDemoModeTest.java`** *(new)* – 13 tests covering mode selection, secret validation, output shape (44-char HMAC base64 vs raw signatures), and metadata presence.

### Python (`lib/python/opentoken-cli`)

- **`tokenize_command.py`** – matching `--demo-mode` flag; `--hashingsecret` changed to `required=False`; demo path calls `process_with_tokenizer(PassthroughTokenizer([]))`; `HashingSecretHash` omitted from metadata in demo mode.
- **`person_attributes_processor.py`** – add `process_with_tokenizer(reader, writer, tokenizer, metadata_map)` static method; refactor shared logic into `_process_with_tokenizer()`.
- **`tokenize_command_demo_mode_test.py`** *(new)* – 12 tests mirroring the Java suite.
- **`pyproject.toml`** – add `[tool.pytest.ini_options] pythonpath` so tests use the worktree source across shared venvs.

### Docs (`pages/reference/cli.md`)

- `tokenize` args table updated (`--hashingsecret` = normal mode only; `--demo-mode` documented).
- Demo Mode section added: pipeline comparison, example token, production warning.

## Testing

- [x] Java: all 88 CLI tests pass (`mvn clean install -pl opentoken-cli -am`)
- [x] Python: all 98 CLI tests pass (`pytest src/test/`)
- [x] Normal-mode behaviour unchanged (existing tests unmodified and passing)
- [x] Demo mode confirmed end-to-end with `resources/sample.csv`

## Files Changed

- `lib/java/opentoken-cli/src/main/.../commands/TokenizeCommand.java`
- `lib/java/opentoken-cli/src/main/.../processor/PersonAttributesProcessor.java`
- `lib/java/opentoken-cli/src/test/.../commands/TokenizeCommandDemoModeTest.java` *(new)*
- `lib/python/opentoken-cli/src/main/opentoken_cli/commands/tokenize_command.py`
- `lib/python/opentoken-cli/src/main/opentoken_cli/processor/person_attributes_processor.py`
- `lib/python/opentoken-cli/src/test/opentoken_cli/tokenize_command_demo_mode_test.py` *(new)*
- `lib/python/opentoken-cli/pyproject.toml`
- `pages/reference/cli.md`