### PR TITLE
chore: bump io.airlift:aircompressor from 2.0.2 to 2.0.3

### DIFF
--- a/lib/java/opentoken-cli/pom.xml
+++ b/lib/java/opentoken-cli/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.3</version>
             </dependency>
             <dependency>
                 <groupId>io.airlift</groupId>


### PR DESCRIPTION
## Summary

Bumps the `io.airlift:aircompressor` dependency from `2.0.2` to `2.0.3` in `lib/java/opentoken-cli/pom.xml`.

## Changes

- Updated `io.airlift:aircompressor` version from `2.0.2` to `2.0.3` in the `dependencyManagement` section of the CLI module POM

## Testing

- [x] Java build passes (`mvn clean install`)
- [x] No functional regressions (pure dependency bump, no API changes expected)

## Files Changed

- `lib/java/opentoken-cli/pom.xml` (1 line)
