### PR TITLE
docs: Update virtual environment activation instructions across documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,19 +63,19 @@ This document provides comprehensive guidance for AI coding agents working on th
 
 ### ⚠️ CRITICAL PYTHON ENVIRONMENT RULE
 
-**The Python virtual environment (`.venv`) is located at the repository root (`/workspaces/OpenToken/.venv`).**
+**In the devcontainer, the workspace-root `.venv` is a symlink to the shared environment at `/home/vscode/.local/share/opentoken/.venv`.**
 
 - ❌ **NEVER** create or activate a venv in any subdirectory (e.g., `lib/python/opentoken/.venv`)
-- ❌ **NEVER** run `uv venv .venv` from any folder other than the repo root
-- ✅ **ALWAYS** activate the root venv: `source /workspaces/OpenToken/.venv/bin/activate`
-- ✅ **ALWAYS** use absolute path or ensure you're at repo root before activating
+- ❌ **NEVER** run `uv venv .venv` from any folder other than the repo or worktree root
+- ✅ **ALWAYS** activate the workspace-root venv: `cd "$(git rev-parse --show-toplevel)" && source .venv/bin/activate`
+- ✅ **ALWAYS** treat `/home/vscode/.local/share/opentoken/.venv` as the canonical devcontainer location and `.venv` as its compatibility symlink
 
 ```bash
-# CORRECT - activate from anywhere using absolute path
-source /workspaces/OpenToken/.venv/bin/activate
+# CORRECT - activate from anywhere in the repo or worktree
+cd "$(git rev-parse --show-toplevel)" && source .venv/bin/activate
 
-# CORRECT - navigate to repo root first
-cd /workspaces/OpenToken && source .venv/bin/activate
+# CORRECT - use the shared devcontainer path directly when needed
+source /home/vscode/.local/share/opentoken/.venv/bin/activate
 
 # WRONG - never do this from lib/python or any subdirectory
 cd lib/python/opentoken && uv venv .venv  # ❌ DO NOT DO THIS
@@ -88,14 +88,14 @@ cd lib/python/opentoken && uv venv .venv  # ❌ DO NOT DO THIS
 # Builds both opentoken (core) and opentoken-cli modules
 cd lib/java && mvn clean install
 
-# Python: Activate root venv first, then run tests from package directories
-source /workspaces/OpenToken/.venv/bin/activate
+# Python: Activate the workspace-root venv first, then run tests from package directories
+cd "$(git rev-parse --show-toplevel)" && source .venv/bin/activate
 
 # Python core library tests:
-cd /workspaces/OpenToken/lib/python/opentoken && pytest
+cd lib/python/opentoken && pytest
 
 # Python CLI tests:
-cd /workspaces/OpenToken/lib/python/opentoken-cli && pytest
+cd ../opentoken-cli && pytest
 
 # Note: No unified build script exists - build each language separately
 ```
@@ -353,7 +353,7 @@ Fix style issues before running full build.
 **Python import errors:**
 
 ```bash
-cd lib/python/opentoken && source .venv/bin/activate
+cd "$(git rev-parse --show-toplevel)" && source .venv/bin/activate && cd lib/python/opentoken
 uv pip install -e .
 ```
 
@@ -396,7 +396,7 @@ cd lib/java/opentoken && mvn verify
 # Open target/site/jacoco/index.html in browser
 
 # Python: Generate and view coverage report
-cd lib/python/opentoken && source .venv/bin/activate
+cd "$(git rev-parse --show-toplevel)" && source .venv/bin/activate && cd lib/python/opentoken
 pytest --cov=opentoken --cov-report=html --cov-report=term
 # Open htmlcov/index.html in browser
 ```

--- a/pages/community-development/index.md
+++ b/pages/community-development/index.md
@@ -45,7 +45,8 @@ uv pip install -r requirements.txt -e .
 ### PySpark Bridge
 
 ```bash
-source /workspaces/OpenToken/.venv/bin/activate
+# From repo root
+source .venv/bin/activate
 cd lib/python/opentoken-pyspark
 uv pip install -r requirements.txt -e .
 ```

--- a/pages/config/configuration.md
+++ b/pages/config/configuration.md
@@ -100,11 +100,13 @@ Input columns are **case-insensitive** and support common aliases:
 ### Postal Code Formats
 
 **US ZIP Codes:**
+
 - `98004` (5 digits)
 - `98004-1234` (9 digits, dash removed)
 - `980` (ZIP-3, auto-padded to `98000`)
 
 **Canadian Postal Codes:**
+
 - `K1A 1A1` (with space)
 - `K1A1A1` (without space, auto-formatted)
 
@@ -174,9 +176,9 @@ java -jar opentoken-cli/target/opentoken-cli-*.jar package \
   -h "HashingKey" -e "EncryptionKey32Characters!!!!!"
 
 # Python
-source /workspaces/OpenToken/.venv/bin/activate
+source ../../.venv/bin/activate
 python -m opentoken_cli.main package \
-  -i ../../../resources/sample.csv -t csv -o ../../../resources/output.csv \
+  -i ../../resources/sample.csv -t csv -o ../../resources/output.csv \
   -h "HashingKey" -e "EncryptionKey32Characters!!!!!"
 ```
 

--- a/pages/operations/spark-or-databricks.md
+++ b/pages/operations/spark-or-databricks.md
@@ -32,7 +32,8 @@ How to use the PySpark bridge for distributed token generation on Spark clusters
 ### Local Development
 
 ```bash
-source /workspaces/OpenToken/.venv/bin/activate
+# From repo root
+source .venv/bin/activate
 
 cd lib/python/opentoken-pyspark
 uv pip install -e .[spark40]  # For Java 21

--- a/pages/quickstarts/python-quickstart.md
+++ b/pages/quickstarts/python-quickstart.md
@@ -211,7 +211,8 @@ OpenToken requires Python 3.10+. Check with `python --version`.
 If commands fail, ensure venv is active:
 
 ```bash
-source /path/to/OpenToken/.venv/bin/activate
+cd /path/to/OpenToken
+source .venv/bin/activate
 ```
 
 ### Import Errors After Updates
@@ -227,8 +228,9 @@ uv pip install -e . --reinstall
 The console script is installed into the active environment. Re-activate your venv and reinstall the CLI package:
 
 ```bash
-source /path/to/OpenToken/.venv/bin/activate
-cd /path/to/OpenToken/lib/python/opentoken-cli
+cd /path/to/OpenToken
+source .venv/bin/activate
+cd lib/python/opentoken-cli
 uv pip install -e .
 ```
 

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -241,7 +241,8 @@ For large-scale distributed token generation and dataset overlap analysis, use t
 Ensure the Python root venv is active, then install:
 
 ```bash
-source /workspaces/OpenToken/.venv/bin/activate
+cd /path/to/OpenToken
+source .venv/bin/activate
 
 cd lib/python/opentoken-pyspark
 uv pip install -r requirements.txt -e .


### PR DESCRIPTION
## Summary

Update virtual environment activation instructions across documentation to reflect the correct shared devcontainer venv path and usage conventions.

## Changes

- Updated `.github/copilot-instructions.md` with corrected venv activation guidance
- Updated `pages/community-development/index.md`
- Updated `pages/config/configuration.md`
- Updated `pages/operations/spark-or-databricks.md`
- Updated `pages/quickstarts/python-quickstart.md`
- Updated `pages/running-opentoken/index.md`

## Testing

- [ ] Documentation reviewed for accuracy
- [ ] venv activation commands verified in devcontainer

## Files Changed

- `.github/copilot-instructions.md` (28 changes)
- `pages/community-development/index.md`
- `pages/config/configuration.md`
- `pages/operations/spark-or-databricks.md`
- `pages/quickstarts/python-quickstart.md`
- `pages/running-opentoken/index.md`