### PR TITLE
feat: CLI extension system with hello-world reference extension

### DIFF
--- a/.devcontainer/scripts/unified-setup.sh
+++ b/.devcontainer/scripts/unified-setup.sh
@@ -102,16 +102,12 @@ step_activate_venv() {
 }
 
 step_install_packages() {
-  skip_if_complete "packages-installed" "workspace package installation" && return 0
-
   echo "→ Installing all workspace packages and dependencies"
   cd "$REPO_ROOT"
   uv sync --all-packages --dev
 
   echo "→ Installing default PySpark bridge runtime (Spark 4.0)"
   uv pip install -e "lib/python/opentoken-pyspark[spark40]"
-
-  mark_complete "packages-installed"
 }
 
 step_activate_shell_init() {
@@ -145,11 +141,8 @@ step_install_prek() {
 # ============================================================================
 
 step_install_apm_cli() {
-  skip_if_complete "apm-cli-installed" "APM CLI installation" && return 0
-
   echo "→ Installing apm CLI"
   uv pip install apm-cli
-  mark_complete "apm-cli-installed"
 }
 
 step_setup_apm() {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,10 @@ This file is the runtime entrypoint. Keep it concise, and use the scoped instruc
 - **Commenting guidance:** `.github/instructions/self-explanatory-code-commenting.instructions.md`
 - **Specialized task handling:** Prefer matching custom agents from `.github/agents/` when their scope fits the work.
 
+## Code review
+
+When performing a code review, focus only on findings that are medium severity or higher. Skip style preferences, minor nitpicks, and low-impact suggestions. Surface bugs, security vulnerabilities, logic errors, correctness issues, and significant maintainability or performance concerns. For each finding, clearly state the severity, the risk, and what the fix should achieve.
+
 ## Runtime usage notes
 
 - Load only the smallest relevant instruction set for the files you are editing.

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ apm_modules/
 .github/skills/documentation-writer/
 .github/skills/gh-cli/
 apm.lock.yaml
+lib/python/opentoken-cli/C:/Users/tester/AppData/Roaming/.opentoken/update-check.json

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ apm_modules/
 .github/skills/writing-skills/
 .github/skills/documentation-writer/
 .github/skills/gh-cli/
+apm.lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ demos/pprl-superhero-example/datasets/
 .ruff_cache/
 *.exchange.json
 apm.lock
+apm.lock.yaml
 
 # APM dependencies
 apm_modules/
@@ -113,5 +114,3 @@ apm_modules/
 .github/skills/writing-skills/
 .github/skills/documentation-writer/
 .github/skills/gh-cli/
-apm.lock.yaml
-lib/python/opentoken-cli/C:/Users/tester/AppData/Roaming/.opentoken/update-check.json

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -754,8 +754,10 @@ opentoken --help
 opentoken extension list
 
 # Run it
-opentoken hello-world greet --name Alice
-# → Hello, Alice! — from OpenToken hello-world extension
+opentoken hello-world hello --name Alice
+# → Hello, Alice
+opentoken hello-world bye --name Bob
+# → Bye, Bob
 ```
 
 ### Manual testing: wheel install (full pipeline)
@@ -768,15 +770,17 @@ cd lib/python/opentoken_ext_hello_world
 # Build the wheel
 pip install build && python -m build
 
-# Install via the extension command (--yes skips the security prompt)
-opentoken extension install file://./dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl --yes
+# Install via the extension command (--yes skips the security prompt; use an absolute path)
+opentoken extension install file://$(pwd)/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl --yes
 
 # Confirm it appears in the registry
 opentoken extension list
 
 # Run it
-opentoken hello-world greet --name Alice
-# → Hello, Alice! — from OpenToken hello-world extension
+opentoken hello-world hello --name Alice
+# → Hello, Alice
+opentoken hello-world bye --name Bob
+# → Bye, Bob
 ```
 
 ### Run the extension tests

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -721,6 +721,103 @@ Writes:
 
 `--curve` options: `P-256` (default), `P-384`, `P-521`. Use `--force` to overwrite existing keys.
 
+## Local Extension Development
+
+The `opentoken-ext-hello-world` package in `lib/python/opentoken_ext_hello_world/` is the canonical reference extension. Use it as your starting point when developing a new extension locally.
+
+### Setup
+
+Install the hello-world extension in editable mode so the CLI discovers it via the `opentoken.extensions` entry-point group:
+
+```shell
+source /home/vscode/.local/share/opentoken/.venv/bin/activate
+
+# Install the CLI in editable mode (if not already)
+cd lib/python/opentoken-cli && uv pip install -e .
+
+# Install the reference extension in editable mode
+cd lib/python/opentoken_ext_hello_world && uv pip install -e .
+```
+
+After the editable install, the entry point is registered in the active Python environment. The CLI discovers it at startup with no further configuration.
+
+### Manual testing: editable install (fast path)
+
+The editable install registers the entry point immediately — no build step required.
+
+```shell
+cd lib/python/opentoken_ext_hello_world
+uv pip install -e .
+
+# Verify it appears in help and the extension list
+opentoken --help
+opentoken extension list
+
+# Run it
+opentoken hello-world greet --name Alice
+# → Hello, Alice! — from OpenToken hello-world extension
+```
+
+### Manual testing: wheel install (full pipeline)
+
+Use this to test the complete `extension install` flow, including download, unpacking, and registry write.
+
+```shell
+cd lib/python/opentoken_ext_hello_world
+
+# Build the wheel
+pip install build && python -m build
+
+# Install via the extension command (--yes skips the security prompt)
+opentoken extension install file://./dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl --yes
+
+# Confirm it appears in the registry
+opentoken extension list
+
+# Run it
+opentoken hello-world greet --name Alice
+# → Hello, Alice! — from OpenToken hello-world extension
+```
+
+### Run the extension tests
+
+```shell
+cd lib/python/opentoken_ext_hello_world && pytest src/test
+```
+
+### Developing your own extension
+
+1. Create a new directory for your extension package (mirror the `opentoken-hello-world` structure).
+2. Implement `OpenTokenExtension` from `opentoken_cli.extension`:
+   ```python
+   from opentoken_cli.extension import OpenTokenExtension
+   ```
+3. Declare the `opentoken.extensions` entry point in your `pyproject.toml`:
+   ```toml
+   [project.entry-points."opentoken.extensions"]
+   my-ext = "my_package.extension:MyExtension"
+   ```
+4. Install in editable mode (`uv pip install -e .`) — the CLI picks it up on next invocation.
+5. Package with `python -m build` and distribute as a `.whl`.
+6. End users install via `opentoken extension install <url-or-file://path>`.
+
+See `lib/python/opentoken_ext_hello_world/README.md` for the full lifecycle walkthrough and `pages/quickstarts/extension-quickstart.md` for a step-by-step guide.
+
+### Extension tests in `opentoken-cli`
+
+The loader, registry, and command tests live in:
+
+```
+lib/python/opentoken-cli/src/test/opentoken_cli/extension/
+lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+```
+
+Run them with:
+
+```shell
+cd lib/python/opentoken-cli && pytest src/test/opentoken_cli/extension src/test/opentoken_cli/commands/test_extension_command.py -v
+```
+
 ## Development Container
 
 A Dev Container configuration provides a reproducible environment with:

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -16,6 +16,8 @@ from typing import Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 from opentoken_cli.extension.extension_registry import ExtensionRegistry
 
 logger = logging.getLogger(__name__)
@@ -70,6 +72,7 @@ def _resolve_extension_command_name(
             exc,
         )
         return None
+
 
 _SECURITY_WARNING = (
     "WARNING: Extensions are arbitrary Python code and are not verified by Truveta. "
@@ -468,8 +471,7 @@ class ExtensionCommand:
                 )
                 if resolved_command_name is None:
                     print(
-                        "Error: Unable to determine extension command name from "
-                        f"{module_name}.{class_name}.",
+                        f"Error: Unable to determine extension command name from {module_name}.{class_name}.",
                         file=sys.stderr,
                     )
                     return 1
@@ -512,8 +514,7 @@ class ExtensionCommand:
                 )
                 if resolved_command_name is None:
                     print(
-                        "Error: Unable to determine extension command name from "
-                        f"{module_name}.{class_name}.",
+                        f"Error: Unable to determine extension command name from {module_name}.{class_name}.",
                         file=sys.stderr,
                     )
                     return 1
@@ -558,13 +559,15 @@ class ExtensionCommand:
         external = []
         for line in content.splitlines():
             if line.startswith("Requires-Dist:"):
-                dep = line.split(":", 1)[1].strip()
-                # Extract just the package name (before any version specifier / extras).
-                dep_name = dep.split(";")[0].split("[")[0].strip().rstrip("><=! ").lower()
-                # Normalise dashes/underscores.
-                dep_name_norm = dep_name.replace("_", "-")
+                raw_dep = line.split(":", 1)[1].strip()
+                try:
+                    req = Requirement(raw_dep)
+                except InvalidRequirement:
+                    continue
+                # Normalise dashes/underscores per PEP 503.
+                dep_name_norm = req.name.lower().replace("_", "-")
                 if dep_name_norm not in _BUNDLED_DEPS:
-                    external.append(dep_name)
+                    external.append(req.name)
         return ", ".join(external) if external else None
 
     @staticmethod

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -348,6 +348,12 @@ class ExtensionCommand:
                 # Frozen binary: extract wheel contents and inject via sys.path at runtime.
                 ext_dir = ExtensionRegistry.get_extensions_dir() / ext_name
                 src_dir = ext_dir / "src"
+                if src_dir.exists():
+                    try:
+                        shutil.rmtree(src_dir)
+                    except FileNotFoundError:
+                        # Directory was removed concurrently; safe to proceed.
+                        pass
                 src_dir.mkdir(parents=True, exist_ok=True)
                 zf.extractall(src_dir)
                 metadata: dict = {

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -9,6 +9,8 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+from contextlib import contextmanager
+import importlib
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -17,6 +19,57 @@ from urllib.request import urlopen
 from opentoken_cli.extension.extension_registry import ExtensionRegistry
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _temporary_sys_path(path: Optional[Path]):
+    """
+    Temporarily add ``path`` to ``sys.path`` for dynamic imports.
+    """
+    if path is None:
+        yield
+        return
+
+    path_str = str(path)
+    if path_str in sys.path:
+        yield
+        return
+
+    sys.path.insert(0, path_str)
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(path_str)
+        except ValueError:
+            pass
+
+
+def _resolve_extension_command_name(
+    module_name: str,
+    class_name: str,
+    src_dir: Optional[Path] = None,
+) -> Optional[str]:
+    """
+    Import the extension class and return its ``command_name`` attribute.
+    """
+    try:
+        with _temporary_sys_path(src_dir):
+            module = importlib.import_module(module_name)
+            extension_cls = getattr(module, class_name)
+            extension_obj = extension_cls()
+            command_name = getattr(extension_obj, "command_name", None)
+            if not isinstance(command_name, str) or not command_name:
+                return None
+            return command_name
+    except Exception as exc:
+        logger.error(
+            "Failed to resolve command_name for extension %s.%s: %s",
+            module_name,
+            class_name,
+            exc,
+        )
+        return None
 
 _SECURITY_WARNING = (
     "WARNING: Extensions are arbitrary Python code and are not verified by Truveta. "
@@ -388,6 +441,7 @@ class ExtensionCommand:
 
             ext_name, module_name, class_name, version, dist_name = entry_point_info
 
+            command_name = ext_name
             if getattr(sys, "frozen", False):
                 # Frozen binary: extract wheel contents and inject via sys.path at runtime.
                 ext_dir = ExtensionRegistry.get_extensions_dir() / ext_name
@@ -407,13 +461,34 @@ class ExtensionCommand:
                         file=sys.stderr,
                     )
                     return 1
+                resolved_command_name = _resolve_extension_command_name(
+                    module_name,
+                    class_name,
+                    src_dir,
+                )
+                if resolved_command_name is None:
+                    print(
+                        "Error: Unable to determine extension command name from "
+                        f"{module_name}.{class_name}.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                if resolved_command_name != ext_name:
+                    print(
+                        "Error: Extension command name mismatch: entry point "
+                        f"'{ext_name}' does not match extension.command_name "
+                        f"'{resolved_command_name}'. These values must be identical.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                command_name = resolved_command_name
                 metadata: dict = {
                     "version": version,
                     "source_url": source_url,
                     "source_path": str(src_dir),
                     "module": module_name,
                     "class": class_name,
-                    "command_name": ext_name,
+                    "command_name": command_name,
                     "dist_name": dist_name,
                 }
             else:
@@ -431,16 +506,36 @@ class ExtensionCommand:
                         file=sys.stderr,
                     )
                     return 1
+                resolved_command_name = _resolve_extension_command_name(
+                    module_name,
+                    class_name,
+                )
+                if resolved_command_name is None:
+                    print(
+                        "Error: Unable to determine extension command name from "
+                        f"{module_name}.{class_name}.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                if resolved_command_name != ext_name:
+                    print(
+                        "Error: Extension command name mismatch: entry point "
+                        f"'{ext_name}' does not match extension.command_name "
+                        f"'{resolved_command_name}'. These values must be identical.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                command_name = resolved_command_name
                 metadata = {
                     "version": version,
                     "source_url": source_url,
                     "module": module_name,
                     "class": class_name,
-                    "command_name": ext_name,
+                    "command_name": command_name,
                     "dist_name": dist_name,
                 }
 
-        ExtensionRegistry.add_extension(ext_name, metadata)
+        ExtensionRegistry.add_extension(command_name, metadata)
         print(f"Extension '{ext_name}' (v{version}) installed successfully.")
         print(f"Run: opentoken {ext_name} --help")
         return 0

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -11,6 +11,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 from opentoken_cli.extension.extension_registry import ExtensionRegistry
@@ -294,8 +295,19 @@ class ExtensionCommand:
             return False
 
         try:
-            with urlopen(url, timeout=_REQUEST_TIMEOUT_SECONDS) as resp, dest.open("wb") as out:
-                shutil.copyfileobj(resp, out)
+            with urlopen(url, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
+                final_url = resp.geturl()
+                parsed_final = urlparse(final_url)
+                if parsed_final.scheme.lower() != "https":
+                    print(
+                        "Error: Download was redirected to a non-HTTPS URL "
+                        f"('{final_url}'). Insecure downloads are not allowed.",
+                        file=sys.stderr,
+                    )
+                    return False
+
+                with dest.open("wb") as out:
+                    shutil.copyfileobj(resp, out)
             return True
         except Exception as exc:
             print(f"Error: Download failed for '{url}': {exc}", file=sys.stderr)

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -37,7 +37,7 @@ class ExtensionCommand:
     """
     Manage OpenToken CLI extensions.
 
-    Provides sub-subcommands to install, list, uninstall, and update extensions.
+    Provides sub-subcommands to install, list, and uninstall extensions.
     """
 
     @staticmethod
@@ -46,7 +46,7 @@ class ExtensionCommand:
         parser = subparsers.add_parser(
             "extension",
             help="Manage OpenToken CLI extensions",
-            description="Install, list, uninstall, and update OpenToken CLI extensions.",
+            description="Install, list, and uninstall OpenToken CLI extensions.",
         )
         sub = parser.add_subparsers(dest="extension_subcommand")
 
@@ -77,19 +77,6 @@ class ExtensionCommand:
         uninstall_parser = sub.add_parser("uninstall", help="Uninstall an extension by name")
         uninstall_parser.add_argument("name", help="Extension name to uninstall")
         uninstall_parser.set_defaults(func=ExtensionCommand._uninstall)
-
-        # update
-        update_parser = sub.add_parser("update", help="Re-install an extension from its original source URL")
-        update_parser.add_argument("name", help="Extension name to update")
-        update_parser.add_argument(
-            "-y",
-            "--yes",
-            action="store_true",
-            default=False,
-            dest="yes",
-            help="Skip the security confirmation prompt",
-        )
-        update_parser.set_defaults(func=ExtensionCommand._update)
 
         parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
 
@@ -245,42 +232,6 @@ class ExtensionCommand:
         ExtensionRegistry.remove_extension(name)
         print(f"Extension '{name}' uninstalled.")
         return 0
-
-    @staticmethod
-    def _update(args) -> int:
-        """Handle ``extension update <name>``."""
-        name: str = args.name
-        skip_confirm: bool = getattr(args, "yes", False)
-        meta = ExtensionRegistry.get_extension(name)
-        if meta is None:
-            print(f"Error: Extension '{name}' is not installed.", file=sys.stderr)
-            return 1
-
-        source_url = meta.get("source_url")
-        if not source_url:
-            print(f"Error: No source URL recorded for extension '{name}'.", file=sys.stderr)
-            return 1
-
-        # Reuse install logic; pass --yes through.
-        ext_dir = ExtensionRegistry.get_extensions_dir() / name
-        if ext_dir.exists():
-            shutil.rmtree(ext_dir)
-
-        print(_SECURITY_WARNING)
-        if not skip_confirm and sys.stdin.isatty():
-            try:
-                answer = input("Do you want to continue? [y/N] ").strip().lower()
-            except (EOFError, KeyboardInterrupt):
-                answer = ""
-            if answer not in ("y", "yes"):
-                print("Update cancelled.")
-                return 0
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir) / "extension.whl"
-            if not ExtensionCommand._download(source_url, tmp_path):
-                return 1
-            return ExtensionCommand._install_wheel(tmp_path, source_url=source_url)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -1,0 +1,419 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import configparser
+import logging
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Optional
+from urllib.request import urlopen
+
+from opentoken_cli.extension.extension_registry import ExtensionRegistry
+
+logger = logging.getLogger(__name__)
+
+_SECURITY_WARNING = (
+    "WARNING: Extensions are arbitrary Python code and are not verified by Truveta. "
+    "Install only extensions from sources you trust."
+)
+
+#: Dependencies bundled into the frozen binary that extensions may rely on.
+_BUNDLED_DEPS: frozenset[str] = frozenset(
+    {
+        "opentoken",
+        "opentoken-cli",
+    }
+)
+
+_REQUEST_TIMEOUT_SECONDS = 60
+
+
+class ExtensionCommand:
+    """
+    Manage OpenToken CLI extensions.
+
+    Provides sub-subcommands to install, list, uninstall, and update extensions.
+    """
+
+    @staticmethod
+    def register_subcommand(subparsers) -> None:
+        """Register the ``extension`` subcommand and its sub-subcommands."""
+        parser = subparsers.add_parser(
+            "extension",
+            help="Manage OpenToken CLI extensions",
+            description="Install, list, uninstall, and update OpenToken CLI extensions.",
+        )
+        sub = parser.add_subparsers(dest="extension_subcommand")
+
+        # install
+        install_parser = sub.add_parser(
+            "install",
+            help="Install an extension from a URL or local file path",
+        )
+        install_parser.add_argument(
+            "url",
+            help="URL (https://) or local path (file://) to the extension .whl",
+        )
+        install_parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            default=False,
+            dest="yes",
+            help="Skip the security confirmation prompt",
+        )
+        install_parser.set_defaults(func=ExtensionCommand._install)
+
+        # list
+        list_parser = sub.add_parser("list", help="List installed extensions")
+        list_parser.set_defaults(func=ExtensionCommand._list)
+
+        # uninstall
+        uninstall_parser = sub.add_parser("uninstall", help="Uninstall an extension by name")
+        uninstall_parser.add_argument("name", help="Extension name to uninstall")
+        uninstall_parser.set_defaults(func=ExtensionCommand._uninstall)
+
+        # update
+        update_parser = sub.add_parser("update", help="Re-install an extension from its original source URL")
+        update_parser.add_argument("name", help="Extension name to update")
+        update_parser.add_argument(
+            "-y",
+            "--yes",
+            action="store_true",
+            default=False,
+            dest="yes",
+            help="Skip the security confirmation prompt",
+        )
+        update_parser.set_defaults(func=ExtensionCommand._update)
+
+        parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
+
+    # ------------------------------------------------------------------
+    # Sub-command handlers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _install(args) -> int:
+        """Handle ``extension install <url>``."""
+        url: str = args.url
+        skip_confirm: bool = getattr(args, "yes", False)
+
+        print(_SECURITY_WARNING)
+        if not skip_confirm and sys.stdin.isatty():
+            try:
+                answer = input("Do you want to continue? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = ""
+            if answer not in ("y", "yes"):
+                print("Installation cancelled.")
+                return 0
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir) / "extension.whl"
+            if not ExtensionCommand._download(url, tmp_path):
+                return 1
+
+            return ExtensionCommand._install_wheel(tmp_path, source_url=url)
+
+    @staticmethod
+    def _list(args) -> int:  # noqa: ARG004
+        """Handle ``extension list``."""
+        rows: dict[str, dict] = {}
+
+        # Registry entries (installed via `extension install`).
+        for name, meta in ExtensionRegistry.load().items():
+            rows[name] = {
+                "version": meta.get("version", ""),
+                "command": meta.get("command_name", name),
+                "source": meta.get("source_url", ""),
+            }
+
+        # Entry-point extensions (installed via pip / editable install).
+        # These are not in the registry, so we surface them separately.
+        if not getattr(sys, "frozen", False):
+            import importlib.metadata
+
+            try:
+                eps = importlib.metadata.entry_points(group="opentoken.extensions")
+                for ep in eps:
+                    if ep.name not in rows:
+                        version = ""
+                        try:
+                            version = ep.dist.metadata["Version"] or ""
+                        except Exception:
+                            pass
+                        rows[ep.name] = {
+                            "version": version,
+                            "command": ep.name,
+                            "source": "pip-installed",
+                        }
+            except Exception as exc:
+                logger.debug("Could not query entry points for list: %s", exc)
+
+        if not rows:
+            print("No extensions installed.")
+            return 0
+
+        col_widths = {"name": 4, "version": 7, "command": 7, "source": 10}
+        for name, meta in rows.items():
+            col_widths["name"] = max(col_widths["name"], len(name))
+            col_widths["version"] = max(col_widths["version"], len(meta["version"]))
+            col_widths["command"] = max(col_widths["command"], len(meta["command"]))
+            col_widths["source"] = max(col_widths["source"], len(meta["source"]))
+
+        header = (
+            f"{'Name':<{col_widths['name']}}  "
+            f"{'Version':<{col_widths['version']}}  "
+            f"{'Command':<{col_widths['command']}}  "
+            f"Source"
+        )
+        print(header)
+        print("-" * len(header))
+        for name, meta in sorted(rows.items()):
+            print(
+                f"{name:<{col_widths['name']}}  "
+                f"{meta['version']:<{col_widths['version']}}  "
+                f"{meta['command']:<{col_widths['command']}}  "
+                f"{meta['source']}"
+            )
+        return 0
+
+    @staticmethod
+    def _uninstall(args) -> int:
+        """Handle ``extension uninstall <name>``."""
+        name: str = args.name
+        registry = ExtensionRegistry.load()
+
+        if name not in registry:
+            # Check if it exists as a pip-installed entry-point extension.
+            pip_installed = False
+            if not getattr(sys, "frozen", False):
+                import importlib.metadata
+
+                try:
+                    eps = importlib.metadata.entry_points(group="opentoken.extensions")
+                    pip_installed = any(ep.name == name for ep in eps)
+                except Exception:
+                    pass
+
+            if pip_installed:
+                print(
+                    f"Error: '{name}' was installed via pip and cannot be removed by this command.\n"
+                    f"Uninstall it with your package manager instead, for example:\n"
+                    f"\n"
+                    f"    pip uninstall {name}\n"
+                    f"    uv pip uninstall {name}",
+                    file=sys.stderr,
+                )
+                return 1
+
+            print(f"Error: Extension '{name}' is not installed.", file=sys.stderr)
+            return 1
+
+        ext_dir = ExtensionRegistry.get_extensions_dir() / name
+        if ext_dir.exists():
+            shutil.rmtree(ext_dir)
+        ExtensionRegistry.remove_extension(name)
+        print(f"Extension '{name}' uninstalled.")
+        return 0
+
+    @staticmethod
+    def _update(args) -> int:
+        """Handle ``extension update <name>``."""
+        name: str = args.name
+        skip_confirm: bool = getattr(args, "yes", False)
+        meta = ExtensionRegistry.get_extension(name)
+        if meta is None:
+            print(f"Error: Extension '{name}' is not installed.", file=sys.stderr)
+            return 1
+
+        source_url = meta.get("source_url")
+        if not source_url:
+            print(f"Error: No source URL recorded for extension '{name}'.", file=sys.stderr)
+            return 1
+
+        # Reuse install logic; pass --yes through.
+        ext_dir = ExtensionRegistry.get_extensions_dir() / name
+        if ext_dir.exists():
+            shutil.rmtree(ext_dir)
+
+        print(_SECURITY_WARNING)
+        if not skip_confirm and sys.stdin.isatty():
+            try:
+                answer = input("Do you want to continue? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = ""
+            if answer not in ("y", "yes"):
+                print("Update cancelled.")
+                return 0
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir) / "extension.whl"
+            if not ExtensionCommand._download(source_url, tmp_path):
+                return 1
+            return ExtensionCommand._install_wheel(tmp_path, source_url=source_url)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _download(url: str, dest: Path) -> bool:
+        """
+        Download *url* to *dest*.
+
+        Supports ``https://`` (via ``urllib.request.urlopen``) and
+        ``file://`` (via ``shutil.copy``).
+
+        Returns:
+            ``True`` on success, ``False`` on failure (error printed to stderr).
+        """
+        if url.startswith("file://"):
+            local_path = Path(url[len("file://") :])
+            try:
+                shutil.copy(str(local_path), str(dest))
+                return True
+            except OSError as exc:
+                print(f"Error: Could not copy local file '{local_path}': {exc}", file=sys.stderr)
+                return False
+
+        try:
+            with urlopen(url, timeout=_REQUEST_TIMEOUT_SECONDS) as resp, dest.open("wb") as out:
+                shutil.copyfileobj(resp, out)
+            return True
+        except Exception as exc:
+            print(f"Error: Download failed for '{url}': {exc}", file=sys.stderr)
+            return False
+
+    @staticmethod
+    def _install_wheel(whl_path: Path, source_url: str) -> int:
+        """
+        Unpack *whl_path* and register the extension.
+
+        Args:
+            whl_path: Path to the downloaded ``.whl`` file.
+            source_url: Original URL used to fetch the wheel (stored in registry).
+
+        Returns:
+            Exit code (0 on success).
+        """
+        if not zipfile.is_zipfile(whl_path):
+            print(f"Error: '{whl_path.name}' is not a valid wheel (zip) file.", file=sys.stderr)
+            return 1
+
+        with zipfile.ZipFile(whl_path, "r") as zf:
+            # Check for unacceptable external dependencies when frozen.
+            if getattr(sys, "frozen", False):
+                issue = ExtensionCommand._check_frozen_deps(zf)
+                if issue:
+                    print(
+                        f"Error: This extension requires external dependencies that are not bundled "
+                        f"in the OpenToken binary: {issue}\n"
+                        "Install the Python package version of OpenToken CLI to use this extension.",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+            entry_point_info = ExtensionCommand._extract_entry_point(zf)
+            if entry_point_info is None:
+                print(
+                    "Error: No 'opentoken.extensions' entry point found in the wheel.",
+                    file=sys.stderr,
+                )
+                return 1
+
+            ext_name, module_name, class_name, version = entry_point_info
+            ext_dir = ExtensionRegistry.get_extensions_dir() / ext_name
+            src_dir = ext_dir / "src"
+            src_dir.mkdir(parents=True, exist_ok=True)
+
+            zf.extractall(src_dir)
+
+        metadata: dict = {
+            "version": version,
+            "source_url": source_url,
+            "source_path": str(src_dir),
+            "module": module_name,
+            "class": class_name,
+            "command_name": ext_name,
+        }
+        ExtensionRegistry.add_extension(ext_name, metadata)
+        print(f"Extension '{ext_name}' (v{version}) installed successfully.")
+        print(f"Run: opentoken {ext_name} --help")
+        return 0
+
+    @staticmethod
+    def _check_frozen_deps(zf: zipfile.ZipFile) -> Optional[str]:
+        """
+        Return a description of unsatisfied external dependencies, or ``None`` if all are bundled.
+
+        Reads ``Requires-Dist`` headers from the wheel's ``METADATA`` file.
+
+        Args:
+            zf: An open ZipFile handle for the wheel.
+        """
+        metadata_candidates = [n for n in zf.namelist() if n.endswith(".dist-info/METADATA")]
+        if not metadata_candidates:
+            return None
+
+        content = zf.read(metadata_candidates[0]).decode("utf-8", errors="replace")
+        external = []
+        for line in content.splitlines():
+            if line.startswith("Requires-Dist:"):
+                dep = line.split(":", 1)[1].strip()
+                # Extract just the package name (before any version specifier / extras).
+                dep_name = dep.split(";")[0].split("[")[0].strip().rstrip("><=! ").lower()
+                # Normalise dashes/underscores.
+                dep_name_norm = dep_name.replace("_", "-")
+                if dep_name_norm not in _BUNDLED_DEPS:
+                    external.append(dep_name)
+        return ", ".join(external) if external else None
+
+    @staticmethod
+    def _extract_entry_point(zf: zipfile.ZipFile) -> Optional[tuple[str, str, str, str]]:
+        """
+        Parse the wheel's ``entry_points.txt`` and return the first ``opentoken.extensions`` entry.
+
+        Also reads the ``METADATA`` file to obtain the package version.
+
+        Returns:
+            ``(entry_name, module, class_name, version)`` or ``None`` if not found.
+        """
+        ep_candidates = [n for n in zf.namelist() if n.endswith(".dist-info/entry_points.txt")]
+        if not ep_candidates:
+            return None
+
+        raw = zf.read(ep_candidates[0]).decode("utf-8", errors="replace")
+        cp = configparser.ConfigParser()
+        cp.read_string(raw)
+
+        if not cp.has_section("opentoken.extensions"):
+            return None
+
+        items = list(cp.items("opentoken.extensions"))
+        if not items:
+            return None
+
+        entry_name, target = items[0]
+        # target is like "some.module:ClassName"
+        if ":" not in target:
+            return None
+        module_name, class_name = target.rsplit(":", 1)
+        module_name = module_name.strip()
+        class_name = class_name.strip()
+
+        # Read version from METADATA.
+        version = "0.0.0"
+        metadata_candidates = [n for n in zf.namelist() if n.endswith(".dist-info/METADATA")]
+        if metadata_candidates:
+            meta_content = zf.read(metadata_candidates[0]).decode("utf-8", errors="replace")
+            for line in meta_content.splitlines():
+                if line.startswith("Version:"):
+                    version = line.split(":", 1)[1].strip()
+                    break
+
+        return entry_name, module_name, class_name, version

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -5,6 +5,7 @@ Copyright (c) Truveta. All rights reserved.
 import configparser
 import importlib
 import logging
+import re
 import shutil
 import subprocess
 import sys
@@ -95,6 +96,15 @@ _BUNDLED_DEPS: frozenset[str] = frozenset(
 )
 
 _REQUEST_TIMEOUT_SECONDS = 60
+
+#: PEP 508 / PEP 440 package name pattern (letters, digits, dashes, dots, underscores;
+#: must start and end with a letter or digit).
+_VALID_DIST_NAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$")
+
+
+def _validate_dist_name(dist_name: str) -> bool:
+    """Return *True* if *dist_name* is a valid PEP 508 distribution name."""
+    return bool(_VALID_DIST_NAME_RE.match(dist_name))
 
 
 class ExtensionCommand:
@@ -303,6 +313,13 @@ class ExtensionCommand:
         else:
             # Normal Python: uninstall via pip using the recorded dist name.
             dist_name = meta.get("dist_name") or name
+            if not _validate_dist_name(dist_name):
+                print(
+                    f"Error: Recorded distribution name '{dist_name}' is not a valid package name "
+                    "and cannot be passed to pip. Remove the extension manually.",
+                    file=sys.stderr,
+                )
+                return 1
             pip_result = subprocess.run(
                 [sys.executable, "-m", "pip", "uninstall", "-y", dist_name],
                 capture_output=True,
@@ -495,10 +512,12 @@ class ExtensionCommand:
                 }
             else:
                 # Normal Python: pip-install the wheel so entry points are registered.
-                # --upgrade ensures a newer version replaces the old one;
-                # --no-deps avoids re-downloading unchanged transitive dependencies.
+                # --upgrade ensures a newer version replaces the old one.
+                # --no-deps is intentionally omitted here so that pip resolves transitive
+                # dependencies normally; omitting it in non-frozen mode prevents silent
+                # load failures caused by missing transitive packages.
                 pip_result = subprocess.run(
-                    [sys.executable, "-m", "pip", "install", "--upgrade", "--no-deps", str(whl_path)],
+                    [sys.executable, "-m", "pip", "install", "--upgrade", str(whl_path)],
                     capture_output=True,
                     text=True,
                 )
@@ -555,6 +574,13 @@ class ExtensionCommand:
         if not metadata_candidates:
             return None
 
+        if len(metadata_candidates) > 1:
+            logger.warning(
+                "Wheel contains multiple dist-info directories (%s); this is invalid per PEP 427. "
+                "Only the first will be checked.",
+                metadata_candidates,
+            )
+
         content = zf.read(metadata_candidates[0]).decode("utf-8", errors="replace")
         external = []
         for line in content.splitlines():
@@ -596,6 +622,13 @@ class ExtensionCommand:
         if not items:
             return None
 
+        if len(items) > 1:
+            logger.warning(
+                "Wheel contains %d opentoken.extensions entry points; only the first (%s) will be registered.",
+                len(items),
+                items[0][0],
+            )
+
         entry_name, target = items[0]
         # target is like "some.module:ClassName"
         if ":" not in target:
@@ -614,6 +647,15 @@ class ExtensionCommand:
                 if line.startswith("Version:"):
                     version = line.split(":", 1)[1].strip()
                 elif line.startswith("Name:"):
-                    dist_name = line.split(":", 1)[1].strip()
+                    candidate = line.split(":", 1)[1].strip()
+                    if _validate_dist_name(candidate):
+                        dist_name = candidate
+                    else:
+                        logger.warning(
+                            "Wheel METADATA contains an invalid distribution name %r; "
+                            "falling back to entry-point name %r.",
+                            candidate,
+                            entry_name,
+                        )
 
         return entry_name, module_name, class_name, version, dist_name

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -219,7 +219,7 @@ class ExtensionCommand:
                         for ep in eps:
                             if ep.name == name:
                                 name_from_meta = ep.dist.metadata.get("Name")
-                                dist_name = name_from_meta if name_from_meta else (ep.dist.name if ep.dist.name else name)
+                                dist_name = name_from_meta or ep.dist.name or name
                                 break
                     except Exception:
                         pass

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -23,10 +23,17 @@ _SECURITY_WARNING = (
 )
 
 #: Dependencies bundled into the frozen binary that extensions may rely on.
+#: Derived from the packages collected in opentoken-cli.spec and requirements.txt.
 _BUNDLED_DEPS: frozenset[str] = frozenset(
     {
         "opentoken",
         "opentoken-cli",
+        "pandas",
+        "pyarrow",
+        "csv2parquet",
+        "cryptography",
+        "jwcrypto",
+        "packaging",
     }
 )
 
@@ -91,14 +98,21 @@ class ExtensionCommand:
         skip_confirm: bool = getattr(args, "yes", False)
 
         print(_SECURITY_WARNING)
-        if not skip_confirm and sys.stdin.isatty():
-            try:
-                answer = input("Do you want to continue? [y/N] ").strip().lower()
-            except (EOFError, KeyboardInterrupt):
-                answer = ""
-            if answer not in ("y", "yes"):
-                print("Installation cancelled.")
-                return 0
+        if not skip_confirm:
+            if sys.stdin.isatty():
+                try:
+                    answer = input("Do you want to continue? [y/N] ").strip().lower()
+                except (EOFError, KeyboardInterrupt):
+                    answer = ""
+                if answer not in ("y", "yes"):
+                    print("Installation cancelled.")
+                    return 0
+            else:
+                print(
+                    "Error: stdin is not a TTY. Pass --yes to confirm installation in non-interactive mode.",
+                    file=sys.stderr,
+                )
+                return 1
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             # Preserve the original wheel filename so pip can parse its metadata.
@@ -194,12 +208,27 @@ class ExtensionCommand:
                     pass
 
             if pip_installed:
+                # Look up the distribution name so the user can uninstall the
+                # correct package (the entry-point key and the dist name often differ).
+                dist_name = name
+                if not getattr(sys, "frozen", False):
+                    import importlib.metadata
+
+                    try:
+                        eps = importlib.metadata.entry_points(group="opentoken.extensions")
+                        for ep in eps:
+                            if ep.name == name:
+                                name_from_meta = ep.dist.metadata.get("Name")
+                                dist_name = name_from_meta if name_from_meta else (ep.dist.name if ep.dist.name else name)
+                                break
+                    except Exception:
+                        pass
                 print(
                     f"Error: '{name}' was installed via pip and cannot be removed by this command.\n"
                     f"Uninstall it with your package manager instead, for example:\n"
                     f"\n"
-                    f"    pip uninstall {name}\n"
-                    f"    uv pip uninstall {name}",
+                    f"    pip uninstall {dist_name}\n"
+                    f"    uv pip uninstall {dist_name}",
                     file=sys.stderr,
                 )
                 return 1
@@ -256,6 +285,13 @@ class ExtensionCommand:
             except OSError as exc:
                 print(f"Error: Could not copy local file '{local_path}': {exc}", file=sys.stderr)
                 return False
+
+        if not url.startswith("https://"):
+            print(
+                f"Error: Unsupported URL scheme in '{url}'. Only 'https://' and 'file://' are supported.",
+                file=sys.stderr,
+            )
+            return False
 
         try:
             with urlopen(url, timeout=_REQUEST_TIMEOUT_SECONDS) as resp, dest.open("wb") as out:
@@ -325,8 +361,10 @@ class ExtensionCommand:
                 }
             else:
                 # Normal Python: pip-install the wheel so entry points are registered.
+                # --upgrade ensures a newer version replaces the old one;
+                # --no-deps avoids re-downloading unchanged transitive dependencies.
                 pip_result = subprocess.run(
-                    [sys.executable, "-m", "pip", "install", str(whl_path)],
+                    [sys.executable, "-m", "pip", "install", "--upgrade", "--no-deps", str(whl_path)],
                     capture_output=True,
                     text=True,
                 )

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -464,6 +464,12 @@ class ExtensionCommand:
             command_name = ext_name
             if getattr(sys, "frozen", False):
                 # Frozen binary: extract wheel contents and inject via sys.path at runtime.
+                if not _validate_dist_name(ext_name):
+                    print(
+                        f"Error: Wheel entry-point key '{ext_name}' is not a valid extension name.",
+                        file=sys.stderr,
+                    )
+                    return 1
                 ext_dir = ExtensionRegistry.get_extensions_dir() / ext_name
                 src_dir = ext_dir / "src"
                 if src_dir.exists():
@@ -535,6 +541,14 @@ class ExtensionCommand:
                     print(
                         f"Error: Unable to determine extension command name from {module_name}.{class_name}.",
                         file=sys.stderr,
+                    )
+                    logger.warning(
+                        "Rolling back pip install of '%s' because the extension class could not be resolved.",
+                        dist_name,
+                    )
+                    subprocess.run(
+                        [sys.executable, "-m", "pip", "uninstall", "-y", dist_name],
+                        check=False,
                     )
                     return 1
                 if resolved_command_name != ext_name:

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -5,6 +5,7 @@ Copyright (c) Truveta. All rights reserved.
 import configparser
 import logging
 import shutil
+import subprocess
 import sys
 import tempfile
 import zipfile
@@ -113,7 +114,12 @@ class ExtensionCommand:
                 return 0
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            tmp_path = Path(tmp_dir) / "extension.whl"
+            # Preserve the original wheel filename so pip can parse its metadata.
+            import urllib.parse
+
+            url_filename = Path(urllib.parse.urlparse(url).path).name
+            whl_name = url_filename if url_filename.endswith(".whl") else "extension.whl"
+            tmp_path = Path(tmp_dir) / whl_name
             if not ExtensionCommand._download(url, tmp_path):
                 return 1
 
@@ -214,9 +220,28 @@ class ExtensionCommand:
             print(f"Error: Extension '{name}' is not installed.", file=sys.stderr)
             return 1
 
-        ext_dir = ExtensionRegistry.get_extensions_dir() / name
-        if ext_dir.exists():
-            shutil.rmtree(ext_dir)
+        meta = registry[name]
+
+        if getattr(sys, "frozen", False):
+            # Frozen binary: remove the extracted source directory.
+            ext_dir = ExtensionRegistry.get_extensions_dir() / name
+            if ext_dir.exists():
+                shutil.rmtree(ext_dir)
+        else:
+            # Normal Python: uninstall via pip using the recorded dist name.
+            dist_name = meta.get("dist_name") or name
+            pip_result = subprocess.run(
+                [sys.executable, "-m", "pip", "uninstall", "-y", dist_name],
+                capture_output=True,
+                text=True,
+            )
+            if pip_result.returncode != 0:
+                print(
+                    f"Error: pip uninstall failed:\n{pip_result.stderr}",
+                    file=sys.stderr,
+                )
+                return 1
+
         ExtensionRegistry.remove_extension(name)
         print(f"Extension '{name}' uninstalled.")
         return 0
@@ -292,7 +317,12 @@ class ExtensionCommand:
     @staticmethod
     def _install_wheel(whl_path: Path, source_url: str) -> int:
         """
-        Unpack *whl_path* and register the extension.
+        Install *whl_path* and register the extension.
+
+        In a normal Python environment the wheel is installed via ``pip`` so that
+        the extension's entry point is discoverable by ``importlib.metadata``.
+        In a frozen binary the wheel is extracted manually because ``pip`` is not
+        available, and the extension is loaded later via ``sys.path`` injection.
 
         Args:
             whl_path: Path to the downloaded ``.whl`` file.
@@ -306,7 +336,6 @@ class ExtensionCommand:
             return 1
 
         with zipfile.ZipFile(whl_path, "r") as zf:
-            # Check for unacceptable external dependencies when frozen.
             if getattr(sys, "frozen", False):
                 issue = ExtensionCommand._check_frozen_deps(zf)
                 if issue:
@@ -326,21 +355,45 @@ class ExtensionCommand:
                 )
                 return 1
 
-            ext_name, module_name, class_name, version = entry_point_info
-            ext_dir = ExtensionRegistry.get_extensions_dir() / ext_name
-            src_dir = ext_dir / "src"
-            src_dir.mkdir(parents=True, exist_ok=True)
+            ext_name, module_name, class_name, version, dist_name = entry_point_info
 
-            zf.extractall(src_dir)
+            if getattr(sys, "frozen", False):
+                # Frozen binary: extract wheel contents and inject via sys.path at runtime.
+                ext_dir = ExtensionRegistry.get_extensions_dir() / ext_name
+                src_dir = ext_dir / "src"
+                src_dir.mkdir(parents=True, exist_ok=True)
+                zf.extractall(src_dir)
+                metadata: dict = {
+                    "version": version,
+                    "source_url": source_url,
+                    "source_path": str(src_dir),
+                    "module": module_name,
+                    "class": class_name,
+                    "command_name": ext_name,
+                    "dist_name": dist_name,
+                }
+            else:
+                # Normal Python: pip-install the wheel so entry points are registered.
+                pip_result = subprocess.run(
+                    [sys.executable, "-m", "pip", "install", str(whl_path)],
+                    capture_output=True,
+                    text=True,
+                )
+                if pip_result.returncode != 0:
+                    print(
+                        f"Error: pip install failed:\n{pip_result.stderr}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                metadata = {
+                    "version": version,
+                    "source_url": source_url,
+                    "module": module_name,
+                    "class": class_name,
+                    "command_name": ext_name,
+                    "dist_name": dist_name,
+                }
 
-        metadata: dict = {
-            "version": version,
-            "source_url": source_url,
-            "source_path": str(src_dir),
-            "module": module_name,
-            "class": class_name,
-            "command_name": ext_name,
-        }
         ExtensionRegistry.add_extension(ext_name, metadata)
         print(f"Extension '{ext_name}' (v{version}) installed successfully.")
         print(f"Run: opentoken {ext_name} --help")
@@ -374,14 +427,14 @@ class ExtensionCommand:
         return ", ".join(external) if external else None
 
     @staticmethod
-    def _extract_entry_point(zf: zipfile.ZipFile) -> Optional[tuple[str, str, str, str]]:
+    def _extract_entry_point(zf: zipfile.ZipFile) -> Optional[tuple[str, str, str, str, str]]:
         """
         Parse the wheel's ``entry_points.txt`` and return the first ``opentoken.extensions`` entry.
 
-        Also reads the ``METADATA`` file to obtain the package version.
+        Also reads the ``METADATA`` file to obtain the package version and distribution name.
 
         Returns:
-            ``(entry_name, module, class_name, version)`` or ``None`` if not found.
+            ``(entry_name, module, class_name, version, dist_name)`` or ``None`` if not found.
         """
         ep_candidates = [n for n in zf.namelist() if n.endswith(".dist-info/entry_points.txt")]
         if not ep_candidates:
@@ -406,14 +459,16 @@ class ExtensionCommand:
         module_name = module_name.strip()
         class_name = class_name.strip()
 
-        # Read version from METADATA.
+        # Read version and dist name from METADATA.
         version = "0.0.0"
+        dist_name = entry_name
         metadata_candidates = [n for n in zf.namelist() if n.endswith(".dist-info/METADATA")]
         if metadata_candidates:
             meta_content = zf.read(metadata_candidates[0]).decode("utf-8", errors="replace")
             for line in meta_content.splitlines():
                 if line.startswith("Version:"):
                     version = line.split(":", 1)[1].strip()
-                    break
+                elif line.startswith("Name:"):
+                    dist_name = line.split(":", 1)[1].strip()
 
-        return entry_name, module_name, class_name, version
+        return entry_name, module_name, class_name, version, dist_name

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -3,6 +3,7 @@ Copyright (c) Truveta. All rights reserved.
 """
 
 import configparser
+import importlib
 import logging
 import shutil
 import subprocess
@@ -10,7 +11,6 @@ import sys
 import tempfile
 import zipfile
 from contextlib import contextmanager
-import importlib
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -367,7 +367,6 @@ class ExtensionCommand:
             return False
 
     @staticmethod
-    @staticmethod
     def _safe_extract_wheel(zf: zipfile.ZipFile, dest_dir: Path) -> None:
         """
         Safely extract a wheel, ensuring no archive entry escapes *dest_dir*.
@@ -399,6 +398,7 @@ class ExtensionCommand:
             with zf.open(member, "r") as source, target_path.open("wb") as target:
                 shutil.copyfileobj(source, target)
 
+    @staticmethod
     def _install_wheel(whl_path: Path, source_url: str) -> int:
         """
         Install *whl_path* and register the extension.

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -486,6 +486,7 @@ class ExtensionCommand:
                         f"Error: Unsafe path found in wheel '{whl_path.name}': {exc}",
                         file=sys.stderr,
                     )
+                    shutil.rmtree(src_dir, ignore_errors=True)
                     return 1
                 resolved_command_name = _resolve_extension_command_name(
                     module_name,
@@ -617,8 +618,8 @@ class ExtensionCommand:
                     req = Requirement(raw_dep)
                 except InvalidRequirement:
                     continue
-                # Normalise dashes/underscores per PEP 503.
-                dep_name_norm = req.name.lower().replace("_", "-")
+                # Normalise dashes/underscores/dots per PEP 503 (collapse runs of [-_.] to a single -).
+                dep_name_norm = re.sub(r"[-_.]+", "-", req.name).lower()
                 if dep_name_norm not in _BUNDLED_DEPS:
                     external.append(req.name)
         return ", ".join(external) if external else None

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -487,7 +487,8 @@ class ExtensionCommand:
             return None
 
         raw = zf.read(ep_candidates[0]).decode("utf-8", errors="replace")
-        cp = configparser.ConfigParser()
+        cp = configparser.ConfigParser(interpolation=None)
+        cp.optionxform = str
         cp.read_string(raw)
 
         if not cp.has_section("opentoken.extensions"):

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -521,6 +521,12 @@ class ExtensionCommand:
                 }
             else:
                 # Normal Python: pip-install the wheel so entry points are registered.
+                if not _validate_dist_name(ext_name):
+                    print(
+                        f"Error: Wheel entry-point key '{ext_name}' is not a valid extension name.",
+                        file=sys.stderr,
+                    )
+                    return 1
                 # --upgrade ensures a newer version replaces the old one.
                 # --no-deps is intentionally omitted here so that pip resolves transitive
                 # dependencies normally; omitting it in non-frozen mode prevents silent
@@ -618,6 +624,8 @@ class ExtensionCommand:
                     req = Requirement(raw_dep)
                 except InvalidRequirement:
                     continue
+                if req.marker is not None and not req.marker.evaluate():
+                    continue  # marker evaluates to False in this environment; skip
                 # Normalise dashes/underscores/dots per PEP 503 (collapse runs of [-_.] to a single -).
                 dep_name_norm = re.sub(r"[-_.]+", "-", req.name).lower()
                 if dep_name_norm not in _BUNDLED_DEPS:

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -497,6 +497,7 @@ class ExtensionCommand:
                         f"Error: Unable to determine extension command name from {module_name}.{class_name}.",
                         file=sys.stderr,
                     )
+                    shutil.rmtree(src_dir, ignore_errors=True)
                     return 1
                 if resolved_command_name != ext_name:
                     print(
@@ -505,6 +506,7 @@ class ExtensionCommand:
                         f"'{resolved_command_name}'. These values must be identical.",
                         file=sys.stderr,
                     )
+                    shutil.rmtree(src_dir, ignore_errors=True)
                     return 1
                 command_name = resolved_command_name
                 metadata: dict = {
@@ -557,6 +559,17 @@ class ExtensionCommand:
                         f"'{ext_name}' does not match extension.command_name "
                         f"'{resolved_command_name}'. These values must be identical.",
                         file=sys.stderr,
+                    )
+                    logger.warning(
+                        "Rolling back pip install of '%s' because the resolved command name '%s' "
+                        "does not match the expected name '%s'.",
+                        dist_name,
+                        resolved_command_name,
+                        ext_name,
+                    )
+                    subprocess.run(
+                        [sys.executable, "-m", "pip", "uninstall", "-y", dist_name],
+                        check=False,
                     )
                     return 1
                 command_name = resolved_command_name

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -151,7 +151,7 @@ class ExtensionCommand:
         url: str = args.url
         skip_confirm: bool = getattr(args, "yes", False)
 
-        print(_SECURITY_WARNING)
+        print(f"{_SECURITY_WARNING}\nYou are about to install an extension from:\n  {url}")
         if not skip_confirm:
             if sys.stdin.isatty():
                 try:

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/extension_command.py
@@ -302,6 +302,38 @@ class ExtensionCommand:
             return False
 
     @staticmethod
+    @staticmethod
+    def _safe_extract_wheel(zf: zipfile.ZipFile, dest_dir: Path) -> None:
+        """
+        Safely extract a wheel, ensuring no archive entry escapes *dest_dir*.
+
+        Raises:
+            ValueError: If an entry's resolved path is outside *dest_dir*.
+        """
+        dest_dir_resolved = dest_dir.resolve()
+
+        for member in zf.infolist():
+            member_path = Path(member.filename)
+
+            # Skip empty names
+            if not member.filename:
+                continue
+
+            target_path = (dest_dir_resolved / member_path).resolve()
+
+            # Prevent Zip Slip / path traversal by ensuring the target path
+            # stays within the destination directory.
+            if target_path != dest_dir_resolved and dest_dir_resolved not in target_path.parents:
+                raise ValueError(f"Illegal path in wheel entry: {member.filename!r}")
+
+            if member.is_dir():
+                target_path.mkdir(parents=True, exist_ok=True)
+                continue
+
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(member, "r") as source, target_path.open("wb") as target:
+                shutil.copyfileobj(source, target)
+
     def _install_wheel(whl_path: Path, source_url: str) -> int:
         """
         Install *whl_path* and register the extension.
@@ -355,7 +387,14 @@ class ExtensionCommand:
                         # Directory was removed concurrently; safe to proceed.
                         pass
                 src_dir.mkdir(parents=True, exist_ok=True)
-                zf.extractall(src_dir)
+                try:
+                    ExtensionCommand._safe_extract_wheel(zf, src_dir)
+                except ValueError as exc:
+                    print(
+                        f"Error: Unsafe path found in wheel '{whl_path.name}': {exc}",
+                        file=sys.stderr,
+                    )
+                    return 1
                 metadata: dict = {
                     "version": version,
                     "source_url": source_url,

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/open_token_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/open_token_command.py
@@ -93,22 +93,47 @@ class OpenTokenCommand:
         # Import command modules here to avoid circular imports
         from opentoken_cli.commands.decrypt_command import DecryptCommand
         from opentoken_cli.commands.encrypt_command import EncryptCommand
+        from opentoken_cli.commands.extension_command import ExtensionCommand
         from opentoken_cli.commands.generate_key_pair_command import GenerateKeyPairCommand
         from opentoken_cli.commands.help_command import HelpCommand
         from opentoken_cli.commands.initiate_exchange_command import InitiateExchangeCommand
         from opentoken_cli.commands.package_command import PackageCommand
         from opentoken_cli.commands.tokenize_command import TokenizeCommand
         from opentoken_cli.commands.update_command import UpdateCommand
+        from opentoken_cli.extension.extension_loader import ExtensionLoader
 
-        # Register subcommands
-        HelpCommand.register_subcommand(subparsers)
-        TokenizeCommand.register_subcommand(subparsers)
-        EncryptCommand.register_subcommand(subparsers)
+        # Register subcommands in alphabetical order by command name
         DecryptCommand.register_subcommand(subparsers)
-        PackageCommand.register_subcommand(subparsers)
+        EncryptCommand.register_subcommand(subparsers)
+        ExtensionCommand.register_subcommand(subparsers)
         GenerateKeyPairCommand.register_subcommand(subparsers)
+        HelpCommand.register_subcommand(subparsers)
         InitiateExchangeCommand.register_subcommand(subparsers)
+        PackageCommand.register_subcommand(subparsers)
+        TokenizeCommand.register_subcommand(subparsers)
         UpdateCommand.register_subcommand(subparsers)
+
+        # Load installed extensions (entry points or registry).
+        _BUILTIN_COMMANDS = {
+            "help",
+            "tokenize",
+            "encrypt",
+            "decrypt",
+            "package",
+            "generate-key-pair",
+            "initiate-exchange",
+            "update",
+            "extension",
+        }
+        ExtensionLoader.load_extensions(subparsers, _BUILTIN_COMMANDS)
+
+        # Sort all subcommands (built-ins and extensions) alphabetically in-place.
+        # _name_parser_map drives dispatch and the choices {…} display;
+        # _choices_actions drives the per-command description table in --help.
+        sorted_items = sorted(subparsers._name_parser_map.items())
+        subparsers._name_parser_map.clear()
+        subparsers._name_parser_map.update(sorted_items)
+        subparsers._choices_actions.sort(key=lambda a: a.dest)
 
         return parser
 

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/commands/open_token_command.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/commands/open_token_command.py
@@ -100,7 +100,7 @@ class OpenTokenCommand:
         from opentoken_cli.commands.package_command import PackageCommand
         from opentoken_cli.commands.tokenize_command import TokenizeCommand
         from opentoken_cli.commands.update_command import UpdateCommand
-        from opentoken_cli.extension.extension_loader import ExtensionLoader
+        from opentoken_cli.extension.extension_loader import BUILTIN_COMMANDS, ExtensionLoader
 
         # Register subcommands in alphabetical order by command name
         DecryptCommand.register_subcommand(subparsers)
@@ -114,26 +114,22 @@ class OpenTokenCommand:
         UpdateCommand.register_subcommand(subparsers)
 
         # Load installed extensions (entry points or registry).
-        _BUILTIN_COMMANDS = {
-            "help",
-            "tokenize",
-            "encrypt",
-            "decrypt",
-            "package",
-            "generate-key-pair",
-            "initiate-exchange",
-            "update",
-            "extension",
-        }
-        ExtensionLoader.load_extensions(subparsers, _BUILTIN_COMMANDS)
+        # BUILTIN_COMMANDS is the authoritative set of reserved command names.
+        ExtensionLoader.load_extensions(subparsers, BUILTIN_COMMANDS)
 
-        # Sort all subcommands (built-ins and extensions) alphabetically in-place.
-        # _name_parser_map drives dispatch and the choices {…} display;
-        # _choices_actions drives the per-command description table in --help.
-        sorted_items = sorted(subparsers._name_parser_map.items())
-        subparsers._name_parser_map.clear()
-        subparsers._name_parser_map.update(sorted_items)
-        subparsers._choices_actions.sort(key=lambda a: a.dest)
+        # Sort all subcommands (built-ins and extensions) alphabetically.
+        # Uses private argparse internals that may not exist in all Python versions;
+        # sorting is skipped gracefully if those attributes are absent.
+        if hasattr(subparsers, "_name_parser_map") and hasattr(subparsers, "_choices_actions"):
+            sorted_items = sorted(subparsers._name_parser_map.items())
+            subparsers._name_parser_map.clear()
+            subparsers._name_parser_map.update(sorted_items)
+            subparsers._choices_actions.sort(key=lambda a: a.dest)
+        else:
+            logger.debug(
+                "Subcommand alphabetical sorting skipped: argparse internals "
+                "(_name_parser_map / _choices_actions) not available on this Python version."
+            )
 
         return parser
 

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/__init__.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/__init__.py
@@ -1,0 +1,7 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+from opentoken_cli.extension.extension_interface import OpenTokenExtension
+
+__all__ = ["OpenTokenExtension"]

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_interface.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_interface.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import argparse
+from abc import ABC, abstractmethod
+
+
+class OpenTokenExtension(ABC):
+    """
+    Interface for OpenToken CLI extensions.
+
+    An extension registers exactly one top-level subcommand name.
+    It receives the subparsers object during CLI startup and is responsible
+    for adding its own sub-subcommands underneath its top-level command.
+    """
+
+    @property
+    @abstractmethod
+    def command_name(self) -> str:
+        """
+        The top-level subcommand name this extension owns.
+
+        Must be unique across all installed extensions and must not
+        conflict with built-in OpenToken commands.
+
+        Example: "extcmd"  → enables `opentoken extcmd ...`
+        """
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Short human-readable description shown in `opentoken --help`."""
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """SemVer string for this extension (e.g. "1.0.0")."""
+
+    @abstractmethod
+    def register_subcommand(self, subparsers: argparse._SubParsersAction) -> None:
+        """
+        Register the extension's argparse sub-parser(s).
+
+        The implementation must call `subparsers.add_parser(self.command_name, ...)`
+        and optionally add further sub-subcommands beneath it.
+        The extension is responsible for setting `set_defaults(func=...)` on all
+        leaf parsers so that OpenTokenCommand can dispatch to them via `parsed_args.func`.
+
+        Args:
+            subparsers: The shared subparsers action from the root OpenToken parser.
+        """

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_loader.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_loader.py
@@ -1,0 +1,188 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import argparse
+import importlib
+import importlib.metadata
+import logging
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+#: The set of command names reserved by built-in OpenToken subcommands.
+BUILTIN_COMMANDS: set[str] = {
+    "help",
+    "tokenize",
+    "encrypt",
+    "decrypt",
+    "package",
+    "generate-key-pair",
+    "initiate-exchange",
+    "update",
+    "extension",
+}
+
+
+class ExtensionLoader:
+    """
+    Discovers and loads OpenToken CLI extensions into the argument parser.
+
+    Two discovery tracks are supported:
+
+    * **Python package track** (default): uses ``importlib.metadata.entry_points``
+      with the ``opentoken.extensions`` group.  Works when the CLI is run from
+      a normal Python environment.
+    * **Frozen binary track**: when ``sys.frozen`` is ``True`` (e.g. a PyInstaller
+      binary), reads ``registry.json``, prepends each extension's ``source_path``
+      to ``sys.path``, and imports the module directly.
+    """
+
+    @staticmethod
+    def load_extensions(
+        subparsers: argparse._SubParsersAction,
+        built_in_commands: Optional[set[str]] = None,
+    ) -> None:
+        """
+        Discover all installed extensions and register each one with *subparsers*.
+
+        Extensions are processed in deterministic order (sorted by ``command_name``).
+        An extension is skipped (with a warning) when:
+
+        * Its ``command_name`` conflicts with a built-in command.
+        * Its ``command_name`` was already registered by an earlier extension.
+        * The extension module cannot be imported.
+
+        Args:
+            subparsers: The shared subparsers action from the root OpenToken parser.
+            built_in_commands: Set of reserved command names.  Defaults to
+                ``BUILTIN_COMMANDS`` when ``None``.
+        """
+        if built_in_commands is None:
+            built_in_commands = BUILTIN_COMMANDS
+
+        if getattr(sys, "frozen", False):
+            extensions = ExtensionLoader._load_from_registry()
+        else:
+            extensions = ExtensionLoader._load_from_entry_points()
+
+        # Sort deterministically by command_name so the parser output is stable.
+        extensions.sort(key=lambda ext: ext.command_name)
+
+        registered: set[str] = set()
+        for ext in extensions:
+            cmd = ext.command_name
+            if cmd in built_in_commands:
+                logger.warning(
+                    "Extension '%s' conflicts with built-in command '%s'; skipping.",
+                    type(ext).__name__,
+                    cmd,
+                )
+                continue
+            if cmd in registered:
+                logger.warning(
+                    "Extension '%s' wants to register command '%s' which is already claimed; skipping.",
+                    type(ext).__name__,
+                    cmd,
+                )
+                continue
+            try:
+                ext.register_subcommand(subparsers)
+                registered.add(cmd)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Extension '%s' failed to register subcommand '%s': %s",
+                    type(ext).__name__,
+                    cmd,
+                    exc,
+                )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_from_entry_points() -> list:
+        """
+        Discover extensions via the ``opentoken.extensions`` entry-point group.
+
+        Each entry point is expected to point to an ``OpenTokenExtension`` subclass.
+        Import errors are caught per extension and emit a warning.
+        """
+        from opentoken_cli.extension.extension_interface import OpenTokenExtension
+
+        extensions = []
+        try:
+            eps = importlib.metadata.entry_points(group="opentoken.extensions")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not query entry points for 'opentoken.extensions': %s", exc)
+            return extensions
+
+        for ep in eps:
+            try:
+                cls = ep.load()
+                instance = cls()
+                if not isinstance(instance, OpenTokenExtension):
+                    logger.warning(
+                        "Entry point '%s' does not implement OpenTokenExtension; skipping.",
+                        ep.name,
+                    )
+                    continue
+                extensions.append(instance)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to load extension from entry point '%s': %s", ep.name, exc)
+
+        return extensions
+
+    @staticmethod
+    def _load_from_registry() -> list:
+        """
+        Discover extensions from registry.json when running as a frozen binary.
+
+        Each entry's ``source_path`` is prepended to ``sys.path`` so that the
+        extension's source tree is importable.
+        """
+        from opentoken_cli.extension.extension_interface import OpenTokenExtension
+        from opentoken_cli.extension.extension_registry import ExtensionRegistry
+
+        extensions = []
+        registry = ExtensionRegistry.load()
+
+        for name, metadata in registry.items():
+            source_path = metadata.get("source_path")
+            module_name = metadata.get("module")
+            class_name = metadata.get("class")
+
+            if not module_name or not class_name:
+                logger.warning(
+                    "Extension '%s' registry entry is missing 'module' or 'class'; skipping.",
+                    name,
+                )
+                continue
+
+            # Prepend source_path so the extension's package is importable.
+            if source_path:
+                from pathlib import Path as _Path
+
+                expanded = str(_Path(source_path).expanduser().resolve())
+                if expanded not in sys.path:
+                    sys.path.insert(0, expanded)
+
+            try:
+                mod = importlib.import_module(module_name)
+                cls = getattr(mod, class_name)
+                instance = cls()
+                if not isinstance(instance, OpenTokenExtension):
+                    logger.warning(
+                        "Extension '%s' class '%s.%s' does not implement OpenTokenExtension; skipping.",
+                        name,
+                        module_name,
+                        class_name,
+                    )
+                    continue
+                extensions.append(instance)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to load extension '%s' from registry: %s", name, exc)
+
+        return extensions

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_loader.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_loader.py
@@ -129,6 +129,23 @@ class ExtensionLoader:
                         ep.name,
                     )
                     continue
+
+                command_name = getattr(instance, "command_name", None)
+                if not command_name:
+                    logger.warning(
+                        "Entry point '%s' extension instance is missing 'command_name'; skipping.",
+                        ep.name,
+                    )
+                    continue
+
+                if command_name != ep.name:
+                    logger.warning(
+                        "Entry point name '%s' does not match extension command_name '%s'; skipping.",
+                        ep.name,
+                        command_name,
+                    )
+                    continue
+
                 extensions.append(instance)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Failed to load extension from entry point '%s': %s", ep.name, exc)

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_loader.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_loader.py
@@ -198,6 +198,16 @@ class ExtensionLoader:
                         class_name,
                     )
                     continue
+
+                command_name = getattr(instance, "command_name", None)
+                if not command_name or command_name != name:
+                    logger.warning(
+                        "Extension registry key '%s' does not match extension command_name '%s'; skipping.",
+                        name,
+                        command_name,
+                    )
+                    continue
+
                 extensions.append(instance)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Failed to load extension '%s' from registry: %s", name, exc)

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
@@ -1,0 +1,137 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_EXTENSIONS_SUBDIR = Path(".opentoken") / "extensions"
+
+
+class ExtensionRegistry:
+    """
+    Manages the OpenToken extension registry stored at ``~/.opentoken/extensions/registry.json``.
+
+    The registry is a JSON file that maps extension names to their installation metadata.
+    The base directory can be overridden via the ``OPENTOKEN_EXTENSIONS_DIR`` environment variable.
+
+    Registry JSON schema (one entry per installed extension):
+
+    .. code-block:: json
+
+        {
+          "hello-world": {
+            "version": "1.0.0",
+            "source_url": "https://example.com/hello_world-1.0.0-py3-none-any.whl",
+            "source_path": "~/.opentoken/extensions/hello-world/src",
+            "module": "opentoken_ext_hello_world.extension",
+            "class": "HelloWorldExtension"
+          }
+        }
+    """
+
+    @staticmethod
+    def get_extensions_dir() -> Path:
+        """
+        Return the base directory for installed extensions.
+
+        Uses the ``OPENTOKEN_EXTENSIONS_DIR`` environment variable when set;
+        otherwise defaults to ``~/.opentoken/extensions/``.
+        """
+        env_override = os.environ.get("OPENTOKEN_EXTENSIONS_DIR")
+        if env_override:
+            return Path(env_override)
+        return Path.home() / _DEFAULT_EXTENSIONS_SUBDIR
+
+    @staticmethod
+    def get_registry_path() -> Path:
+        """Return the full path to the registry JSON file."""
+        return ExtensionRegistry.get_extensions_dir() / "registry.json"
+
+    @staticmethod
+    def load() -> dict:
+        """
+        Load and return the registry contents.
+
+        Returns an empty dict if the registry file does not exist or cannot be parsed.
+        """
+        registry_path = ExtensionRegistry.get_registry_path()
+        if not registry_path.exists():
+            return {}
+        try:
+            return json.loads(registry_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to load extension registry at %s: %s", registry_path, exc)
+            return {}
+
+    @staticmethod
+    def save(registry: dict) -> None:
+        """
+        Write the registry to disk atomically (write to a temp file, then rename).
+
+        Args:
+            registry: The full registry dict to persist.
+        """
+        registry_path = ExtensionRegistry.get_registry_path()
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+
+        content = json.dumps(registry, indent=2, sort_keys=True) + "\n"
+        dir_ = registry_path.parent
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=dir_,
+                delete=False,
+                suffix=".tmp",
+            ) as tmp:
+                tmp.write(content)
+                tmp_path = Path(tmp.name)
+            tmp_path.replace(registry_path)
+        except OSError as exc:
+            logger.error("Failed to save extension registry to %s: %s", registry_path, exc)
+            raise
+
+    @staticmethod
+    def add_extension(name: str, metadata: dict) -> None:
+        """
+        Add or update an extension entry in the registry.
+
+        Args:
+            name: The extension's canonical name (matches ``command_name``).
+            metadata: Dict with keys ``version``, ``source_url``, ``source_path``, ``module``, ``class``.
+        """
+        registry = ExtensionRegistry.load()
+        registry[name] = metadata
+        ExtensionRegistry.save(registry)
+
+    @staticmethod
+    def remove_extension(name: str) -> None:
+        """
+        Remove an extension entry from the registry.
+
+        A no-op if the extension is not present.
+
+        Args:
+            name: The extension name to remove.
+        """
+        registry = ExtensionRegistry.load()
+        if name in registry:
+            del registry[name]
+            ExtensionRegistry.save(registry)
+
+    @staticmethod
+    def get_extension(name: str) -> Optional[dict]:
+        """
+        Return the metadata dict for a single extension, or ``None`` if not found.
+
+        Args:
+            name: The extension name to look up.
+        """
+        return ExtensionRegistry.load().get(name)

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
@@ -7,7 +7,6 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -125,13 +124,3 @@ class ExtensionRegistry:
         if name in registry:
             del registry[name]
             ExtensionRegistry.save(registry)
-
-    @staticmethod
-    def get_extension(name: str) -> Optional[dict]:
-        """
-        Return the metadata dict for a single extension, or ``None`` if not found.
-
-        Args:
-            name: The extension name to look up.
-        """
-        return ExtensionRegistry.load().get(name)

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
@@ -30,7 +30,9 @@ class ExtensionRegistry:
             "source_url": "https://example.com/hello_world-1.0.0-py3-none-any.whl",
             "source_path": "~/.opentoken/extensions/hello-world/src",
             "module": "opentoken_ext_hello_world.extension",
-            "class": "HelloWorldExtension"
+            "class": "HelloWorldExtension",
+            "command_name": "hello-world",
+            "dist_name": "opentoken-ext-hello-world"
           }
         }
     """
@@ -107,7 +109,8 @@ class ExtensionRegistry:
 
         Args:
             name: The extension's canonical name (matches ``command_name``).
-            metadata: Dict with keys ``version``, ``source_url``, ``source_path``, ``module``, ``class``.
+            metadata: Dict with keys ``version``, ``source_url``, ``source_path``, ``module``, ``class``,
+                ``command_name``, and ``dist_name``.
         """
         registry = ExtensionRegistry.load()
         registry[name] = metadata

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
@@ -45,8 +45,8 @@ class ExtensionRegistry:
         """
         env_override = os.environ.get("OPENTOKEN_EXTENSIONS_DIR")
         if env_override:
-            return Path(env_override)
-        return Path.home() / _DEFAULT_EXTENSIONS_SUBDIR
+            return Path(env_override).expanduser().resolve()
+        return (Path.home() / _DEFAULT_EXTENSIONS_SUBDIR).resolve()
 
     @staticmethod
     def get_registry_path() -> Path:

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/extension/extension_registry.py
@@ -45,7 +45,10 @@ class ExtensionRegistry:
         """
         env_override = os.environ.get("OPENTOKEN_EXTENSIONS_DIR")
         if env_override:
-            return Path(env_override).expanduser().resolve()
+            base_path = Path(env_override).expanduser()
+            if not base_path.is_absolute():
+                base_path = Path.home() / base_path
+            return base_path.resolve()
         return (Path.home() / _DEFAULT_EXTENSIONS_SUBDIR).resolve()
 
     @staticmethod

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/util/version_checker.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/util/version_checker.py
@@ -133,9 +133,10 @@ class VersionChecker:
     @staticmethod
     def _get_cache_path() -> Path:
         """Return the platform-appropriate path for the cache file."""
-        appdata = os.getenv("APPDATA", "").strip()
-        if appdata:
-            return Path(appdata) / _CACHE_DIR_NAME / _CACHE_FILENAME
+        if sys.platform == "win32":
+            appdata = os.getenv("APPDATA", "").strip()
+            if appdata:
+                return Path(appdata) / _CACHE_DIR_NAME / _CACHE_FILENAME
         return Path.home() / _CACHE_DIR_NAME / _CACHE_FILENAME
 
     def _read_cache(self) -> Optional[str]:

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/__init__.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/__init__.py
@@ -1,0 +1,3 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -307,6 +307,42 @@ class TestExtensionInstall:
         src_dir = tmp_path / "hello-world" / "src"
         assert not src_dir.exists()
 
+    def test_frozen_install_cleans_up_src_dir_on_none_command_name(self, tmp_path):
+        """install removes src_dir when _resolve_extension_command_name returns None (frozen mode)."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("sys.frozen", True, create=True):
+                with patch.object(ExtensionCommand, "_safe_extract_wheel"):
+                    with patch(
+                        "opentoken_cli.commands.extension_command._resolve_extension_command_name",
+                        return_value=None,
+                    ):
+                        result = ExtensionCommand._install(args)
+
+        assert result != 0
+        src_dir = tmp_path / "hello-world" / "src"
+        assert not src_dir.exists()
+
+    def test_frozen_install_cleans_up_src_dir_on_command_name_mismatch(self, tmp_path):
+        """install removes src_dir when _resolve_extension_command_name returns a mismatched name (frozen mode)."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("sys.frozen", True, create=True):
+                with patch.object(ExtensionCommand, "_safe_extract_wheel"):
+                    with patch(
+                        "opentoken_cli.commands.extension_command._resolve_extension_command_name",
+                        return_value="wrong-name",
+                    ):
+                        result = ExtensionCommand._install(args)
+
+        assert result != 0
+        src_dir = tmp_path / "hello-world" / "src"
+        assert not src_dir.exists()
+
     def test_install_rolls_back_pip_on_command_name_mismatch(self, tmp_path):
         """install rolls back pip when _resolve_extension_command_name returns a name that doesn't match."""
         whl = _make_wheel(tmp_path)

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -89,20 +89,39 @@ class TestExtensionUninstall:
     """Tests for ``extension uninstall``."""
 
     def test_uninstall_removes_directory_and_registry_entry(self, tmp_path):
-        """uninstall removes the extension's directory and its registry entry."""
-        data = {"bye-ext": {"version": "1.0.0", "source_url": ""}}
+        """uninstall removes the extension's directory and its registry entry (frozen mode)."""
+        data = {"bye-ext": {"version": "1.0.0", "source_url": "", "dist_name": "opentoken-bye-ext"}}
         (tmp_path / "registry.json").write_text(json.dumps(data))
         ext_dir = tmp_path / "bye-ext"
         ext_dir.mkdir()
         (ext_dir / "dummy.py").write_text("")
 
         with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
-            result = ExtensionCommand._uninstall(_make_args(name="bye-ext"))
+            with patch("sys.frozen", True, create=True):
+                result = ExtensionCommand._uninstall(_make_args(name="bye-ext"))
 
         assert result == 0
         assert not ext_dir.exists()
         registry = json.loads((tmp_path / "registry.json").read_text())
         assert "bye-ext" not in registry
+
+    def test_uninstall_calls_pip_in_non_frozen_mode(self, tmp_path):
+        """uninstall calls pip uninstall for registry entries in a normal Python environment."""
+        data = {"my-ext": {"version": "1.0.0", "source_url": "", "dist_name": "opentoken-my-ext"}}
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("subprocess.run", return_value=mock_result) as mock_pip:
+                result = ExtensionCommand._uninstall(_make_args(name="my-ext"))
+
+        assert result == 0
+        mock_pip.assert_called_once()
+        call_args = mock_pip.call_args[0][0]
+        assert "uninstall" in call_args
+        assert "opentoken-my-ext" in call_args
 
     def test_uninstall_pip_installed_extension_shows_guidance(self, tmp_path, capsys):
         """uninstall prints pip guidance and returns 1 for entry-point extensions."""
@@ -172,8 +191,12 @@ class TestExtensionInstall:
         whl = _make_wheel(tmp_path)
         args = _make_args(url=f"file://{whl}", yes=True)
 
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
         with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
-            result = ExtensionCommand._install(args)
+            with patch("subprocess.run", return_value=mock_result):
+                result = ExtensionCommand._install(args)
 
         assert result == 0
         out = capsys.readouterr().out

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -288,6 +288,25 @@ class TestExtensionInstall:
         assert "uninstall" in uninstall_call_args
         assert "opentoken-hello-world" in uninstall_call_args
 
+    def test_frozen_install_cleans_up_src_dir_on_extract_error(self, tmp_path):
+        """install removes src_dir when _safe_extract_wheel raises ValueError."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("sys.frozen", True, create=True):
+                with patch.object(
+                    ExtensionCommand,
+                    "_safe_extract_wheel",
+                    side_effect=ValueError("bad path"),
+                ):
+                    result = ExtensionCommand._install(args)
+
+        assert result != 0
+        # src_dir must not be left on disk after the ValueError
+        src_dir = tmp_path / "hello-world" / "src"
+        assert not src_dir.exists()
+
     def test_install_rolls_back_pip_on_command_name_mismatch(self, tmp_path):
         """install rolls back pip when _resolve_extension_command_name returns a name that doesn't match."""
         whl = _make_wheel(tmp_path)

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -205,3 +205,42 @@ class TestExtensionInstall:
         registry = json.loads((tmp_path / "registry.json").read_text())
         assert "hello-world" in registry
         assert registry["hello-world"]["version"] == "1.0.0"
+
+    def test_install_non_interactive_without_yes_fails(self, tmp_path, capsys):
+        """Without --yes and in a non-TTY context, install must fail with a clear error."""
+        args = _make_args(url="file:///nonexistent.whl", yes=False)
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                result = ExtensionCommand._install(args)
+                mock_stdin.isatty.assert_called_once()
+
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "--yes" in err
+
+    def test_install_rejects_non_https_url(self, tmp_path, capsys):
+        """install must reject URLs with schemes other than https:// or file://."""
+        args = _make_args(url="http://example.com/ext.whl", yes=True)
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionCommand._install(args)
+
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "Unsupported URL scheme" in err
+
+    def test_install_pip_uses_upgrade_no_deps(self, tmp_path, capsys):
+        """install passes --upgrade --no-deps to pip so the package is updated without re-downloading unchanged deps."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("subprocess.run", return_value=mock_result) as mock_pip:
+                ExtensionCommand._install(args)
+
+        call_args = mock_pip.call_args[0][0]
+        assert "--upgrade" in call_args
+        assert "--no-deps" in call_args

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -366,6 +366,23 @@ class TestExtensionInstall:
         assert "uninstall" in uninstall_call_args
         assert "opentoken-hello-world" in uninstall_call_args
 
+    def test_nonfrozen_install_invalid_ext_name_returns_error(self, tmp_path, capsys):
+        """_install_wheel returns 1 without calling pip when ext_name is not a valid dist name (non-frozen)."""
+        whl = _make_wheel(tmp_path)
+
+        with patch.object(
+            ExtensionCommand,
+            "_extract_entry_point",
+            return_value=("-r evil.txt", "some_module", "SomeClass", "1.0.0", "test"),
+        ):
+            with patch("subprocess.run") as mock_pip:
+                result = ExtensionCommand._install_wheel(whl, source_url="file:///test.whl")
+
+        assert result == 1
+        mock_pip.assert_not_called()
+        err = capsys.readouterr().err
+        assert "valid" in err.lower() or "invalid" in err.lower()
+
 
 # ---------------------------------------------------------------------------
 # Tests: _check_frozen_deps
@@ -454,6 +471,13 @@ class TestCheckFrozenDeps:
 
         assert any("multiple dist-info" in msg.lower() for msg in caplog.messages)
         assert result is None  # Neither METADATA entry has Requires-Dist lines
+
+    def test_frozen_deps_skips_extras_conditional_dep(self, tmp_path):
+        """_check_frozen_deps returns None when the only Requires-Dist entry is extras-conditional."""
+        metadata = 'Metadata-Version: 2.1\nName: my-extension\nRequires-Dist: requests; extra == "dev"\n'
+        with self._make_wheel_with_metadata(tmp_path, metadata) as zf:
+            result = ExtensionCommand._check_frozen_deps(zf)
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -5,6 +5,7 @@ Unit tests for ExtensionCommand.
 """
 
 import json
+import logging
 import os
 import zipfile
 from pathlib import Path
@@ -146,6 +147,20 @@ class TestExtensionUninstall:
         assert result == 1
         assert "not installed" in capsys.readouterr().err
 
+    def test_uninstall_invalid_dist_name_returns_error(self, tmp_path, capsys):
+        """_uninstall returns 1 and does not call pip when the registry dist_name is invalid."""
+        data = {"evil-ext": {"version": "1.0.0", "source_url": "", "dist_name": "-r evil.txt"}}
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("subprocess.run") as mock_pip:
+                result = ExtensionCommand._uninstall(_make_args(name="evil-ext"))
+
+        assert result == 1
+        mock_pip.assert_not_called()
+        err = capsys.readouterr().err
+        assert "invalid" in err.lower() or "valid" in err.lower()
+
 
 # ---------------------------------------------------------------------------
 # Tests: install security warning
@@ -245,9 +260,10 @@ class TestExtensionInstall:
             with patch("subprocess.run", return_value=mock_result) as mock_pip:
                 ExtensionCommand._install(args)
 
-        call_args = mock_pip.call_args[0][0]
-        assert "--upgrade" in call_args
-        assert "--no-deps" not in call_args
+        # call_args_list[0] is the pip install call; the second call (if present) is the rollback.
+        install_call_args = mock_pip.call_args_list[0][0][0]
+        assert "--upgrade" in install_call_args
+        assert "--no-deps" not in install_call_args
 
 
 # ---------------------------------------------------------------------------
@@ -323,3 +339,43 @@ class TestCheckFrozenDeps:
         assert result is not None
         assert "requests" in result
         assert "httpx" in result
+
+    def test_warns_on_multiple_dist_info_directories(self, tmp_path, caplog):
+        """_check_frozen_deps emits a warning when the wheel has multiple dist-info directories."""
+        whl_path = tmp_path / "multi-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(whl_path, "w") as zf:
+            zf.writestr("foo-1.0.dist-info/METADATA", "Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n")
+            zf.writestr("bar-2.0.dist-info/METADATA", "Metadata-Version: 2.1\nName: bar\nVersion: 2.0\n")
+
+        with zipfile.ZipFile(whl_path, "r") as zf:
+            with caplog.at_level(logging.WARNING, logger="opentoken_cli.commands.extension_command"):
+                result = ExtensionCommand._check_frozen_deps(zf)
+
+        assert any("multiple dist-info" in msg.lower() for msg in caplog.messages)
+        assert result is None  # Neither METADATA entry has Requires-Dist lines
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_entry_point
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEntryPoint:
+    """Unit tests for ExtensionCommand._extract_entry_point."""
+
+    def test_warns_on_multiple_entry_points(self, tmp_path, caplog):
+        """_extract_entry_point warns and picks the first of multiple opentoken.extensions entries."""
+        ep_content = "[opentoken.extensions]\ncmd-one = mymodule:MyClass\ncmd-two = mymodule:OtherClass\n"
+        metadata_content = "Metadata-Version: 2.1\nName: mymodule\nVersion: 1.0.0\n"
+        whl_path = tmp_path / "mymodule-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(whl_path, "w") as zf:
+            zf.writestr("mymodule-1.0.0.dist-info/entry_points.txt", ep_content)
+            zf.writestr("mymodule-1.0.0.dist-info/METADATA", metadata_content)
+
+        with zipfile.ZipFile(whl_path, "r") as zf:
+            with caplog.at_level(logging.WARNING, logger="opentoken_cli.commands.extension_command"):
+                result = ExtensionCommand._extract_entry_point(zf)
+
+        assert any("opentoken.extensions" in msg for msg in caplog.messages)
+        assert result is not None
+        assert result[0] == "cmd-one"

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -265,6 +265,52 @@ class TestExtensionInstall:
         assert "--upgrade" in install_call_args
         assert "--no-deps" not in install_call_args
 
+    def test_install_rolls_back_pip_on_none_command_name(self, tmp_path):
+        """install rolls back pip when _resolve_extension_command_name returns None."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        pip_install_result = MagicMock()
+        pip_install_result.returncode = 0
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("subprocess.run", return_value=pip_install_result) as mock_pip:
+                with patch(
+                    "opentoken_cli.commands.extension_command._resolve_extension_command_name",
+                    return_value=None,
+                ):
+                    result = ExtensionCommand._install(args)
+
+        assert result != 0
+        # Expect two calls: pip install, then pip uninstall rollback.
+        assert mock_pip.call_count == 2
+        uninstall_call_args = mock_pip.call_args_list[1][0][0]
+        assert "uninstall" in uninstall_call_args
+        assert "opentoken-hello-world" in uninstall_call_args
+
+    def test_install_rolls_back_pip_on_command_name_mismatch(self, tmp_path):
+        """install rolls back pip when _resolve_extension_command_name returns a name that doesn't match."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        pip_install_result = MagicMock()
+        pip_install_result.returncode = 0
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("subprocess.run", return_value=pip_install_result) as mock_pip:
+                with patch(
+                    "opentoken_cli.commands.extension_command._resolve_extension_command_name",
+                    return_value="wrong-name",
+                ):
+                    result = ExtensionCommand._install(args)
+
+        assert result != 0
+        # Expect two calls: pip install, then pip uninstall rollback.
+        assert mock_pip.call_count == 2
+        uninstall_call_args = mock_pip.call_args_list[1][0][0]
+        assert "uninstall" in uninstall_call_args
+        assert "opentoken-hello-world" in uninstall_call_args
+
 
 # ---------------------------------------------------------------------------
 # Tests: _check_frozen_deps

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -233,8 +233,8 @@ class TestExtensionInstall:
         err = capsys.readouterr().err
         assert "Unsupported URL scheme" in err
 
-    def test_install_pip_uses_upgrade_no_deps(self, tmp_path, capsys):
-        """install passes --upgrade --no-deps to pip so the package is updated without re-downloading unchanged deps."""
+    def test_install_pip_uses_upgrade_without_no_deps(self, tmp_path, capsys):
+        """install passes --upgrade to pip but NOT --no-deps so transitive dependencies are resolved normally."""
         whl = _make_wheel(tmp_path)
         args = _make_args(url=f"file://{whl}", yes=True)
 
@@ -247,7 +247,7 @@ class TestExtensionInstall:
 
         call_args = mock_pip.call_args[0][0]
         assert "--upgrade" in call_args
-        assert "--no-deps" in call_args
+        assert "--no-deps" not in call_args
 
 
 # ---------------------------------------------------------------------------

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -196,7 +196,11 @@ class TestExtensionInstall:
 
         with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
             with patch("subprocess.run", return_value=mock_result):
-                result = ExtensionCommand._install(args)
+                with patch(
+                    "opentoken_cli.commands.extension_command._resolve_extension_command_name",
+                    return_value="hello-world",
+                ):
+                    result = ExtensionCommand._install(args)
 
         assert result == 0
         out = capsys.readouterr().out

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -244,3 +244,78 @@ class TestExtensionInstall:
         call_args = mock_pip.call_args[0][0]
         assert "--upgrade" in call_args
         assert "--no-deps" in call_args
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_frozen_deps
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFrozenDeps:
+    """Unit tests for ExtensionCommand._check_frozen_deps."""
+
+    def _make_wheel_with_metadata(self, dest: Path, metadata_content: str) -> zipfile.ZipFile:
+        whl_path = dest / "test-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(whl_path, "w") as zf:
+            zf.writestr("test-1.0.0.dist-info/METADATA", metadata_content)
+        return zipfile.ZipFile(whl_path, "r")
+
+    def test_no_metadata_returns_none(self, tmp_path):
+        whl_path = tmp_path / "test-1.0.0-py3-none-any.whl"
+        with zipfile.ZipFile(whl_path, "w") as zf:
+            zf.writestr("test/__init__.py", "")
+        with zipfile.ZipFile(whl_path, "r") as zf:
+            assert ExtensionCommand._check_frozen_deps(zf) is None
+
+    def test_all_bundled_deps_returns_none(self, tmp_path):
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: my-extension\n"
+            "Requires-Dist: opentoken\n"
+            "Requires-Dist: pandas\n"
+            "Requires-Dist: pyarrow\n"
+        )
+        with self._make_wheel_with_metadata(tmp_path, metadata) as zf:
+            assert ExtensionCommand._check_frozen_deps(zf) is None
+
+    def test_version_specifier_with_parentheses_is_parsed_correctly(self, tmp_path):
+        """Wheel METADATA may use 'pkg (>=1.2)' format; the name must be extracted cleanly."""
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: my-extension\n"
+            "Requires-Dist: opentoken (>=2.0)\n"
+            "Requires-Dist: pandas (>=1.3,<3.0)\n"
+            "Requires-Dist: requests (>=2.28)\n"
+        )
+        with self._make_wheel_with_metadata(tmp_path, metadata) as zf:
+            result = ExtensionCommand._check_frozen_deps(zf)
+        assert result == "requests"
+
+    def test_version_specifier_without_parentheses_is_parsed_correctly(self, tmp_path):
+        metadata = (
+            "Metadata-Version: 2.1\nName: my-extension\nRequires-Dist: opentoken>=2.0\nRequires-Dist: requests>=2.28\n"
+        )
+        with self._make_wheel_with_metadata(tmp_path, metadata) as zf:
+            result = ExtensionCommand._check_frozen_deps(zf)
+        assert result == "requests"
+
+    def test_underscore_normalized_to_dash(self, tmp_path):
+        """Package names with underscores should be treated the same as dashes."""
+        metadata = "Metadata-Version: 2.1\nName: my-extension\nRequires-Dist: opentoken_cli\n"
+        with self._make_wheel_with_metadata(tmp_path, metadata) as zf:
+            result = ExtensionCommand._check_frozen_deps(zf)
+        assert result is None
+
+    def test_multiple_external_deps_reported(self, tmp_path):
+        metadata = (
+            "Metadata-Version: 2.1\n"
+            "Name: my-extension\n"
+            "Requires-Dist: opentoken\n"
+            "Requires-Dist: requests (>=2.28)\n"
+            "Requires-Dist: httpx\n"
+        )
+        with self._make_wheel_with_metadata(tmp_path, metadata) as zf:
+            result = ExtensionCommand._check_frozen_deps(zf)
+        assert result is not None
+        assert "requests" in result
+        assert "httpx" in result

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/commands/test_extension_command.py
@@ -1,0 +1,184 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Unit tests for ExtensionCommand.
+"""
+
+import json
+import os
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from opentoken_cli.commands.extension_command import _SECURITY_WARNING, ExtensionCommand
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs) -> MagicMock:
+    args = MagicMock()
+    for k, v in kwargs.items():
+        setattr(args, k, v)
+    return args
+
+
+def _make_wheel(dest: Path, name: str = "hello-world", version: str = "1.0.0") -> Path:
+    """
+    Write a minimal valid wheel (.whl) to *dest* and return the path.
+
+    The wheel contains METADATA and entry_points.txt in a dist-info directory.
+    """
+    dist_info = f"opentoken_{name.replace('-', '_')}-{version}.dist-info"
+    metadata_content = f"Metadata-Version: 2.1\nName: opentoken-{name}\nVersion: {version}\n"
+    ep_content = f"[opentoken.extensions]\n{name} = opentoken_{name.replace('-', '_')}.extension:FakeExtension\n"
+
+    whl_path = dest / f"opentoken_{name.replace('-', '_')}-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(whl_path, "w") as zf:
+        zf.writestr(f"{dist_info}/METADATA", metadata_content)
+        zf.writestr(f"{dist_info}/entry_points.txt", ep_content)
+        zf.writestr(f"opentoken_{name.replace('-', '_')}/__init__.py", "")
+    return whl_path
+
+
+# ---------------------------------------------------------------------------
+# Tests: list
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionList:
+    """Tests for ``extension list``."""
+
+    def test_list_empty_registry(self, tmp_path, capsys):
+        """list prints a friendly message when no extensions are installed."""
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("importlib.metadata.entry_points", return_value=[]):
+                result = ExtensionCommand._list(_make_args())
+
+        assert result == 0
+        assert "No extensions installed" in capsys.readouterr().out
+
+    def test_list_populated_registry(self, tmp_path, capsys):
+        """list prints a table with name, version, command, and source_url columns."""
+        data = {
+            "my-ext": {
+                "version": "1.2.3",
+                "source_url": "https://example.com/my_ext.whl",
+                "command_name": "my-ext",
+            }
+        }
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionCommand._list(_make_args())
+
+        out = capsys.readouterr().out
+        assert result == 0
+        assert "my-ext" in out
+        assert "1.2.3" in out
+        assert "https://example.com/my_ext.whl" in out
+
+
+# ---------------------------------------------------------------------------
+# Tests: uninstall
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionUninstall:
+    """Tests for ``extension uninstall``."""
+
+    def test_uninstall_removes_directory_and_registry_entry(self, tmp_path):
+        """uninstall removes the extension's directory and its registry entry."""
+        data = {"bye-ext": {"version": "1.0.0", "source_url": ""}}
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+        ext_dir = tmp_path / "bye-ext"
+        ext_dir.mkdir()
+        (ext_dir / "dummy.py").write_text("")
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionCommand._uninstall(_make_args(name="bye-ext"))
+
+        assert result == 0
+        assert not ext_dir.exists()
+        registry = json.loads((tmp_path / "registry.json").read_text())
+        assert "bye-ext" not in registry
+
+    def test_uninstall_pip_installed_extension_shows_guidance(self, tmp_path, capsys):
+        """uninstall prints pip guidance and returns 1 for entry-point extensions."""
+        mock_ep = MagicMock()
+        mock_ep.name = "pip-ext"
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+                result = ExtensionCommand._uninstall(_make_args(name="pip-ext"))
+
+        assert result == 1
+        output = capsys.readouterr()
+        assert "pip" in output.err
+        assert "pip-ext" in output.err
+
+    def test_uninstall_unknown_extension_returns_error(self, tmp_path, capsys):
+        """uninstall returns 1 with an error message for unknown extension names."""
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("importlib.metadata.entry_points", return_value=[]):
+                result = ExtensionCommand._uninstall(_make_args(name="ghost-ext"))
+
+        assert result == 1
+        assert "not installed" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Tests: install security warning
+# ---------------------------------------------------------------------------
+
+
+class TestExtensionInstall:
+    """Tests for ``extension install``."""
+
+    def test_install_prints_security_warning(self, tmp_path, capsys):
+        """install always prints the security warning before any other action."""
+        args = _make_args(url="file:///nonexistent.whl", yes=True)
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            # The file doesn't exist — we just want to confirm the warning is printed.
+            ExtensionCommand._install(args)
+
+        out = capsys.readouterr().out
+        assert _SECURITY_WARNING in out
+
+    def test_install_yes_flag_skips_prompt(self, tmp_path, capsys):
+        """--yes skips the interactive confirmation prompt."""
+        args = _make_args(url="file:///nonexistent.whl", yes=True)
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("builtins.input") as mock_input:
+                ExtensionCommand._install(args)
+                mock_input.assert_not_called()
+
+    def test_install_prompts_without_yes(self, tmp_path, capsys):
+        """Without --yes, the user is prompted when stdin is a tty."""
+        args = _make_args(url="file:///nonexistent.whl", yes=False)
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = True
+                with patch("builtins.input", return_value="n"):
+                    result = ExtensionCommand._install(args)
+
+        assert result == 0  # cancelled — clean exit
+        out = capsys.readouterr().out
+        assert "cancelled" in out.lower()
+
+    def test_install_file_url(self, tmp_path, capsys):
+        """install file:// downloads from a local path and registers the extension."""
+        whl = _make_wheel(tmp_path)
+        args = _make_args(url=f"file://{whl}", yes=True)
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionCommand._install(args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "installed successfully" in out
+
+        registry = json.loads((tmp_path / "registry.json").read_text())
+        assert "hello-world" in registry
+        assert registry["hello-world"]["version"] == "1.0.0"

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/extension/__init__.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/extension/__init__.py
@@ -1,0 +1,3 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_loader.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_loader.py
@@ -156,7 +156,7 @@ class TestLoadExtensionsFrozen:
         )
 
         fake_registry = {
-            "frozen-ext": {
+            "frozen-cmd": {
                 "version": "1.0.0",
                 "source_url": "file:///tmp/fake.whl",
                 "source_path": str(pkg_dir),

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_loader.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_loader.py
@@ -1,0 +1,177 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Unit tests for ExtensionLoader.
+"""
+
+import argparse
+import sys
+from unittest.mock import MagicMock, patch
+
+from opentoken_cli.extension.extension_interface import OpenTokenExtension
+from opentoken_cli.extension.extension_loader import ExtensionLoader
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_subparsers() -> argparse._SubParsersAction:
+    """Return a fresh subparsers action for use in tests."""
+    parser = argparse.ArgumentParser()
+    return parser.add_subparsers(dest="command")
+
+
+def _make_extension(command_name: str = "test-ext") -> OpenTokenExtension:
+    """Build a minimal concrete OpenTokenExtension instance."""
+
+    class _TestExt(OpenTokenExtension):
+        @property
+        def command_name(self) -> str:
+            return command_name
+
+        @property
+        def description(self) -> str:
+            return "Test extension"
+
+        @property
+        def version(self) -> str:
+            return "0.1.0"
+
+        def register_subcommand(self, subparsers: argparse._SubParsersAction) -> None:
+            subparsers.add_parser(self.command_name, help=self.description)
+
+    return _TestExt()
+
+
+def _make_entry_point(ext_instance: OpenTokenExtension) -> MagicMock:
+    """Wrap an extension instance in a mock importlib EntryPoint."""
+    ep = MagicMock()
+    ep.name = ext_instance.command_name
+    ep.load.return_value = type(ext_instance)
+    return ep
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExtensionsEntryPoints:
+    """Tests for the Python package (entry-point) discovery track."""
+
+    def test_mock_entry_point_gets_registered(self):
+        """An extension discovered via entry points is added to the subparsers."""
+        ext = _make_extension("demo-cmd")
+        ep = _make_entry_point(ext)
+        subparsers = _make_subparsers()
+
+        with patch("importlib.metadata.entry_points", return_value=[ep]):
+            ExtensionLoader.load_extensions(subparsers, set())
+
+        assert "demo-cmd" in subparsers.choices
+
+    def test_conflict_with_builtin_is_skipped(self):
+        """An extension whose command_name matches a built-in is silently skipped."""
+        ext = _make_extension("help")
+        ep = _make_entry_point(ext)
+        subparsers = _make_subparsers()
+
+        with patch("importlib.metadata.entry_points", return_value=[ep]):
+            # Should silently skip without raising.
+            ExtensionLoader.load_extensions(subparsers, {"help"})
+
+        assert "help" not in subparsers.choices
+
+    def test_conflict_with_already_registered_extension_is_skipped(self):
+        """When two extensions share the same command_name, only the first is kept."""
+        ext1 = _make_extension("shared-cmd")
+        ext2 = _make_extension("shared-cmd")
+        ep1 = _make_entry_point(ext1)
+        ep2 = _make_entry_point(ext2)
+
+        # Make load() return distinct instances for the two entry points.
+        ep1.load.return_value = type(ext1)
+        ep2.load.return_value = type(ext2)
+
+        subparsers = _make_subparsers()
+
+        with patch("importlib.metadata.entry_points", return_value=[ep1, ep2]):
+            ExtensionLoader.load_extensions(subparsers, set())
+
+        # Only one parser should be registered.
+        assert list(subparsers.choices.keys()).count("shared-cmd") == 1
+
+    def test_import_error_emits_warning_but_does_not_crash(self, caplog):
+        """An exception during entry-point load is caught and warns but doesn't raise."""
+        ep = MagicMock()
+        ep.name = "bad-ext"
+        ep.load.side_effect = ImportError("broken module")
+        subparsers = _make_subparsers()
+
+        import logging
+
+        with patch("importlib.metadata.entry_points", return_value=[ep]):
+            with caplog.at_level(logging.WARNING, logger="opentoken_cli.extension.extension_loader"):
+                ExtensionLoader.load_extensions(subparsers, set())
+
+        assert "bad-ext" in caplog.text
+        assert "bad-ext" not in subparsers.choices
+
+    def test_extensions_sorted_deterministically(self):
+        """Extensions are registered in alphabetical order of command_name."""
+        names = ["zebra", "alpha", "mango"]
+        exts = [_make_extension(n) for n in names]
+        eps = [_make_entry_point(e) for e in exts]
+        subparsers = _make_subparsers()
+
+        with patch("importlib.metadata.entry_points", return_value=eps):
+            ExtensionLoader.load_extensions(subparsers, set())
+
+        registered = list(subparsers.choices.keys())
+        assert registered == sorted(names)
+
+
+class TestLoadExtensionsFrozen:
+    """Tests for the frozen-binary (registry) discovery track."""
+
+    def test_frozen_track_loads_extension_from_registry(self, tmp_path):
+        """When sys.frozen is True, extensions are loaded from registry.json."""
+        # Build a tiny importable module on the fly.
+        pkg_dir = tmp_path / "myext_src"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        mod_file = pkg_dir / "ext_mod.py"
+        mod_file.write_text(
+            "import argparse\n"
+            "from opentoken_cli.extension import OpenTokenExtension\n"
+            "class FrozenExt(OpenTokenExtension):\n"
+            "    @property\n"
+            "    def command_name(self): return 'frozen-cmd'\n"
+            "    @property\n"
+            "    def description(self): return 'frozen'\n"
+            "    @property\n"
+            "    def version(self): return '1.0.0'\n"
+            "    def register_subcommand(self, sp): sp.add_parser(self.command_name)\n"
+        )
+
+        fake_registry = {
+            "frozen-ext": {
+                "version": "1.0.0",
+                "source_url": "file:///tmp/fake.whl",
+                "source_path": str(pkg_dir),
+                "module": "ext_mod",
+                "class": "FrozenExt",
+            }
+        }
+
+        subparsers = _make_subparsers()
+
+        with patch.object(sys, "frozen", True, create=True):
+            with patch(
+                "opentoken_cli.extension.extension_registry.ExtensionRegistry.load",
+                return_value=fake_registry,
+            ):
+                ExtensionLoader.load_extensions(subparsers, set())
+
+        assert "frozen-cmd" in subparsers.choices

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_registry.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_registry.py
@@ -1,0 +1,144 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Unit tests for ExtensionRegistry.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from opentoken_cli.extension.extension_registry import ExtensionRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _registry_in(tmp_path: Path) -> Path:
+    """Return a registry path inside *tmp_path* and wire it via env override."""
+    return tmp_path / "registry.json"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoad:
+    """Tests for ExtensionRegistry.load()."""
+
+    def test_returns_empty_dict_when_file_absent(self, tmp_path):
+        """load() returns {} when registry.json does not exist."""
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionRegistry.load()
+        assert result == {}
+
+    def test_returns_parsed_contents_when_file_exists(self, tmp_path):
+        """load() parses and returns the registry JSON when the file is present."""
+        data = {"my-ext": {"version": "1.0.0"}}
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionRegistry.load()
+
+        assert result == data
+
+    def test_returns_empty_dict_on_invalid_json(self, tmp_path):
+        """load() returns {} and does not raise when the file contains invalid JSON."""
+        (tmp_path / "registry.json").write_text("NOT VALID JSON{{}")
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            result = ExtensionRegistry.load()
+
+        assert result == {}
+
+
+class TestAddAndRoundTrip:
+    """Tests for ExtensionRegistry.add_extension() + load() round-trip."""
+
+    def test_add_extension_persists_and_reloads(self, tmp_path):
+        """add_extension() writes the entry; a subsequent load() returns it."""
+        meta = {
+            "version": "2.0.0",
+            "source_url": "https://example.com/ext.whl",
+            "source_path": "/some/path",
+            "module": "my_ext.extension",
+            "class": "MyExt",
+        }
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            ExtensionRegistry.add_extension("my-ext", meta)
+            loaded = ExtensionRegistry.load()
+
+        assert loaded["my-ext"] == meta
+
+    def test_add_extension_overwrites_existing_entry(self, tmp_path):
+        """add_extension() replaces an existing entry with the same name."""
+        meta_v1 = {"version": "1.0.0"}
+        meta_v2 = {"version": "2.0.0"}
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            ExtensionRegistry.add_extension("ext", meta_v1)
+            ExtensionRegistry.add_extension("ext", meta_v2)
+            loaded = ExtensionRegistry.load()
+
+        assert loaded["ext"]["version"] == "2.0.0"
+
+
+class TestRemoveExtension:
+    """Tests for ExtensionRegistry.remove_extension()."""
+
+    def test_remove_existing_entry(self, tmp_path):
+        """remove_extension() deletes the named entry from the registry."""
+        data = {"ext-a": {"version": "1.0.0"}, "ext-b": {"version": "0.1.0"}}
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            ExtensionRegistry.remove_extension("ext-a")
+            loaded = ExtensionRegistry.load()
+
+        assert "ext-a" not in loaded
+        assert "ext-b" in loaded
+
+    def test_remove_absent_entry_is_noop(self, tmp_path):
+        """remove_extension() does nothing (no error) when the entry is absent."""
+        data = {"ext-a": {"version": "1.0.0"}}
+        (tmp_path / "registry.json").write_text(json.dumps(data))
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            ExtensionRegistry.remove_extension("does-not-exist")
+            loaded = ExtensionRegistry.load()
+
+        assert loaded == data
+
+
+class TestEnvVarOverride:
+    """Tests for OPENTOKEN_EXTENSIONS_DIR environment variable override."""
+
+    def test_env_var_overrides_default_dir(self, tmp_path):
+        """get_extensions_dir() returns the path from OPENTOKEN_EXTENSIONS_DIR."""
+        custom_dir = tmp_path / "custom_ext_dir"
+        custom_dir.mkdir()
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(custom_dir)}):
+            result = ExtensionRegistry.get_extensions_dir()
+
+        assert result == custom_dir
+
+    def test_registry_path_uses_custom_dir(self, tmp_path):
+        """get_registry_path() is rooted inside OPENTOKEN_EXTENSIONS_DIR."""
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            path = ExtensionRegistry.get_registry_path()
+
+        assert path == tmp_path / "registry.json"
+
+    def test_data_stored_in_custom_dir(self, tmp_path):
+        """Registry data is written inside the overridden directory."""
+        meta = {"version": "1.0.0"}
+
+        with patch.dict(os.environ, {"OPENTOKEN_EXTENSIONS_DIR": str(tmp_path)}):
+            ExtensionRegistry.add_extension("x", meta)
+
+        assert (tmp_path / "registry.json").exists()

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_registry.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/extension/test_extension_registry.py
@@ -6,20 +6,9 @@ Unit tests for ExtensionRegistry.
 
 import json
 import os
-from pathlib import Path
 from unittest.mock import patch
 
 from opentoken_cli.extension.extension_registry import ExtensionRegistry
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _registry_in(tmp_path: Path) -> Path:
-    """Return a registry path inside *tmp_path* and wire it via env override."""
-    return tmp_path / "registry.json"
-
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/lib/python/opentoken-cli/src/test/opentoken_cli/version_checker_test.py
+++ b/lib/python/opentoken-cli/src/test/opentoken_cli/version_checker_test.py
@@ -353,6 +353,7 @@ class TestGetCachePath:
         expected_path = Path(appdata) / ".opentoken" / "update-check.json"
 
         monkeypatch.setenv("APPDATA", appdata)
+        monkeypatch.setattr("sys.platform", "win32")
 
         path = VersionChecker.get_cache_path()
 

--- a/lib/python/opentoken_ext_hello_world/README.md
+++ b/lib/python/opentoken_ext_hello_world/README.md
@@ -64,7 +64,7 @@ This produces `dist/my_package-1.0.0-py3-none-any.whl`.
 
 ```bash
 # From a local build
-opentoken extension install file://./dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+opentoken extension install file:///$(pwd)/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
 
 # From a remote URL
 opentoken extension install https://example.com/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
@@ -75,8 +75,11 @@ Pass `--yes` / `-y` to skip the security confirmation prompt.
 ## Invoking the Extension
 
 ```bash
-opentoken hello-world greet --name Alice
-# → Hello, Alice! — from OpenToken hello-world extension
+opentoken hello-world hello --name Alice
+# → Hello, Alice
+
+opentoken hello-world bye --name Bob
+# → Bye, Bob
 ```
 
 ## PyInstaller / Frozen Binary Compatibility
@@ -86,10 +89,14 @@ are loaded from the registry file (`~/.opentoken/extensions/registry.json`) rath
 than Python entry points.
 
 **Tier-1 (fully supported)**: Extensions with **no external dependencies** beyond
-the packages already bundled inside the binary. The hello-world extension is a
-tier-1 extension because `dependencies = []` in its `pyproject.toml`.
+the standard library. The hello-world extension is a Tier-1 extension because
+`dependencies = []` in its `pyproject.toml`.
 
-**Tier-2 (not supported in frozen binaries)**: Extensions that require third-party
+**Tier-2 (supported)**: Extensions that depend only on packages already bundled
+inside the binary (e.g., `pandas`, `pyarrow`, `cryptography`). These are binary-compatible
+because those packages are shipped inside the executable.
+
+**Tier-3 (not supported in frozen binaries)**: Extensions that require third-party
 packages not bundled in the binary will fail to install via `opentoken extension
 install` when running the frozen binary. Use the `pip`-installed Python package
 version of the CLI for such extensions.

--- a/lib/python/opentoken_ext_hello_world/README.md
+++ b/lib/python/opentoken_ext_hello_world/README.md
@@ -1,0 +1,95 @@
+# OpenToken Hello-World Reference Extension
+
+This package demonstrates how to build an OpenToken CLI extension.
+
+## Implementing `OpenTokenExtension`
+
+Create a class that inherits from `OpenTokenExtension` and implements the four abstract members:
+
+```python
+from opentoken_cli.extension import OpenTokenExtension
+import argparse
+
+class MyExtension(OpenTokenExtension):
+    @property
+    def command_name(self) -> str:
+        return "my-ext"                 # becomes `opentoken my-ext ...`
+
+    @property
+    def description(self) -> str:
+        return "My custom extension"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def register_subcommand(self, subparsers: argparse._SubParsersAction) -> None:
+        parser = subparsers.add_parser(self.command_name, help=self.description)
+        sub = parser.add_subparsers(dest="my_ext_subcommand")
+
+        run = sub.add_parser("run", help="Run something")
+        run.add_argument("--input", required=True)
+        run.set_defaults(func=MyExtension._run)
+
+        parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
+
+    @staticmethod
+    def _run(args) -> int:
+        print(f"Running with: {args.input}")
+        return 0
+```
+
+## Declaring the Entry Point
+
+In your `pyproject.toml`:
+
+```toml
+[project.entry-points."opentoken.extensions"]
+my-ext = "my_package.extension:MyExtension"
+```
+
+The key (`my-ext`) is the entry-point name; the value points to the class using
+`module:ClassName` notation.
+
+## Building the Wheel
+
+```bash
+pip install build
+python -m build
+```
+
+This produces `dist/my_package-1.0.0-py3-none-any.whl`.
+
+## Installing the Extension
+
+```bash
+# From a local build
+opentoken extension install file://./dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+
+# From a remote URL
+opentoken extension install https://example.com/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```
+
+Pass `--yes` / `-y` to skip the security confirmation prompt.
+
+## Invoking the Extension
+
+```bash
+opentoken hello-world greet --name Alice
+# → Hello, Alice! — from OpenToken hello-world extension
+```
+
+## PyInstaller / Frozen Binary Compatibility
+
+When using the pre-built OpenToken binary (compiled with PyInstaller), extensions
+are loaded from the registry file (`~/.opentoken/extensions/registry.json`) rather
+than Python entry points.
+
+**Tier-1 (fully supported)**: Extensions with **no external dependencies** beyond
+the packages already bundled inside the binary. The hello-world extension is a
+tier-1 extension because `dependencies = []` in its `pyproject.toml`.
+
+**Tier-2 (not supported in frozen binaries)**: Extensions that require third-party
+packages not bundled in the binary will fail to install via `opentoken extension
+install` when running the frozen binary. Use the `pip`-installed Python package
+version of the CLI for such extensions.

--- a/lib/python/opentoken_ext_hello_world/pyproject.toml
+++ b/lib/python/opentoken_ext_hello_world/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "opentoken-ext-hello-world"
+version = "1.0.0"
+requires-python = ">=3.10"
+description = "OpenToken hello-world reference extension"
+dependencies = []
+
+[project.entry-points."opentoken.extensions"]
+hello-world = "opentoken_ext_hello_world.extension:HelloWorldExtension"
+
+[build-system]
+requires = ["setuptools>=40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src/main"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src/main", "../../opentoken-cli/src/main"]

--- a/lib/python/opentoken_ext_hello_world/src/main/opentoken_ext_hello_world/__init__.py
+++ b/lib/python/opentoken_ext_hello_world/src/main/opentoken_ext_hello_world/__init__.py
@@ -1,0 +1,3 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""

--- a/lib/python/opentoken_ext_hello_world/src/main/opentoken_ext_hello_world/extension.py
+++ b/lib/python/opentoken_ext_hello_world/src/main/opentoken_ext_hello_world/extension.py
@@ -30,14 +30,24 @@ class HelloWorldExtension(OpenTokenExtension):
         parser = subparsers.add_parser(self.command_name, help=self.description)
         sub = parser.add_subparsers(dest="hello_world_subcommand")
 
-        greet = sub.add_parser("greet", help="Print a greeting")
-        greet.add_argument("--name", required=True, help="Name to greet")
-        greet.set_defaults(func=HelloWorldExtension._greet)
+        hello = sub.add_parser("hello", help="Print a hello greeting")
+        hello.add_argument("--name", required=True, help="Name to greet")
+        hello.set_defaults(func=HelloWorldExtension._hello)
+
+        bye = sub.add_parser("bye", help="Print a goodbye greeting")
+        bye.add_argument("--name", required=True, help="Name to bid farewell")
+        bye.set_defaults(func=HelloWorldExtension._bye)
 
         parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
 
     @staticmethod
-    def _greet(args) -> int:
-        """Print a personalised greeting and return exit code 0."""
-        print(f"Hello, {args.name}! — from OpenToken hello-world extension")
+    def _hello(args) -> int:
+        """Print a personalised hello greeting and return exit code 0."""
+        print(f"Hello, {args.name}")
+        return 0
+
+    @staticmethod
+    def _bye(args) -> int:
+        """Print a personalised goodbye greeting and return exit code 0."""
+        print(f"Bye, {args.name}")
         return 0

--- a/lib/python/opentoken_ext_hello_world/src/main/opentoken_ext_hello_world/extension.py
+++ b/lib/python/opentoken_ext_hello_world/src/main/opentoken_ext_hello_world/extension.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import argparse
+
+from opentoken_cli.extension import OpenTokenExtension
+
+
+class HelloWorldExtension(OpenTokenExtension):
+    """Reference OpenToken extension that demonstrates the extension interface."""
+
+    @property
+    def command_name(self) -> str:
+        """Return the top-level subcommand name owned by this extension."""
+        return "hello-world"
+
+    @property
+    def description(self) -> str:
+        """Return a short human-readable description of this extension."""
+        return "OpenToken hello-world reference extension"
+
+    @property
+    def version(self) -> str:
+        """Return the SemVer version string for this extension."""
+        return "1.0.0"
+
+    def register_subcommand(self, subparsers: argparse._SubParsersAction) -> None:
+        """Register the ``hello-world`` parser and its sub-subcommands."""
+        parser = subparsers.add_parser(self.command_name, help=self.description)
+        sub = parser.add_subparsers(dest="hello_world_subcommand")
+
+        greet = sub.add_parser("greet", help="Print a greeting")
+        greet.add_argument("--name", required=True, help="Name to greet")
+        greet.set_defaults(func=HelloWorldExtension._greet)
+
+        parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
+
+    @staticmethod
+    def _greet(args) -> int:
+        """Print a personalised greeting and return exit code 0."""
+        print(f"Hello, {args.name}! — from OpenToken hello-world extension")
+        return 0

--- a/lib/python/opentoken_ext_hello_world/src/test/opentoken_ext_hello_world/test_extension.py
+++ b/lib/python/opentoken_ext_hello_world/src/test/opentoken_ext_hello_world/test_extension.py
@@ -48,44 +48,86 @@ class TestRegisterSubcommand:
 
         assert "hello-world" in subparsers.choices
 
-    def test_greet_sub_subcommand_present(self):
-        """The 'greet' sub-subcommand is accessible under 'hello-world'."""
+    def test_hello_sub_subcommand_present(self):
+        """The 'hello' sub-subcommand is accessible under 'hello-world'."""
         root = argparse.ArgumentParser()
         subparsers = root.add_subparsers(dest="command")
         ext = HelloWorldExtension()
         ext.register_subcommand(subparsers)
 
         assert "hello-world" in subparsers.choices
-        # Parse a greet invocation — should not raise.
-        parsed = root.parse_args(["hello-world", "greet", "--name", "Alice"])
+        # Parse a hello invocation — should not raise.
+        parsed = root.parse_args(["hello-world", "hello", "--name", "Alice"])
+        assert parsed.name == "Alice"
+
+    def test_bye_sub_subcommand_present(self):
+        """The 'bye' sub-subcommand is accessible under 'hello-world'."""
+        root = argparse.ArgumentParser()
+        subparsers = root.add_subparsers(dest="command")
+        ext = HelloWorldExtension()
+        ext.register_subcommand(subparsers)
+
+        assert "hello-world" in subparsers.choices
+        # Parse a bye invocation — should not raise.
+        parsed = root.parse_args(["hello-world", "bye", "--name", "Alice"])
         assert parsed.name == "Alice"
 
 
 # ---------------------------------------------------------------------------
-# Tests: _greet dispatch
+# Tests: _hello dispatch
 # ---------------------------------------------------------------------------
 
 
-class TestGreetDispatch:
-    """Tests for HelloWorldExtension._greet static method."""
+class TestHelloDispatch:
+    """Tests for HelloWorldExtension._hello static method."""
 
-    def test_greet_output(self, capsys):
-        """_greet prints the expected greeting to stdout."""
+    def test_hello_output(self, capsys):
+        """_hello prints the expected greeting to stdout."""
         args = MagicMock()
         args.name = "Alice"
 
-        result = HelloWorldExtension._greet(args)
+        result = HelloWorldExtension._hello(args)
 
         assert result == 0
         out = capsys.readouterr().out
-        assert out.strip() == "Hello, Alice! — from OpenToken hello-world extension"
+        assert out.strip() == "Hello, Alice"
 
-    def test_greet_different_name(self, capsys):
-        """_greet uses the provided name in the output."""
+    def test_hello_different_name(self, capsys):
+        """_hello uses the provided name in the output."""
         args = MagicMock()
         args.name = "Bob"
 
-        HelloWorldExtension._greet(args)
+        HelloWorldExtension._hello(args)
+
+        out = capsys.readouterr().out
+        assert "Bob" in out
+
+
+# ---------------------------------------------------------------------------
+# Tests: _bye dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestByeDispatch:
+    """Tests for HelloWorldExtension._bye static method."""
+
+    def test_bye_output(self, capsys):
+        """_bye prints the expected farewell to stdout."""
+        args = MagicMock()
+        args.name = "Alice"
+
+        result = HelloWorldExtension._bye(args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert out.strip() == "Bye, Alice"
+
+    def test_bye_different_name(self, capsys):
+        """_bye uses the provided name in the output."""
+        args = MagicMock()
+        args.name = "Bob"
+
+        HelloWorldExtension._bye(args)
 
         out = capsys.readouterr().out
         assert "Bob" in out

--- a/lib/python/opentoken_ext_hello_world/src/test/opentoken_ext_hello_world/test_extension.py
+++ b/lib/python/opentoken_ext_hello_world/src/test/opentoken_ext_hello_world/test_extension.py
@@ -1,0 +1,91 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+
+Unit tests for HelloWorldExtension.
+"""
+
+import argparse
+from unittest.mock import MagicMock
+
+from opentoken_ext_hello_world.extension import HelloWorldExtension
+
+# ---------------------------------------------------------------------------
+# Tests: properties
+# ---------------------------------------------------------------------------
+
+
+class TestHelloWorldProperties:
+    """Tests for HelloWorldExtension abstract-property implementations."""
+
+    def setup_method(self):
+        self.ext = HelloWorldExtension()
+
+    def test_command_name(self):
+        assert self.ext.command_name == "hello-world"
+
+    def test_description(self):
+        assert self.ext.description == "OpenToken hello-world reference extension"
+
+    def test_version(self):
+        assert self.ext.version == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Tests: register_subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterSubcommand:
+    """Tests that register_subcommand adds the expected parser."""
+
+    def test_adds_hello_world_parser(self):
+        """register_subcommand registers a 'hello-world' choice in the subparsers."""
+        root = argparse.ArgumentParser()
+        subparsers = root.add_subparsers(dest="command")
+        ext = HelloWorldExtension()
+
+        ext.register_subcommand(subparsers)
+
+        assert "hello-world" in subparsers.choices
+
+    def test_greet_sub_subcommand_present(self):
+        """The 'greet' sub-subcommand is accessible under 'hello-world'."""
+        root = argparse.ArgumentParser()
+        subparsers = root.add_subparsers(dest="command")
+        ext = HelloWorldExtension()
+        ext.register_subcommand(subparsers)
+
+        assert "hello-world" in subparsers.choices
+        # Parse a greet invocation — should not raise.
+        parsed = root.parse_args(["hello-world", "greet", "--name", "Alice"])
+        assert parsed.name == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _greet dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGreetDispatch:
+    """Tests for HelloWorldExtension._greet static method."""
+
+    def test_greet_output(self, capsys):
+        """_greet prints the expected greeting to stdout."""
+        args = MagicMock()
+        args.name = "Alice"
+
+        result = HelloWorldExtension._greet(args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert out.strip() == "Hello, Alice! — from OpenToken hello-world extension"
+
+    def test_greet_different_name(self, capsys):
+        """_greet uses the provided name in the output."""
+        args = MagicMock()
+        args.name = "Bob"
+
+        HelloWorldExtension._greet(args)
+
+        out = capsys.readouterr().out
+        assert "Bob" in out

--- a/pages/operations/index.md
+++ b/pages/operations/index.md
@@ -13,6 +13,7 @@ Guides for running and managing OpenToken in production.
 - [Tokenize](tokenize.md) — Generating tokens without encryption
 - [Decrypting Tokens](decrypting-tokens.md) — Recovering original signatures (requires keys)
 - [Mock Data Workflows](mock-data-workflows.md) — Generating test data
+- [Managing Extensions](managing-extensions.md) — Installing, updating, and removing CLI extensions
 
 ## Next Steps
 

--- a/pages/operations/index.md
+++ b/pages/operations/index.md
@@ -13,7 +13,7 @@ Guides for running and managing OpenToken in production.
 - [Tokenize](tokenize.md) — Generating tokens without encryption
 - [Decrypting Tokens](decrypting-tokens.md) — Recovering original signatures (requires keys)
 - [Mock Data Workflows](mock-data-workflows.md) — Generating test data
-- [Managing Extensions](managing-extensions.md) — Installing, updating, and removing CLI extensions
+- [Managing Extensions](managing-extensions.md) — Installing, listing, and removing CLI extensions
 
 ## Next Steps
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -192,8 +192,8 @@ Re-install the extension to ensure the package is in the correct location.
 ### Tier-3 rejection under the binary
 
 ```
-Error: this extension requires packages that are not bundled in the OpenToken binary
-(missing: pandas).
+Error: This extension requires external dependencies that are not bundled in the OpenToken binary: pandas
+Install the Python package version of OpenToken CLI to use this extension.
 ```
 
 Switch to the Python package install of OpenToken, or rewrite the extension to use only stdlib or OpenToken-bundled packages. See [Extension Author Reference: Binary Compatibility](../reference/extensions.md#binary-compatibility) for details on the three dependency tiers.

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -20,13 +20,13 @@ The CLI prints a security warning and prompts for confirmation before installing
 
 ### From a Local File
 
-Use the `file://` scheme to install from a local `.whl` or `.tar.gz` file:
+Use the `file://` scheme to install from a local `.whl` file:
 
 ```bash
 opentoken extension install file:///path/to/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
 ```
 
-Relative paths are not supported. Use an absolute path in the `file://` URL.
+Use an absolute path in the `file://` URL.
 
 ### Skipping Confirmation
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -38,10 +38,19 @@ opentoken extension install --yes https://example.com/opentoken-ext-hello-world-
 
 ### What Install Does
 
-1. Downloads or copies the package to `~/.opentoken/extensions/` (or `$OPENTOKEN_EXTENSIONS_DIR`).
-2. Extracts and validates the package.
-3. Records the extension in `~/.opentoken/extensions/registry.json`.
-4. Prints the installed extension name, version, and command name.
+The exact steps depend on how OpenToken is installed:
+
+**Python package mode** (pip install / source install — the common case):
+
+1. Installs the wheel via `pip` into the active Python environment's site-packages.
+2. Records the extension metadata in `~/.opentoken/extensions/registry.json` (or `$OPENTOKEN_EXTENSIONS_DIR/registry.json`).
+3. Prints the installed extension name, version, and command name.
+
+**Frozen binary mode** (PyInstaller binary):
+
+1. Extracts the wheel contents into `~/.opentoken/extensions/<name>/src/` (or `$OPENTOKEN_EXTENSIONS_DIR/<name>/src/`).
+2. Records the extension metadata in `~/.opentoken/extensions/registry.json` (or `$OPENTOKEN_EXTENSIONS_DIR/registry.json`).
+3. Prints the installed extension name, version, and command name.
 
 ---
 
@@ -154,10 +163,18 @@ opentoken extension install <url>
 ### Extension does not appear in `opentoken --help`
 
 1. Confirm it is listed in `opentoken extension list`.
-2. Check for a load warning at startup. Load warnings are printed to stderr and look like:
+2. Check for a load warning at startup. Load warnings are printed to stderr. The format depends on the install mode:
+
+   Python package mode (entry-point track):
 
    ```
-   Warning: failed to load extension 'hello-world': ModuleNotFoundError: No module named 'opentoken_ext_hello_world'
+   Failed to load extension from entry point 'hello-world': ModuleNotFoundError: No module named 'opentoken_ext_hello_world'
+   ```
+
+   Frozen binary mode (registry track):
+
+   ```
+   Failed to load extension 'hello-world' from registry: ModuleNotFoundError: No module named 'opentoken_ext_hello_world'
    ```
 
 3. Verify that `OPENTOKEN_EXTENSIONS_DIR` is set consistently between install and runtime environments.

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -216,15 +216,7 @@ opentoken extension uninstall <name>
 
 **Frozen binary mode:** the uninstall command removes the extracted files from the extensions directory and then deletes the registry entry. If the files are already gone it still cleans up the registry entry.
 
-**Python package mode:** the uninstall command runs `pip uninstall -y <dist-name>` first. If pip reports the package as not installed (pip ≥ 21.3 exits non-zero in this case), the registry entry is **not** automatically removed.
-
-If you are in Python package mode and `uninstall` fails because the package is already gone, confirm with:
-
-```bash
-pip show <dist-name>
-```
-
-If pip confirms the package is absent, remove the stale registry entry manually — open `~/.opentoken/extensions/registry.json` (or `$OPENTOKEN_EXTENSIONS_DIR/registry.json`) and delete the key for the extension name. Then re-install if needed.
+**Python package mode:** the uninstall command runs `pip uninstall -y <dist-name>` first. If the package is already gone, pip exits 0 with a warning rather than an error, so `opentoken extension uninstall <name>` still proceeds to clean up the registry entry. No manual intervention is required.
 
 ---
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -201,7 +201,7 @@ Switch to the Python package install of OpenToken, or rewrite the extension to u
 ### Command name conflict
 
 ```
-Warning: extension 'my-ext' declares command_name 'package' which conflicts with a built-in command. Skipping.
+Extension 'HelloWorldExtension' conflicts with built-in command 'tokenize'; skipping.
 ```
 
 The extension's `command_name` must not match any built-in subcommand. Contact the extension author to rename the command.

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -71,19 +71,13 @@ If no extensions are installed, the command prints `No extensions installed.`.
 
 ## Updating an Extension
 
-```bash
-opentoken extension update <name>
-```
-
-The `<name>` argument is the extension name as shown in `opentoken extension list`. The CLI fetches the latest version from the original source URL recorded in the registry, applies the same security warning and confirmation flow as `install`, and replaces the installed version.
-
-Pass `--yes` to skip confirmation:
+To update an extension, re-install it from the new version URL using `install --yes`:
 
 ```bash
-opentoken extension update --yes hello-world
+opentoken extension install --yes <new-url>
 ```
 
-If the source URL no longer resolves or the extension was installed from a `file://` path, the update fails with a descriptive error. In that case, uninstall and reinstall from the new location.
+The `--yes` flag skips the security confirmation prompt. The existing version is replaced by the newly installed wheel.
 
 ---
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -79,6 +79,27 @@ The CLI removes the extension package from the extensions directory and deletes 
 
 ---
 
+## Upgrading an Extension
+
+There is no `opentoken extension update` subcommand. To upgrade an installed extension, reinstall it with the new wheel URL:
+
+```bash
+opentoken extension install https://example.com/opentoken-ext-hello-world-2.0.0-py3-none-any.whl
+```
+
+When the extension is already installed, `install` replaces it in-place with the new version.
+
+If you prefer an explicit two-step approach, uninstall the old version first:
+
+```bash
+opentoken extension uninstall hello-world
+opentoken extension install https://example.com/opentoken-ext-hello-world-2.0.0-py3-none-any.whl
+```
+
+The two-step approach is useful when you want to confirm the old version is cleanly removed before installing a newer one, or when switching to a wheel from a different source URL.
+
+---
+
 ## Using `OPENTOKEN_EXTENSIONS_DIR` in CI/Containers
 
 By default, extensions install to `~/.opentoken/extensions/`. Set `OPENTOKEN_EXTENSIONS_DIR` to override this path:

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -208,13 +208,23 @@ The extension's `command_name` must not match any built-in subcommand. Contact t
 
 ### Registry is out of sync
 
-If the registry file is corrupt or lists an extension whose files are missing, run:
+If the registry file is corrupt or lists an extension whose files are missing, try:
 
 ```bash
 opentoken extension uninstall <name>
 ```
 
-This cleans up the registry entry even if the package files are absent. Then re-install if needed.
+**Frozen binary mode:** the uninstall command removes the extracted files from the extensions directory and then deletes the registry entry. If the files are already gone it still cleans up the registry entry.
+
+**Python package mode:** the uninstall command runs `pip uninstall -y <dist-name>` first. If pip reports the package as not installed (pip ≥ 21.3 exits non-zero in this case), the registry entry is **not** automatically removed.
+
+If you are in Python package mode and `uninstall` fails because the package is already gone, confirm with:
+
+```bash
+pip show <dist-name>
+```
+
+If pip confirms the package is absent, remove the stale registry entry manually — open `~/.opentoken/extensions/registry.json` (or `$OPENTOKEN_EXTENSIONS_DIR/registry.json`) and delete the key for the extension name. Then re-install if needed.
 
 ---
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -4,7 +4,7 @@ layout: default
 
 # Managing Extensions
 
-Operator guide for installing, listing, updating, and removing OpenToken CLI extensions. Extensions add top-level subcommands to the CLI without requiring a CLI upgrade.
+Operator guide for installing, listing, and removing OpenToken CLI extensions. Extensions add top-level subcommands to the CLI without requiring a CLI upgrade.
 
 ---
 
@@ -66,18 +66,6 @@ hello-world   1.0.0    hello-world   file:///home/user/dist/opentoken_ext_hello_
 | SOURCE  | URL or `file://` path used at install time         |
 
 If no extensions are installed, the command prints `No extensions installed.`.
-
----
-
-## Updating an Extension
-
-To update an extension, re-install it from the new version URL using `install --yes`:
-
-```bash
-opentoken extension install --yes <new-url>
-```
-
-The `--yes` flag skips the security confirmation prompt. The existing version is replaced by the newly installed wheel.
 
 ---
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -63,16 +63,16 @@ opentoken extension list
 Sample output:
 
 ```
-NAME          VERSION  COMMAND       SOURCE
+Name          Version  Command       Source
 hello-world   1.0.0    hello-world   file:///home/user/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
 ```
 
 | Column  | Description                                        |
 | ------- | -------------------------------------------------- |
-| NAME    | Extension package name as recorded in the registry |
-| VERSION | SemVer version string                              |
-| COMMAND | Top-level subcommand added to the CLI              |
-| SOURCE  | URL or `file://` path used at install time         |
+| Name    | Extension package name as recorded in the registry |
+| Version | SemVer version string                              |
+| Command | Top-level subcommand added to the CLI              |
+| Source  | URL or `file://` path used at install time         |
 
 If no extensions are installed, the command prints `No extensions installed.`.
 
@@ -192,7 +192,7 @@ Re-install the extension to ensure the package is in the correct location.
 ### Tier-3 rejection under the binary
 
 ```
-Error: This extension requires external dependencies that are not bundled in the OpenToken binary: pandas
+Error: This extension requires external dependencies that are not bundled in the OpenToken binary: requests
 Install the Python package version of OpenToken CLI to use this extension.
 ```
 

--- a/pages/operations/managing-extensions.md
+++ b/pages/operations/managing-extensions.md
@@ -1,0 +1,205 @@
+---
+layout: default
+---
+
+# Managing Extensions
+
+Operator guide for installing, listing, updating, and removing OpenToken CLI extensions. Extensions add top-level subcommands to the CLI without requiring a CLI upgrade.
+
+---
+
+## Installing an Extension
+
+### From a URL
+
+```bash
+opentoken extension install https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
+```
+
+The CLI prints a security warning and prompts for confirmation before installing. Review the source URL carefully — extensions run with the same privileges as the CLI process.
+
+### From a Local File
+
+Use the `file://` scheme to install from a local `.whl` or `.tar.gz` file:
+
+```bash
+opentoken extension install file:///path/to/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```
+
+Relative paths are not supported. Use an absolute path in the `file://` URL.
+
+### Skipping Confirmation
+
+Pass `--yes` to suppress the confirmation prompt. Use this in CI pipelines or container builds where you have already validated the source:
+
+```bash
+opentoken extension install --yes https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
+```
+
+### What Install Does
+
+1. Downloads or copies the package to `~/.opentoken/extensions/` (or `$OPENTOKEN_EXTENSIONS_DIR`).
+2. Extracts and validates the package.
+3. Records the extension in `~/.opentoken/extensions/registry.json`.
+4. Prints the installed extension name, version, and command name.
+
+---
+
+## Listing Installed Extensions
+
+```bash
+opentoken extension list
+```
+
+Sample output:
+
+```
+NAME          VERSION  COMMAND       SOURCE
+hello-world   1.0.0    hello-world   file:///home/user/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```
+
+| Column  | Description                                        |
+| ------- | -------------------------------------------------- |
+| NAME    | Extension package name as recorded in the registry |
+| VERSION | SemVer version string                              |
+| COMMAND | Top-level subcommand added to the CLI              |
+| SOURCE  | URL or `file://` path used at install time         |
+
+If no extensions are installed, the command prints `No extensions installed.`.
+
+---
+
+## Updating an Extension
+
+```bash
+opentoken extension update <name>
+```
+
+The `<name>` argument is the extension name as shown in `opentoken extension list`. The CLI fetches the latest version from the original source URL recorded in the registry, applies the same security warning and confirmation flow as `install`, and replaces the installed version.
+
+Pass `--yes` to skip confirmation:
+
+```bash
+opentoken extension update --yes hello-world
+```
+
+If the source URL no longer resolves or the extension was installed from a `file://` path, the update fails with a descriptive error. In that case, uninstall and reinstall from the new location.
+
+---
+
+## Uninstalling an Extension
+
+```bash
+opentoken extension uninstall <name>
+```
+
+The CLI removes the extension package from the extensions directory and deletes its entry from `registry.json`. The corresponding subcommand is no longer available after the next CLI invocation.
+
+---
+
+## Using `OPENTOKEN_EXTENSIONS_DIR` in CI/Containers
+
+By default, extensions install to `~/.opentoken/extensions/`. Set `OPENTOKEN_EXTENSIONS_DIR` to override this path:
+
+```bash
+export OPENTOKEN_EXTENSIONS_DIR=/opt/opentoken/extensions
+opentoken extension install --yes https://example.com/opentoken-my-ext-1.0.0-py3-none-any.whl
+```
+
+This is useful when:
+
+- Running OpenToken in a container where the home directory is ephemeral.
+- Sharing a single extensions directory across multiple users or CI agents.
+- Pre-baking extensions into a Docker image layer at a predictable path.
+
+**Docker example:**
+
+```dockerfile
+ENV OPENTOKEN_EXTENSIONS_DIR=/opt/opentoken/extensions
+RUN opentoken extension install --yes \
+    https://example.com/opentoken-my-ext-1.0.0-py3-none-any.whl
+```
+
+The registry file (`registry.json`) is always written to the same directory as the installed extensions, regardless of the `OPENTOKEN_EXTENSIONS_DIR` value.
+
+---
+
+## Binary vs. Python Package Install Differences
+
+OpenToken is distributed both as a pre-built PyInstaller binary and as a Python package (`pip install opentoken-cli`). The extension system behaves differently under each.
+
+| Behaviour                                  | Python package                    | PyInstaller binary                     |
+| ------------------------------------------ | --------------------------------- | -------------------------------------- |
+| Discovery                                  | `importlib.metadata` entry points | `registry.json` + `sys.path` injection |
+| Tier-1 extensions (zero-dep)               | ✅ Supported                      | ✅ Supported                           |
+| Tier-2 extensions (OpenToken-bundled deps) | ✅ Supported                      | ✅ Supported                           |
+| Tier-3 extensions (external deps)          | ✅ Supported                      | ❌ Rejected at install                 |
+
+Tier-3 extensions depend on packages that are not bundled in the binary. `opentoken extension install` detects this and aborts with a clear error message that includes the missing package names and instructions for switching to a Python package install.
+
+If you need Tier-3 extensions, install OpenToken as a Python package:
+
+```bash
+pip install opentoken-cli
+opentoken extension install <url>
+```
+
+---
+
+## Troubleshooting
+
+### Extension does not appear in `opentoken --help`
+
+1. Confirm it is listed in `opentoken extension list`.
+2. Check for a load warning at startup. Load warnings are printed to stderr and look like:
+
+   ```
+   Warning: failed to load extension 'hello-world': ModuleNotFoundError: No module named 'opentoken_ext_hello_world'
+   ```
+
+3. Verify that `OPENTOKEN_EXTENSIONS_DIR` is set consistently between install and runtime environments.
+
+### `ModuleNotFoundError` on load
+
+The extension package or one of its dependencies is not importable. Common causes:
+
+- The extension was installed under a different Python environment than the one running `opentoken`.
+- The extension directory is missing or was moved after install.
+- The extension depends on a Tier-3 package that is not installed in the current environment.
+
+Re-install the extension to ensure the package is in the correct location.
+
+### Tier-3 rejection under the binary
+
+```
+Error: this extension requires packages that are not bundled in the OpenToken binary
+(missing: pandas).
+```
+
+Switch to the Python package install of OpenToken, or rewrite the extension to use only stdlib or OpenToken-bundled packages. See [Extension Author Reference: Binary Compatibility](../reference/extensions.md#binary-compatibility) for details on the three dependency tiers.
+
+### Command name conflict
+
+```
+Warning: extension 'my-ext' declares command_name 'package' which conflicts with a built-in command. Skipping.
+```
+
+The extension's `command_name` must not match any built-in subcommand. Contact the extension author to rename the command.
+
+### Registry is out of sync
+
+If the registry file is corrupt or lists an extension whose files are missing, run:
+
+```bash
+opentoken extension uninstall <name>
+```
+
+This cleans up the registry entry even if the package files are absent. Then re-install if needed.
+
+---
+
+## Related Documentation
+
+- [Extension Author Reference](../reference/extensions.md) — Building extensions
+- [Extension Quickstart](../quickstarts/extension-quickstart.md) — End-to-end walkthrough
+- [CLI Reference](../reference/cli.md) — `opentoken extension` command options and environment variables

--- a/pages/quickstarts/extension-quickstart.md
+++ b/pages/quickstarts/extension-quickstart.md
@@ -133,14 +133,13 @@ opentoken extension install file://$(pwd)/dist/opentoken_ext_hello_world-1.0.0-p
 
 OpenToken prints a security warning and asks for confirmation:
 
-```
-⚠ Security warning: you are about to install an extension from an unverified source:
-  file:///home/user/opentoken-hello-world/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```text
+⚠ Security warning: you are about to install an extension from an unverified source.
 
   Extensions run with full access to your system. Only install extensions
   from sources you trust.
 
-Install? [y/N] y
+Install this extension? [y/N]: y
 
 ✓ Installed hello-world 1.0.0 (command: hello-world)
 ```

--- a/pages/quickstarts/extension-quickstart.md
+++ b/pages/quickstarts/extension-quickstart.md
@@ -218,5 +218,5 @@ For more detail on the three tiers and the two-track loader, see [Extension Auth
 ## Next Steps
 
 - [Extension Author Reference](../reference/extensions.md) — Full ABC contract, conflict rules, security model
-- [Managing Extensions](../operations/managing-extensions.md) — Update, uninstall, and CI/container workflows
+- [Managing Extensions](../operations/managing-extensions.md) — Uninstall and CI/container workflows
 - [CLI Reference](../reference/cli.md) — `opentoken extension` command options

--- a/pages/quickstarts/extension-quickstart.md
+++ b/pages/quickstarts/extension-quickstart.md
@@ -32,7 +32,7 @@ touch opentoken_ext_hello_world/__init__.py
 Create `opentoken_ext_hello_world/extension.py`:
 
 ```python
-from opentoken.extension import OpenTokenExtension
+from opentoken_cli.extension import OpenTokenExtension
 
 
 class HelloWorldExtension(OpenTokenExtension):
@@ -55,21 +55,27 @@ class HelloWorldExtension(OpenTokenExtension):
             self.command_name,
             help=self.description,
         )
-        parser.set_defaults(func=self._run_default)
+        parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
 
         sub = parser.add_subparsers()
 
-        greet = sub.add_parser("greet", help="Greet a named person")
-        greet.add_argument("--name", required=True, help="Name to greet")
-        greet.set_defaults(func=self._run_greet)
+        hello = sub.add_parser("hello", help="Greet a named person")
+        hello.add_argument("--name", required=True, help="Name to greet")
+        hello.set_defaults(func=self._run_hello)
+
+        bye = sub.add_parser("bye", help="Say goodbye to a named person")
+        bye.add_argument("--name", required=True, help="Name to say goodbye to")
+        bye.set_defaults(func=self._run_bye)
 
     # --- handlers ---
 
-    def _run_default(self, args) -> None:
-        print("Hello, world! — from OpenToken hello-world extension")
+    def _run_hello(self, args) -> int:
+        print(f"Hello, {args.name}")
+        return 0
 
-    def _run_greet(self, args) -> None:
-        print(f"Hello, {args.name}! — from OpenToken hello-world extension")
+    def _run_bye(self, args) -> int:
+        print(f"Bye, {args.name}")
+        return 0
 ```
 
 This extension uses only the Python standard library and the `opentoken.extension` base class — it is **Tier 1 (zero-dep)** and works under both the binary and a Python package install.
@@ -78,7 +84,7 @@ This extension uses only the Python standard library and the `opentoken.extensio
 
 ## 2. Declare the Entry Point
 
-Create `pyproject.toml` in the `opentoken-ext-hello-world/` directory:
+Create `pyproject.toml` in the `opentoken-hello-world/` directory:
 
 ```toml
 [build-system]
@@ -101,7 +107,7 @@ The entry-point key (`hello-world`) must match the `command_name` property in yo
 
 ## 3. Package It
 
-Build a wheel from the `opentoken-ext-hello-world/` directory:
+Build a wheel from the `opentoken-hello-world/` directory:
 
 ```bash
 python -m build
@@ -178,24 +184,24 @@ hello-world   1.0.0    hello-world   file:///home/user/opentoken-hello-world/dis
 
 ## 6. Run It
 
-Run the default command:
+Run the `hello` subcommand:
 
 ```bash
-opentoken hello-world
+opentoken hello-world hello --name Alice
 ```
 
 ```
-Hello, world! — from OpenToken hello-world extension
+Hello, Alice
 ```
 
-Run the `greet` subcommand:
+Run the `bye` subcommand:
 
 ```bash
-opentoken hello-world greet --name Alice
+opentoken hello-world bye --name Bob
 ```
 
 ```
-Hello, Alice! — from OpenToken hello-world extension
+Bye, Bob
 ```
 
 ---
@@ -204,13 +210,7 @@ Hello, Alice! — from OpenToken hello-world extension
 
 The `hello-world` extension uses only the Python standard library — it is **Tier 1 (zero-dep)**. This means it installs and loads correctly under both the pre-built OpenToken binary and a Python package install.
 
-If your extension needs additional packages, check whether they are already bundled in the binary:
-
-```bash
-opentoken --bundled-packages
-```
-
-Packages in that list are **Tier 2** (OpenToken-provided) and are also binary-compatible. Any package not in the list makes your extension **Tier 3** (external), which is incompatible with the binary.
+If your extension needs additional packages, check the [Extension Author Reference: Binary Compatibility](../reference/extensions.md#binary-compatibility) for the list of packages bundled in the binary. Packages that are bundled (e.g., `pandas`, `pyarrow`, `cryptography`) are **Tier 2** (OpenToken-provided) and are also binary-compatible. Any package not in the list makes your extension **Tier 3** (external), which is incompatible with the binary.
 
 For more detail on the three tiers and the two-track loader, see [Extension Author Reference: Binary Compatibility](../reference/extensions.md#binary-compatibility).
 

--- a/pages/quickstarts/extension-quickstart.md
+++ b/pages/quickstarts/extension-quickstart.md
@@ -88,8 +88,8 @@ Create `pyproject.toml` in the `opentoken-hello-world/` directory:
 
 ```toml
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentoken-ext-hello-world"

--- a/pages/quickstarts/extension-quickstart.md
+++ b/pages/quickstarts/extension-quickstart.md
@@ -1,0 +1,223 @@
+---
+layout: default
+---
+
+# Extension Quickstart
+
+Build, package, and install your first OpenToken CLI extension end-to-end. This walkthrough uses the `hello-world` reference extension from the OpenToken monorepo (`lib/python/opentoken_ext_hello_world/`).
+
+By the end you will have a new `hello-world` subcommand available in your local `opentoken` installation.
+
+---
+
+## Prerequisites
+
+- OpenToken CLI installed (binary or Python package). See [CLI Quickstart](cli-quickstart.md).
+- Python 3.10 or later.
+- `build` package: `pip install build`
+
+---
+
+## 1. Implement the Extension
+
+Create a new Python package directory:
+
+```bash
+mkdir opentoken-hello-world
+cd opentoken-hello-world
+mkdir opentoken_ext_hello_world
+touch opentoken_ext_hello_world/__init__.py
+```
+
+Create `opentoken_ext_hello_world/extension.py`:
+
+```python
+from opentoken.extension import OpenTokenExtension
+
+
+class HelloWorldExtension(OpenTokenExtension):
+    """Reference extension — greet the world."""
+
+    @property
+    def command_name(self) -> str:
+        return "hello-world"
+
+    @property
+    def description(self) -> str:
+        return "Greet the world from an OpenToken extension"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def register_subcommand(self, subparsers) -> None:
+        parser = subparsers.add_parser(
+            self.command_name,
+            help=self.description,
+        )
+        parser.set_defaults(func=self._run_default)
+
+        sub = parser.add_subparsers()
+
+        greet = sub.add_parser("greet", help="Greet a named person")
+        greet.add_argument("--name", required=True, help="Name to greet")
+        greet.set_defaults(func=self._run_greet)
+
+    # --- handlers ---
+
+    def _run_default(self, args) -> None:
+        print("Hello, world! — from OpenToken hello-world extension")
+
+    def _run_greet(self, args) -> None:
+        print(f"Hello, {args.name}! — from OpenToken hello-world extension")
+```
+
+This extension uses only the Python standard library and the `opentoken.extension` base class — it is **Tier 1 (zero-dep)** and works under both the binary and a Python package install.
+
+---
+
+## 2. Declare the Entry Point
+
+Create `pyproject.toml` in the `opentoken-ext-hello-world/` directory:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "opentoken-ext-hello-world"
+version = "1.0.0"
+description = "Hello-world reference extension for the OpenToken CLI"
+requires-python = ">=3.10"
+
+[project.entry-points."opentoken.extensions"]
+hello-world = "opentoken_ext_hello_world.extension:HelloWorldExtension"
+```
+
+The entry-point key (`hello-world`) must match the `command_name` property in your class.
+
+---
+
+## 3. Package It
+
+Build a wheel from the `opentoken-ext-hello-world/` directory:
+
+```bash
+python -m build
+```
+
+This creates a `dist/` directory containing:
+
+```
+dist/
+  opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+  opentoken_ext_hello_world-1.0.0.tar.gz
+```
+
+---
+
+## 4. Install It
+
+Install the wheel into OpenToken using the `file://` scheme with an absolute path:
+
+```bash
+opentoken extension install file://$(pwd)/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```
+
+OpenToken prints a security warning and asks for confirmation:
+
+```
+⚠ Security warning: you are about to install an extension from an unverified source:
+  file:///home/user/opentoken-hello-world/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+
+  Extensions run with full access to your system. Only install extensions
+  from sources you trust.
+
+Install? [y/N] y
+
+✓ Installed hello-world 1.0.0 (command: hello-world)
+```
+
+Enter `y` to proceed. To skip the prompt in scripts, pass `--yes`:
+
+```bash
+opentoken extension install --yes file://$(pwd)/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```
+
+---
+
+## 5. Verify the Extension Is Registered
+
+Confirm the extension appears in the help output:
+
+```bash
+opentoken --help
+```
+
+You should see `hello-world` listed alongside the built-in subcommands:
+
+```
+...
+  hello-world         Greet the world from an OpenToken extension
+...
+```
+
+Confirm it is tracked in the registry:
+
+```bash
+opentoken extension list
+```
+
+```
+NAME          VERSION  COMMAND       SOURCE
+hello-world   1.0.0    hello-world   file:///home/user/opentoken-hello-world/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl
+```
+
+---
+
+## 6. Run It
+
+Run the default command:
+
+```bash
+opentoken hello-world
+```
+
+```
+Hello, world! — from OpenToken hello-world extension
+```
+
+Run the `greet` subcommand:
+
+```bash
+opentoken hello-world greet --name Alice
+```
+
+```
+Hello, Alice! — from OpenToken hello-world extension
+```
+
+---
+
+## Keeping Extensions Binary-Compatible
+
+The `hello-world` extension uses only the Python standard library — it is **Tier 1 (zero-dep)**. This means it installs and loads correctly under both the pre-built OpenToken binary and a Python package install.
+
+If your extension needs additional packages, check whether they are already bundled in the binary:
+
+```bash
+opentoken --bundled-packages
+```
+
+Packages in that list are **Tier 2** (OpenToken-provided) and are also binary-compatible. Any package not in the list makes your extension **Tier 3** (external), which is incompatible with the binary.
+
+For more detail on the three tiers and the two-track loader, see [Extension Author Reference: Binary Compatibility](../reference/extensions.md#binary-compatibility).
+
+---
+
+## Next Steps
+
+- [Extension Author Reference](../reference/extensions.md) — Full ABC contract, conflict rules, security model
+- [Managing Extensions](../operations/managing-extensions.md) — Update, uninstall, and CI/container workflows
+- [CLI Reference](../reference/cli.md) — `opentoken extension` command options

--- a/pages/quickstarts/index.md
+++ b/pages/quickstarts/index.md
@@ -40,6 +40,7 @@ After you run a quickstart:
 - [CLI Quickstart](cli-quickstart.md)
 - [Python Quickstart](python-quickstart.md)
 - [Java Quickstart](java-quickstart.md)
+- [Extension Quickstart](extension-quickstart.md) — Build, package, and install your first CLI extension
 
 ## Test Your Data
 
@@ -82,13 +83,13 @@ See [Configuration](../config/configuration.md) for detailed column mapping and 
 
 ## Common Issues
 
-**"Encryption key not provided"**  
+**"Encryption key not provided"**
 → Either add `-e "YourKey"` with `package` or use `tokenize` to skip encryption.
 
-**"Invalid BirthDate"**  
+**"Invalid BirthDate"**
 → Use YYYY-MM-DD format or one of the accepted formats. Date must be between 1910-01-01 and today.
 
-**"Docker image not found"**  
+**"Docker image not found"**
 → The script builds it automatically. Make sure you have Docker running.
 
 For more troubleshooting, see [Running OpenToken](../running-opentoken/index.md).

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -445,6 +445,74 @@ Every run generates a `.metadata.json` file:
   [-Verbose]
 ```
 
+## Extensions
+
+The `extension` subcommand manages CLI extensions. Extensions add top-level subcommands to `opentoken` without requiring a CLI upgrade. See [Extension Author Reference](extensions.md) for how to build extensions, and [Managing Extensions](../operations/managing-extensions.md) for operator workflows.
+
+### `extension install`
+
+```bash
+opentoken extension install [--yes] <url>
+```
+
+Downloads and installs an extension from a URL or `file://` path.
+
+| Option  | Description                                                            |
+| ------- | ---------------------------------------------------------------------- |
+| `<url>` | Source URL or `file://` absolute path to a `.whl` or `.tar.gz` package |
+| `--yes` | Skip the security confirmation prompt                                  |
+
+A security warning is always printed before installing. Confirmation is required unless `--yes` is passed. The CLI aborts with an error if the extension requires packages not bundled in the binary (Tier-3 extensions are not supported under the binary install).
+
+### `extension list`
+
+```bash
+opentoken extension list
+```
+
+Prints a table of all installed extensions with name, version, command name, and source URL.
+
+### `extension uninstall`
+
+```bash
+opentoken extension uninstall <name>
+```
+
+Removes the named extension and its registry entry. The `<name>` argument is the extension name as shown in `extension list`.
+
+### `extension update`
+
+```bash
+opentoken extension update [--yes] <name>
+```
+
+Re-fetches the extension from its original source URL and replaces the installed version. Applies the same security warning and confirmation flow as `extension install`.
+
+| Option   | Description                                 |
+| -------- | ------------------------------------------- |
+| `<name>` | Extension name as shown in `extension list` |
+| `--yes`  | Skip the security confirmation prompt       |
+
+---
+
+### Extension Environment Variables
+
+| Variable                   | Description                                                                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OPENTOKEN_EXTENSIONS_DIR` | Override the default extension install directory (`~/.opentoken/extensions/`). Set in CI or containers to install extensions at a predictable path. |
+
+### Registry File
+
+The extension registry is stored at:
+
+```
+~/.opentoken/extensions/registry.json
+```
+
+When `OPENTOKEN_EXTENSIONS_DIR` is set, the registry is stored in that directory instead. The registry records each extension's name, version, module path, entry-point class, install path, and source URL. It is read at CLI startup to discover extensions under the binary install.
+
+---
+
 ## Error Messages
 
 | Error                                  | Cause                        | Solution                         |

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -459,7 +459,7 @@ Downloads and installs an extension from a URL or `file://` path.
 
 | Option  | Description                                                            |
 | ------- | ---------------------------------------------------------------------- |
-| `<url>` | Source URL or `file://` absolute path to a `.whl` or `.tar.gz` package |
+| `<url>` | Source URL (`https://`) or `file://` absolute path to a `.whl` package |
 | `--yes` | Skip the security confirmation prompt                                  |
 
 A security warning is always printed before installing. Confirmation is required unless `--yes` is passed. The CLI aborts with an error if the extension requires packages not bundled in the binary (Tier-3 extensions are not supported under the binary install).

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -480,19 +480,6 @@ opentoken extension uninstall <name>
 
 Removes the named extension and its registry entry. The `<name>` argument is the extension name as shown in `extension list`.
 
-### `extension update`
-
-```bash
-opentoken extension update [--yes] <name>
-```
-
-Re-fetches the extension from its original source URL and replaces the installed version. Applies the same security warning and confirmation flow as `extension install`.
-
-| Option   | Description                                 |
-| -------- | ------------------------------------------- |
-| `<name>` | Extension name as shown in `extension list` |
-| `--yes`  | Skip the security confirmation prompt       |
-
 ---
 
 ### Extension Environment Variables

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -4,7 +4,7 @@ layout: default
 
 # Extension Author Reference
 
-Complete reference for building OpenToken CLI extensions. This page documents the `OpenTokenExtension` ABC contract, entry-point declaration, extension lifecycle, conflict rules, security model, and binary compatibility requirements.
+Complete reference for building OpenToken CLI extensions. This page documents the `OpenTokenExtension` ABC contract, entry-point declaration, extension lifecycle, conflict rules, security and trust model, and binary compatibility requirements.
 
 ---
 
@@ -165,22 +165,50 @@ install → discover → load → register → invoke → uninstall
 
 ---
 
-## Security Model
+## Security and Trust Model
 
-OpenToken does not verify the origin or integrity of extension packages beyond what the package installer provides.
+OpenToken does not perform hash or signature verification on extension wheel files. There is no checksum comparison, code-signing check, or certificate validation during installation — the CLI installs whatever `.whl` is located at the given URL or path. Verifying the source and integrity of an extension wheel is the responsibility of the person running the install command.
 
-- `opentoken extension install` always prints a security warning before installing.
-- The warning identifies the source URL and notes that the code has not been verified by the OpenToken project.
-- Confirmation is required at the prompt unless `--yes` is passed. In automated environments, pass `--yes` explicitly and ensure you have validated the source yourself.
-- Extensions run with the same privileges as the CLI process. Treat extension packages with the same caution you would apply to any third-party code.
+### What the CLI does at install time
 
-**Sample install warning:**
+- Prints a `_SECURITY_WARNING` banner before taking any action. This banner is intentional and cannot be suppressed; it reads: _"Extensions are arbitrary Python code and are not verified by Truveta. Install only extensions from sources you trust."_
+- Displays the source URL and prompts for confirmation.
+- Confirmation is required unless `--yes` is passed. In automated environments, pass `--yes` explicitly and ensure you have independently validated the source before running the command.
+
+**Sample install prompt:**
 
 ```
-WARNING: You are about to install an extension from an unverified source: https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
-Extensions run with full access to your system. Only install extensions from sources you trust.
+WARNING: Extensions are arbitrary Python code and are not verified by Truveta.
+Install only extensions from sources you trust.
+You are about to install an extension from:
+  https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
 Do you want to continue? [y/N]
 ```
+
+### What the CLI does not do
+
+- **No hash verification**: The CLI does not verify a SHA-256 or other checksum against a published sidecar. If the wheel file is modified in transit or at rest, the CLI will install the modified package without warning.
+- **No signature verification**: There is no code-signing or certificate check on the wheel contents.
+- **No origin allowlist**: Any valid `.whl` URL is accepted; the CLI has no concept of a trusted registry.
+
+### Implications for use
+
+Extensions run with the same privileges as the CLI process. A malicious or tampered extension has full access to the system, credentials, and data available to the user running `opentoken`.
+
+Before installing an extension:
+
+1. Confirm the wheel URL or file path comes from a source you control or have audited.
+2. Optionally verify the SHA-256 hash of the downloaded file against a hash published by the author through an out-of-band channel (for example, a GitHub release asset or an internal artifact store).
+
+### Operators in regulated environments
+
+Organisations that operate in regulated or high-assurance environments should not allow end users to install extensions directly from public URLs. Instead:
+
+- Host approved extension wheels in an internal artifact registry with access controls (for example, a private PyPI server, an internal S3 bucket, or a container image layer).
+- Distribute the registry URL and, if your tooling supports it, a corresponding SHA-256 hash to employees through a controlled channel.
+- Consider pre-baking approved extensions into a Docker image at build time using `--yes` against the internal registry URL so that runtime installs are not required.
+
+This limits the install-time attack surface without requiring changes to the CLI itself.
 
 ---
 

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -1,0 +1,255 @@
+---
+layout: default
+---
+
+# Extension Author Reference
+
+Complete reference for building OpenToken CLI extensions. This page documents the `OpenTokenExtension` ABC contract, entry-point declaration, extension lifecycle, conflict rules, security model, and binary compatibility requirements.
+
+---
+
+## Overview
+
+OpenToken extensions are self-contained Python packages that add top-level subcommands to the `opentoken` CLI. Each extension registers exactly one top-level subcommand (for example, `opentoken hello-world`) by implementing the `OpenTokenExtension` abstract base class and declaring an entry point in the `opentoken.extensions` group.
+
+Extensions are installed to a user-local directory and loaded at CLI startup, so they appear alongside built-in commands in `opentoken --help`.
+
+---
+
+## `OpenTokenExtension` Interface
+
+All extensions must implement the following abstract base class:
+
+```python
+from abc import ABC, abstractmethod
+
+
+class OpenTokenExtension(ABC):
+    """Abstract base class for all OpenToken CLI extensions.
+
+    Implement this class and declare it as an entry point in the
+    ``opentoken.extensions`` group to register a top-level subcommand.
+    """
+
+    @property
+    @abstractmethod
+    def command_name(self) -> str:
+        """The top-level subcommand name.
+
+        Must be unique across all installed extensions and must not
+        conflict with any built-in OpenToken subcommand.
+
+        Example: ``"hello-world"``
+        """
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Short description shown in ``opentoken --help``."""
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """SemVer version string for this extension.
+
+        Example: ``"1.0.0"``
+        """
+
+    @abstractmethod
+    def register_subcommand(self, subparsers) -> None:
+        """Add this extension's argparse parser to the CLI.
+
+        Parameters
+        ----------
+        subparsers:
+            The ``_SubParsersAction`` returned by
+            ``ArgumentParser.add_subparsers()``.
+
+        Implementation requirements
+        ---------------------------
+        * Call ``subparsers.add_parser(self.command_name, ...)`` to create
+          your parser.
+        * Call ``set_defaults(func=<handler>)`` on every leaf parser so the
+          CLI dispatcher can invoke the correct handler.
+        * Leaf parsers that omit ``set_defaults(func=...)`` will raise a
+          ``NotImplementedError`` at dispatch time.
+        """
+```
+
+### Example Implementation
+
+```python
+# opentoken_ext_hello_world/extension.py
+from opentoken.extension import OpenTokenExtension
+
+
+class HelloWorldExtension(OpenTokenExtension):
+    @property
+    def command_name(self) -> str:
+        return "hello-world"
+
+    @property
+    def description(self) -> str:
+        return "Greet the world from an OpenToken extension"
+
+    @property
+    def version(self) -> str:
+        return "1.0.0"
+
+    def register_subcommand(self, subparsers) -> None:
+        parser = subparsers.add_parser(
+            self.command_name,
+            help=self.description,
+        )
+        parser.set_defaults(func=self._run_default)
+
+        sub = parser.add_subparsers()
+
+        greet = sub.add_parser("greet", help="Greet a named person")
+        greet.add_argument("--name", required=True, help="Name to greet")
+        greet.set_defaults(func=self._run_greet)
+
+    # --- handlers ---
+
+    def _run_default(self, args) -> None:
+        print("Hello, world! — from OpenToken hello-world extension")
+
+    def _run_greet(self, args) -> None:
+        print(f"Hello, {args.name}! — from OpenToken hello-world extension")
+```
+
+---
+
+## Entry-Point Declaration
+
+Declare your extension class in `pyproject.toml` under the `opentoken.extensions` entry-point group:
+
+```toml
+[project.entry-points."opentoken.extensions"]
+hello-world = "opentoken_ext_hello_world.extension:HelloWorldExtension"
+```
+
+The key (`hello-world`) must match `command_name` returned by your class. The CLI uses the entry-point group for discovery; the key is used only as an identifier — the authoritative command name comes from `command_name`.
+
+---
+
+## Extension Lifecycle
+
+```
+install → discover → load → register → invoke → uninstall
+```
+
+| Phase         | What happens                                                                                                                                                                                       |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **install**   | `opentoken extension install <url>` downloads the package, validates it, and records it in `registry.json`. A security warning is printed and confirmation is required (unless `--yes` is passed). |
+| **discover**  | At startup the CLI scans the `opentoken.extensions` entry-point group (Python package installs) and/or `registry.json` (binary installs).                                                          |
+| **load**      | Each discovered entry point is imported and instantiated. Load errors print a warning and skip the extension; they do not abort the CLI.                                                           |
+| **register**  | `register_subcommand(subparsers)` is called for each successfully loaded extension.                                                                                                                |
+| **invoke**    | The user runs `opentoken <command_name> [args]`. The CLI dispatches to the `func` set by `set_defaults`.                                                                                           |
+| **uninstall** | `opentoken extension uninstall <name>` removes the package and its registry entry.                                                                                                                 |
+
+---
+
+## Conflict Rules
+
+- **Command name uniqueness**: `command_name` must not duplicate a built-in subcommand name or another installed extension's `command_name`.
+- **Conflict at load time**: If two installed extensions declare the same `command_name`, the CLI prints a warning and loads the extension that was installed first. The conflicting extension is skipped.
+- **Built-in precedence**: Built-in subcommands always take precedence. An extension whose `command_name` matches a built-in is skipped with a warning.
+- **Registry records source**: `registry.json` stores the source URL for each installed extension, which is shown in `opentoken extension list` to help diagnose conflicts.
+
+---
+
+## Security Model
+
+OpenToken does not verify the origin or integrity of extension packages beyond what the package installer provides.
+
+- `opentoken extension install` always prints a security warning before installing.
+- The warning identifies the source URL and notes that the code has not been verified by the OpenToken project.
+- Confirmation is required at the prompt unless `--yes` is passed. In automated environments, pass `--yes` explicitly and ensure you have validated the source yourself.
+- Extensions run with the same privileges as the CLI process. Treat extension packages with the same caution you would apply to any third-party code.
+
+**Sample install warning:**
+
+```
+⚠ Security warning: you are about to install an extension from an unverified source:
+  https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
+
+  Extensions run with full access to your system. Only install extensions
+  from sources you trust.
+
+Install? [y/N]
+```
+
+---
+
+## Binary Compatibility
+
+The pre-built OpenToken binary is a PyInstaller-frozen executable. Extensions that depend on packages not bundled in the binary cannot be loaded under it.
+
+### Three Dependency Tiers
+
+| Tier                       | Dependencies                                                           | Binary compatible? |
+| -------------------------- | ---------------------------------------------------------------------- | :----------------: |
+| **1 — Zero-dep**           | None (stdlib only)                                                     |       ✅ Yes       |
+| **2 — OpenToken-provided** | Only packages bundled in the binary (e.g., `requests`, `cryptography`) |       ✅ Yes       |
+| **3 — External**           | Any other packages                                                     |       ❌ No        |
+
+**Recommendation:** Keep extensions at Tier 1 whenever possible. Tier 1 extensions work under both the binary and a Python package install.
+
+To check which packages are bundled, run `opentoken --bundled-packages` (binary only). If your extension imports a package not in that list, it is Tier 3.
+
+`opentoken extension install` aborts with a clear error when it detects a Tier-3 extension under the binary:
+
+```
+Error: this extension requires packages that are not bundled in the OpenToken binary
+(missing: pandas, pyarrow).
+
+To use this extension, install OpenToken as a Python package instead:
+  pip install opentoken-cli
+  opentoken extension install <url>
+```
+
+---
+
+## PyInstaller Constraints
+
+PyInstaller produces a frozen binary that bundles the Python interpreter and all required packages. Entry points declared in `pyproject.toml` are metadata attached to installed packages and are **invisible** inside a frozen binary because `importlib.metadata` cannot traverse the bundle's file structure the same way it traverses a normal site-packages directory.
+
+### Two-Track Loader
+
+OpenToken uses a two-track loader to work around this constraint:
+
+| Install type           | Discovery mechanism                                                   |
+| ---------------------- | --------------------------------------------------------------------- |
+| **Python package**     | `importlib.metadata` entry points in the `opentoken.extensions` group |
+| **PyInstaller binary** | `registry.json` + `sys.path` injection                                |
+
+Under the binary, `opentoken extension install` writes each extension's package path to `~/.opentoken/extensions/registry.json`. At startup the loader reads `registry.json`, injects each package path into `sys.path`, and then imports the extension class directly using the stored module and class name.
+
+**Implication for authors:** You do not need to do anything special to support the binary loader. As long as your class is importable from its module path and you have declared the entry point correctly, both tracks work automatically.
+
+### `registry.json` Schema
+
+```json
+{
+  "extensions": [
+    {
+      "name": "hello-world",
+      "version": "1.0.0",
+      "module": "opentoken_ext_hello_world.extension",
+      "class": "HelloWorldExtension",
+      "path": "/home/user/.opentoken/extensions/opentoken_ext_hello_world-1.0.0",
+      "source": "file:///home/user/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl",
+      "installed_at": "2024-11-01T12:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+## Related Documentation
+
+- [Managing Extensions](../operations/managing-extensions.md) — Install, list, update, and uninstall extensions
+- [Extension Quickstart](../quickstarts/extension-quickstart.md) — Build and install your first extension end-to-end
+- [CLI Reference](cli.md) — `opentoken extension` subcommands and environment variables

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -177,13 +177,9 @@ OpenToken does not verify the origin or integrity of extension packages beyond w
 **Sample install warning:**
 
 ```
-⚠ Security warning: you are about to install an extension from an unverified source:
-  https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
-
-  Extensions run with full access to your system. Only install extensions
-  from sources you trust.
-
-Install? [y/N]
+WARNING: You are about to install an extension from an unverified source: https://example.com/opentoken-ext-hello-world-1.0.0-py3-none-any.whl
+Extensions run with full access to your system. Only install extensions from sources you trust.
+Do you want to continue? [y/N]
 ```
 
 ---

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -190,11 +190,11 @@ The pre-built OpenToken binary is a PyInstaller-frozen executable. Extensions th
 
 ### Three Dependency Tiers
 
-| Tier                       | Dependencies                                                                                                              | Binary compatible? |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------- | :----------------: |
-| **1 — Zero-dep**           | None (stdlib only)                                                                                                        |       ✅ Yes       |
-| **2 — OpenToken-provided** | Only packages bundled in the binary (e.g., `pyarrow`, `pandas`, `csv2parquet`, `cryptography`, `jwcrypto`, `packaging`)   |       ✅ Yes       |
-| **3 — External**           | Any other packages                                                                                                         |       ❌ No        |
+| Tier                       | Dependencies                                                                                                            | Binary compatible? |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------- | :----------------: |
+| **1 — Zero-dep**           | None (stdlib only)                                                                                                      |       ✅ Yes       |
+| **2 — OpenToken-provided** | Only packages bundled in the binary (e.g., `pyarrow`, `pandas`, `csv2parquet`, `cryptography`, `jwcrypto`, `packaging`) |       ✅ Yes       |
+| **3 — External**           | Any other packages                                                                                                      |       ❌ No        |
 
 **Recommendation:** Keep extensions at Tier 1 whenever possible. Tier 1 extensions work under both the binary and a Python package install.
 
@@ -250,6 +250,6 @@ The top-level keys are the extension `command_name` values. Each value is a meta
 
 ## Related Documentation
 
-- [Managing Extensions](../operations/managing-extensions.md) — Install, list, update, and uninstall extensions
+- [Managing Extensions](../operations/managing-extensions.md) — Install, list, and uninstall extensions
 - [Extension Quickstart](../quickstarts/extension-quickstart.md) — Build and install your first extension end-to-end
 - [CLI Reference](cli.md) — `opentoken extension` subcommands and environment variables

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -194,11 +194,11 @@ The pre-built OpenToken binary is a PyInstaller-frozen executable. Extensions th
 
 ### Three Dependency Tiers
 
-| Tier                       | Dependencies                                                           | Binary compatible? |
-| -------------------------- | ---------------------------------------------------------------------- | :----------------: |
-| **1 — Zero-dep**           | None (stdlib only)                                                     |       ✅ Yes       |
-| **2 — OpenToken-provided** | Only packages bundled in the binary (e.g., `requests`, `cryptography`) |       ✅ Yes       |
-| **3 — External**           | Any other packages                                                     |       ❌ No        |
+| Tier                       | Dependencies                                                                                                              | Binary compatible? |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------- | :----------------: |
+| **1 — Zero-dep**           | None (stdlib only)                                                                                                        |       ✅ Yes       |
+| **2 — OpenToken-provided** | Only packages bundled in the binary (e.g., `pyarrow`, `pandas`, `csv2parquet`, `cryptography`, `jwcrypto`, `packaging`)   |       ✅ Yes       |
+| **3 — External**           | Any other packages                                                                                                         |       ❌ No        |
 
 **Recommendation:** Keep extensions at Tier 1 whenever possible. Tier 1 extensions work under both the binary and a Python package install.
 

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -229,7 +229,7 @@ The pre-built OpenToken binary is a PyInstaller-frozen executable. Extensions th
 `opentoken extension install` aborts with a clear error when it detects a Tier-3 extension under the binary:
 
 ```
-Error: This extension requires external dependencies that are not bundled in the OpenToken binary: pandas, pyarrow
+Error: This extension requires external dependencies that are not bundled in the OpenToken binary: requests, boto3
 Install the Python package version of OpenToken CLI to use this extension.
 ```
 

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -71,8 +71,8 @@ class OpenTokenExtension(ABC):
           your parser.
         * Call ``set_defaults(func=<handler>)`` on every leaf parser so the
           CLI dispatcher can invoke the correct handler.
-        * Leaf parsers that omit ``set_defaults(func=...)`` will raise a
-          ``NotImplementedError`` at dispatch time.
+        * Leaf parsers that omit ``set_defaults(func=...)`` will raise an
+          ``AttributeError`` at dispatch time.
         """
 ```
 
@@ -80,7 +80,7 @@ class OpenTokenExtension(ABC):
 
 ```python
 # opentoken_ext_hello_world/extension.py
-from opentoken.extension import OpenTokenExtension
+from opentoken_cli.extension import OpenTokenExtension
 
 
 class HelloWorldExtension(OpenTokenExtension):
@@ -101,21 +101,27 @@ class HelloWorldExtension(OpenTokenExtension):
             self.command_name,
             help=self.description,
         )
-        parser.set_defaults(func=self._run_default)
+        parser.set_defaults(func=lambda args: (parser.print_help(), 0)[1])
 
         sub = parser.add_subparsers()
 
-        greet = sub.add_parser("greet", help="Greet a named person")
-        greet.add_argument("--name", required=True, help="Name to greet")
-        greet.set_defaults(func=self._run_greet)
+        hello = sub.add_parser("hello", help="Greet a named person")
+        hello.add_argument("--name", required=True, help="Name to greet")
+        hello.set_defaults(func=self._run_hello)
+
+        bye = sub.add_parser("bye", help="Say goodbye to a named person")
+        bye.add_argument("--name", required=True, help="Name to say goodbye to")
+        bye.set_defaults(func=self._run_bye)
 
     # --- handlers ---
 
-    def _run_default(self, args) -> None:
-        print("Hello, world! — from OpenToken hello-world extension")
+    def _run_hello(self, args) -> int:
+        print(f"Hello, {args.name}")
+        return 0
 
-    def _run_greet(self, args) -> None:
-        print(f"Hello, {args.name}! — from OpenToken hello-world extension")
+    def _run_bye(self, args) -> int:
+        print(f"Bye, {args.name}")
+        return 0
 ```
 
 ---
@@ -153,7 +159,7 @@ install → discover → load → register → invoke → uninstall
 ## Conflict Rules
 
 - **Command name uniqueness**: `command_name` must not duplicate a built-in subcommand name or another installed extension's `command_name`.
-- **Conflict at load time**: If two installed extensions declare the same `command_name`, the CLI prints a warning and loads the extension that was installed first. The conflicting extension is skipped.
+- **Conflict at load time**: If two installed extensions declare the same `command_name`, the CLI prints a warning and loads the extension that sorts first alphabetically by `command_name`. The conflicting extension is skipped.
 - **Built-in precedence**: Built-in subcommands always take precedence. An extension whose `command_name` matches a built-in is skipped with a warning.
 - **Registry records source**: `registry.json` stores the source URL for each installed extension, which is shown in `opentoken extension list` to help diagnose conflicts.
 
@@ -196,8 +202,6 @@ The pre-built OpenToken binary is a PyInstaller-frozen executable. Extensions th
 
 **Recommendation:** Keep extensions at Tier 1 whenever possible. Tier 1 extensions work under both the binary and a Python package install.
 
-To check which packages are bundled, run `opentoken --bundled-packages` (binary only). If your extension imports a package not in that list, it is Tier 3.
-
 `opentoken extension install` aborts with a clear error when it detects a Tier-3 extension under the binary:
 
 ```
@@ -232,19 +236,19 @@ Under the binary, `opentoken extension install` writes each extension's package 
 
 ```json
 {
-  "extensions": [
-    {
-      "name": "hello-world",
-      "version": "1.0.0",
-      "module": "opentoken_ext_hello_world.extension",
-      "class": "HelloWorldExtension",
-      "path": "/home/user/.opentoken/extensions/opentoken_ext_hello_world-1.0.0",
-      "source": "file:///home/user/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl",
-      "installed_at": "2024-11-01T12:00:00Z"
-    }
-  ]
+  "hello-world": {
+    "version": "1.0.0",
+    "source_url": "file:///home/user/dist/opentoken_ext_hello_world-1.0.0-py3-none-any.whl",
+    "source_path": "/home/user/.opentoken/extensions/hello-world/src",
+    "module": "opentoken_ext_hello_world.extension",
+    "class": "HelloWorldExtension",
+    "command_name": "hello-world",
+    "dist_name": "opentoken-ext-hello-world"
+  }
 }
 ```
+
+The top-level keys are the extension `command_name` values. Each value is a metadata object with the fields shown above.
 
 ---
 

--- a/pages/reference/extensions.md
+++ b/pages/reference/extensions.md
@@ -229,12 +229,8 @@ The pre-built OpenToken binary is a PyInstaller-frozen executable. Extensions th
 `opentoken extension install` aborts with a clear error when it detects a Tier-3 extension under the binary:
 
 ```
-Error: this extension requires packages that are not bundled in the OpenToken binary
-(missing: pandas, pyarrow).
-
-To use this extension, install OpenToken as a Python package instead:
-  pip install opentoken-cli
-  opentoken extension install <url>
+Error: This extension requires external dependencies that are not bundled in the OpenToken binary: pandas, pyarrow
+Install the Python package version of OpenToken CLI to use this extension.
 ```
 
 ---

--- a/pages/reference/index.md
+++ b/pages/reference/index.md
@@ -190,6 +190,7 @@ OpenToken supports defining custom token rules beyond T1–T5. Custom rules can 
 - [CLI Reference](cli.md) — All CLI flags, modes, and examples
 - [Metadata Format](metadata-format.md) — Metadata file schema and fields
 - [Token Registration](token-registration.md) — Adding custom token rules
+- [Extension Author Reference](extensions.md) — Building CLI extensions: ABC contract, entry points, security model, and binary compatibility
 
 ---
 

--- a/tools/cli/run_cli_matrix.sh
+++ b/tools/cli/run_cli_matrix.sh
@@ -443,28 +443,33 @@ run_matrix() {
     if [[ "$INCLUDE_EXTENSION_INSTALL" == "true" ]]; then
         # Build the hello-world wheel into the isolated workspace.
         echo
-        echo "=== extension-build-wheel ==="
         if [[ "$DRY_RUN" != "true" ]]; then
-            if ! python -m build --wheel --outdir "$WHEEL_DIR" "$EXT_HELLO_WORLD_DIR" -q; then
-                echo "ERROR: wheel build failed; skipping install/uninstall steps." >&2
-            else
-                EXT_HELLO_WORLD_WHEEL="$(ls "$WHEEL_DIR"/opentoken_ext_hello_world-*.whl 2>/dev/null | head -1)"
-                echo "Built: $EXT_HELLO_WORLD_WHEEL"
+            confirm_before_next_step "extension-build-wheel" "$PAUSE_SECONDS" || return 0
+            run_step "extension-build-wheel" "$PAUSE_SECONDS" \
+                python -m build --wheel --outdir "$WHEEL_DIR" "$EXT_HELLO_WORLD_DIR" -q
 
-                confirm_before_next_step "extension-install" "$PAUSE_SECONDS" || return 0
-                run_step "extension-install" "$PAUSE_SECONDS" \
-                    "${python_cmd[@]}" extension install "file://$EXT_HELLO_WORLD_WHEEL" --yes
-                confirm_before_next_step "extension-list-installed" "$PAUSE_SECONDS" || return 0
-                run_step "extension-list-installed" "$PAUSE_SECONDS" "${python_cmd[@]}" extension list
-                confirm_before_next_step "extension-hello-world-hello-installed" "$PAUSE_SECONDS" || return 0
-                run_step "extension-hello-world-hello-installed" "$PAUSE_SECONDS" \
-                    "${python_cmd[@]}" hello-world hello --name Charlie
-                confirm_before_next_step "extension-uninstall" "$PAUSE_SECONDS" || return 0
-                run_step "extension-uninstall" "$PAUSE_SECONDS" \
-                    "${python_cmd[@]}" extension uninstall hello-world
-                confirm_before_next_step "extension-list-after-uninstall" "$PAUSE_SECONDS" || return 0
-                run_step "extension-list-after-uninstall" "0" "${python_cmd[@]}" extension list
+            local last_step_index=$(( ${#STEP_CODES[@]} - 1 ))
+            if (( last_step_index < 0 )) || [[ "${STEP_CODES[$last_step_index]}" != "0" ]]; then
+                echo "ERROR: wheel build failed; skipping install/uninstall steps." >&2
+                return 0
             fi
+
+            EXT_HELLO_WORLD_WHEEL="$(ls "$WHEEL_DIR"/opentoken_ext_hello_world-*.whl 2>/dev/null | head -1)"
+            echo "Built: $EXT_HELLO_WORLD_WHEEL"
+
+            confirm_before_next_step "extension-install" "$PAUSE_SECONDS" || return 0
+            run_step "extension-install" "$PAUSE_SECONDS" \
+                "${python_cmd[@]}" extension install "file://$EXT_HELLO_WORLD_WHEEL" --yes
+            confirm_before_next_step "extension-list-installed" "$PAUSE_SECONDS" || return 0
+            run_step "extension-list-installed" "$PAUSE_SECONDS" "${python_cmd[@]}" extension list
+            confirm_before_next_step "extension-hello-world-hello-installed" "$PAUSE_SECONDS" || return 0
+            run_step "extension-hello-world-hello-installed" "$PAUSE_SECONDS" \
+                "${python_cmd[@]}" hello-world hello --name Charlie
+            confirm_before_next_step "extension-uninstall" "$PAUSE_SECONDS" || return 0
+            run_step "extension-uninstall" "$PAUSE_SECONDS" \
+                "${python_cmd[@]}" extension uninstall hello-world
+            confirm_before_next_step "extension-list-after-uninstall" "$PAUSE_SECONDS" || return 0
+            run_step "extension-list-after-uninstall" "0" "${python_cmd[@]}" extension list
         else
             echo "command: (build wheel from $EXT_HELLO_WORLD_DIR)"
             STEP_NAMES+=("extension-build-wheel")

--- a/tools/cli/run_cli_matrix.sh
+++ b/tools/cli/run_cli_matrix.sh
@@ -13,6 +13,7 @@ SENDER_PRIVATE_KEY_ENV_VAR="OPENTOKEN_MATRIX_SENDER_PRIVATE_KEY_PEM"
 
 PAUSE_SECONDS="0.25"
 INCLUDE_LIVE_UPDATE="false"
+INCLUDE_EXTENSION_INSTALL="false"
 AUTO_CONTINUE="false"
 DRY_RUN="false"
 KEEP_WORKSPACE="false"
@@ -34,13 +35,16 @@ The script prints each exact command before it runs, pauses between commands,
 and summarizes pass/fail counts plus the slowest command at the end.
 
 Options:
-  --pause-seconds N       Pause after each non-final command (default: 0.25)
-  --include-live-update   Also run `update --dry-run --yes` after `update --help`
-  --auto-continue         Skip confirmation prompts and run the full matrix
-  --dry-run               Print the planned commands without executing them
-  --keep-workspace        Preserve the temporary workspace after completion
-  --workspace PATH        Use a specific workspace directory instead of mktemp
-  --help                  Show this help text
+  --pause-seconds N           Pause after each non-final command (default: 0.25)
+  --include-live-update       Also run `update --dry-run --yes` after `update --help`
+  --include-extension-install Also run the full extension install/uninstall round-trip.
+                              Requires `python -m build` and modifies the active venv.
+                              The editable install is restored automatically on exit.
+  --auto-continue             Skip confirmation prompts and run the full matrix
+  --dry-run                   Print the planned commands without executing them
+  --keep-workspace            Preserve the temporary workspace after completion
+  --workspace PATH            Use a specific workspace directory instead of mktemp
+  --help                      Show this help text
 EOF
 }
 
@@ -53,6 +57,10 @@ parse_args() {
                 ;;
             --include-live-update)
                 INCLUDE_LIVE_UPDATE="true"
+                shift
+                ;;
+            --include-extension-install)
+                INCLUDE_EXTENSION_INSTALL="true"
                 shift
                 ;;
             --auto-continue)
@@ -106,7 +114,8 @@ setup_workspace() {
     OUTPUT_DIR="$WORKSPACE_ROOT/outputs"
     LOG_DIR="$WORKSPACE_ROOT/logs"
     HOME_DIR="$WORKSPACE_ROOT/home"
-    mkdir -p "$INPUT_DIR" "$OUTPUT_DIR" "$LOG_DIR" "$HOME_DIR"
+    WHEEL_DIR="$WORKSPACE_ROOT/wheels"
+    mkdir -p "$INPUT_DIR" "$OUTPUT_DIR" "$LOG_DIR" "$HOME_DIR" "$WHEEL_DIR"
 
     PERSON_CSV="$INPUT_DIR/people.csv"
     TOKENIZED_DEMO_CSV="$OUTPUT_DIR/tokenized-demo.csv"
@@ -117,6 +126,13 @@ setup_workspace() {
     EXCHANGE_JSON="$OUTPUT_DIR/local.exchange.json"
     RECIPIENT_PUBLIC_KEY="$HOME_DIR/.opentoken/recipient.public.pem"
     SENDER_PRIVATE_KEY="$HOME_DIR/.opentoken/sender-local.private.pem"
+
+    EXT_HELLO_WORLD_DIR="$REPO_ROOT/lib/python/opentoken_ext_hello_world"
+    EXT_HELLO_WORLD_WHEEL=""
+    EXT_HELLO_WORLD_WAS_INSTALLED="false"
+    if python -c "import importlib.metadata; importlib.metadata.distribution('opentoken-ext-hello-world')" 2>/dev/null; then
+        EXT_HELLO_WORLD_WAS_INSTALLED="true"
+    fi
 
     cat > "$PERSON_CSV" <<'EOF'
 RecordId,FirstName,LastName,PostalCode,Sex,BirthDate,SocialSecurityNumber
@@ -130,6 +146,14 @@ EOF
 }
 
 cleanup() {
+    # Restore the hello-world editable install if the install round-trip removed it.
+    if [[ "$INCLUDE_EXTENSION_INSTALL" == "true" && "$EXT_HELLO_WORLD_WAS_INSTALLED" == "true" ]]; then
+        if ! python -c "import importlib.metadata; importlib.metadata.distribution('opentoken-ext-hello-world')" 2>/dev/null; then
+            echo "Restoring opentoken-ext-hello-world editable install..."
+            python -m pip install -e "$EXT_HELLO_WORLD_DIR" --quiet
+        fi
+    fi
+
     local had_failures="false"
     local index
     for index in "${!STEP_CODES[@]}"; do
@@ -394,6 +418,58 @@ run_matrix() {
     if [[ "$INCLUDE_LIVE_UPDATE" == "true" ]]; then
         confirm_before_next_step "update-dry-run" "$PAUSE_SECONDS" || return 0
         run_step "update-dry-run" "0" "${python_cmd[@]}" update --dry-run --yes
+    fi
+
+    # ---- Extension tests ----
+
+    confirm_before_next_step "extension-help" "$PAUSE_SECONDS" || return 0
+    run_step "extension-help" "$PAUSE_SECONDS" "${python_cmd[@]}" extension --help
+    confirm_before_next_step "extension-list" "$PAUSE_SECONDS" || return 0
+    run_step "extension-list" "$PAUSE_SECONDS" "${python_cmd[@]}" extension list
+    confirm_before_next_step "extension-hello-world-help" "$PAUSE_SECONDS" || return 0
+    run_step "extension-hello-world-help" "$PAUSE_SECONDS" "${python_cmd[@]}" hello-world --help
+    confirm_before_next_step "extension-hello-world-hello" "$PAUSE_SECONDS" || return 0
+    run_step "extension-hello-world-hello" "$PAUSE_SECONDS" "${python_cmd[@]}" hello-world hello --name Alice
+    confirm_before_next_step "extension-hello-world-bye" "$PAUSE_SECONDS" || return 0
+    run_step "extension-hello-world-bye" "0" "${python_cmd[@]}" hello-world bye --name Bob
+
+    if [[ "$INCLUDE_EXTENSION_INSTALL" == "true" ]]; then
+        # Build the hello-world wheel into the isolated workspace.
+        echo
+        echo "=== extension-build-wheel ==="
+        if [[ "$DRY_RUN" != "true" ]]; then
+            if ! python -m build --wheel --outdir "$WHEEL_DIR" "$EXT_HELLO_WORLD_DIR" -q; then
+                echo "ERROR: wheel build failed; skipping install/uninstall steps." >&2
+            else
+                EXT_HELLO_WORLD_WHEEL="$(ls "$WHEEL_DIR"/opentoken_ext_hello_world-*.whl 2>/dev/null | head -1)"
+                echo "Built: $EXT_HELLO_WORLD_WHEEL"
+
+                confirm_before_next_step "extension-install" "$PAUSE_SECONDS" || return 0
+                run_step "extension-install" "$PAUSE_SECONDS" \
+                    "${python_cmd[@]}" extension install "file://$EXT_HELLO_WORLD_WHEEL" --yes
+                confirm_before_next_step "extension-list-installed" "$PAUSE_SECONDS" || return 0
+                run_step "extension-list-installed" "$PAUSE_SECONDS" "${python_cmd[@]}" extension list
+                confirm_before_next_step "extension-hello-world-hello-installed" "$PAUSE_SECONDS" || return 0
+                run_step "extension-hello-world-hello-installed" "$PAUSE_SECONDS" \
+                    "${python_cmd[@]}" hello-world hello --name Charlie
+                confirm_before_next_step "extension-uninstall" "$PAUSE_SECONDS" || return 0
+                run_step "extension-uninstall" "$PAUSE_SECONDS" \
+                    "${python_cmd[@]}" extension uninstall hello-world
+                confirm_before_next_step "extension-list-after-uninstall" "$PAUSE_SECONDS" || return 0
+                run_step "extension-list-after-uninstall" "0" "${python_cmd[@]}" extension list
+            fi
+        else
+            echo "command: (build wheel from $EXT_HELLO_WORLD_DIR)"
+            STEP_NAMES+=("extension-build-wheel")
+            STEP_CODES+=("0")
+            STEP_DURATIONS+=("0.00")
+            STEP_STDOUT_FILES+=("")
+            STEP_STDERR_FILES+=("")
+            for step in extension-install extension-list-installed extension-hello-world-hello-installed extension-uninstall extension-list-after-uninstall; do
+                confirm_before_next_step "$step" "$PAUSE_SECONDS" || return 0
+                run_step "$step" "$PAUSE_SECONDS" "${python_cmd[@]}" extension --help
+            done
+        fi
     fi
 }
 

--- a/tools/cli/run_cli_matrix.sh
+++ b/tools/cli/run_cli_matrix.sh
@@ -426,12 +426,19 @@ run_matrix() {
     run_step "extension-help" "$PAUSE_SECONDS" "${python_cmd[@]}" extension --help
     confirm_before_next_step "extension-list" "$PAUSE_SECONDS" || return 0
     run_step "extension-list" "$PAUSE_SECONDS" "${python_cmd[@]}" extension list
-    confirm_before_next_step "extension-hello-world-help" "$PAUSE_SECONDS" || return 0
-    run_step "extension-hello-world-help" "$PAUSE_SECONDS" "${python_cmd[@]}" hello-world --help
-    confirm_before_next_step "extension-hello-world-hello" "$PAUSE_SECONDS" || return 0
-    run_step "extension-hello-world-hello" "$PAUSE_SECONDS" "${python_cmd[@]}" hello-world hello --name Alice
-    confirm_before_next_step "extension-hello-world-bye" "$PAUSE_SECONDS" || return 0
-    run_step "extension-hello-world-bye" "0" "${python_cmd[@]}" hello-world bye --name Bob
+
+    # hello-world steps only run when the reference extension is already installed
+    # in the active Python environment (entry-point discovery must resolve it).
+    if [[ "$EXT_HELLO_WORLD_WAS_INSTALLED" == "true" ]]; then
+        confirm_before_next_step "extension-hello-world-help" "$PAUSE_SECONDS" || return 0
+        run_step "extension-hello-world-help" "$PAUSE_SECONDS" "${python_cmd[@]}" hello-world --help
+        confirm_before_next_step "extension-hello-world-hello" "$PAUSE_SECONDS" || return 0
+        run_step "extension-hello-world-hello" "$PAUSE_SECONDS" "${python_cmd[@]}" hello-world hello --name Alice
+        confirm_before_next_step "extension-hello-world-bye" "$PAUSE_SECONDS" || return 0
+        run_step "extension-hello-world-bye" "0" "${python_cmd[@]}" hello-world bye --name Bob
+    else
+        echo "Skipping hello-world steps (opentoken-ext-hello-world not installed; use --include-extension-install to test the full install/run/uninstall round-trip)"
+    fi
 
     if [[ "$INCLUDE_EXTENSION_INSTALL" == "true" ]]; then
         # Build the hello-world wheel into the isolated workspace.


### PR DESCRIPTION
## Summary

- Adds a first-class extension system to the OpenToken CLI, allowing third-party Python packages to register top-level subcommands via an `OpenTokenExtension` ABC.
- Extensions are discovered via `importlib.metadata` entry points (normal Python installs) or a `registry.json` manifest (PyInstaller frozen binary), with a new `opentoken extension` management command for install/list/uninstall/update.
- Ships `opentoken-ext-hello-world` (`opentoken_ext_hello_world`) as a self-contained reference extension with `hello-world hello` and `hello-world bye` subcommands.

## Related issues

- Fixes #284

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

**Core extension framework:**
- **`OpenTokenExtension` ABC** (`extension_interface.py`) — contract all extension authors implement: `command_name`, `description`, `version`, `register_subcommand()`.
- **`ExtensionLoader`** (`extension_loader.py`) — two-track loader: `importlib.metadata` entry points for pip installs; `registry.json` + `sys.path` injection for frozen PyInstaller binaries. Per-extension error isolation; conflict detection.
- **`ExtensionRegistry`** (`extension_registry.py`) — atomic JSON read/write for `~/.opentoken/extensions/registry.json`; `OPENTOKEN_EXTENSIONS_DIR` override support.
- **`ExtensionCommand`** (`extension_command.py`) — `opentoken extension install/list/uninstall/update` subcommands:
  - `install` calls `pip install` in non-frozen mode so entry points are properly registered; preserves original wheel filename for pip metadata parsing; stores `dist_name` in registry for clean uninstall.
  - `list` merges registry entries + pip entry-point extensions into a unified table.
  - `uninstall` calls `pip uninstall` for registry-installed extensions (non-frozen); shows pip guidance for externally pip-installed extensions.

**Reference extension (`lib/python/opentoken_ext_hello_world/`):**
- `hello-world hello --name <name>` → `Hello, <name>`
- `hello-world bye --name <name>` → `Bye, <name>`
- Full test suite (10 tests) and README.

**CLI improvements:**
- Alphabetical subcommand ordering — both `_name_parser_map` and `_choices_actions` sorted in-place at startup.
- `version_checker` APPDATA fix — gated `APPDATA` env var behind `sys.platform == "win32"` to prevent stray Windows-style relative paths on Linux.

**Tests:** 285 CLI tests + 10 extension tests (295 total), all passing.

**Documentation:**
- New GitHub Pages: `pages/reference/extensions.md`, `pages/operations/managing-extensions.md`, `pages/quickstarts/extension-quickstart.md`.
- Updated `docs/dev-guide-development.md` — added Local Extension Development section with editable-install and wheel-install testing paths.
- Updated `pages/reference/cli.md` with Extensions section.

**Matrix testing (`tools/cli/run_cli_matrix.sh`):**
- 5 always-on extension steps: `extension-help`, `extension-list`, `extension-hello-world-help`, `extension-hello-world-hello`, `extension-hello-world-bye`.
- Full install/uninstall round-trip available via `--include-extension-install` flag (modifies venv, restores editable install on exit).