### PR TITLE
Release v1.13.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.13.1
+current_version = 1.13.2
 commit = False
 tag = False
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,7 @@
     }
   },
   "mounts": [
-    "type=volume,source=opentoken-venv,target=/workspaces/OpenToken/.venv"
+    "type=volume,source=opentoken-venv,target=/workspaces/${localWorkspaceFolderBasename}/.venv"
   ],
   "containerEnv": {
     "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS file for OpenToken repository
+# CODEOWNERS file for OpenLinkToken repository
 # This file defines individuals or teams that are responsible for code in this repository.
 # For more information, see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,19 +63,19 @@ This document provides comprehensive guidance for AI coding agents working on th
 
 ### ⚠️ CRITICAL PYTHON ENVIRONMENT RULE
 
-**The Python virtual environment (`.venv`) is located at the repository root (`/workspaces/OpenToken/.venv`).**
+**The Python virtual environment (`.venv`) is located at the repository root (`/workspaces/OpenLinkToken/.venv`).**
 
 - ❌ **NEVER** create or activate a venv in any subdirectory (e.g., `lib/python/opentoken/.venv`)
 - ❌ **NEVER** run `python -m venv .venv` from any folder other than the repo root
-- ✅ **ALWAYS** activate the root venv: `source /workspaces/OpenToken/.venv/bin/activate`
+- ✅ **ALWAYS** activate the root venv: `source /workspaces/OpenLinkToken/.venv/bin/activate`
 - ✅ **ALWAYS** use absolute path or ensure you're at repo root before activating
 
 ```bash
 # CORRECT - activate from anywhere using absolute path
-source /workspaces/OpenToken/.venv/bin/activate
+source /workspaces/OpenLinkToken/.venv/bin/activate
 
 # CORRECT - navigate to repo root first
-cd /workspaces/OpenToken && source .venv/bin/activate
+cd /workspaces/OpenLinkToken && source .venv/bin/activate
 
 # WRONG - never do this from lib/python or any subdirectory
 cd lib/python/opentoken && python -m venv .venv  # ❌ DO NOT DO THIS
@@ -89,13 +89,13 @@ cd lib/python/opentoken && python -m venv .venv  # ❌ DO NOT DO THIS
 cd lib/java && mvn clean install
 
 # Python: Activate root venv first, then run tests from package directories
-source /workspaces/OpenToken/.venv/bin/activate
+source /workspaces/OpenLinkToken/.venv/bin/activate
 
 # Python core library tests:
-cd /workspaces/OpenToken/lib/python/opentoken && pytest
+cd /workspaces/OpenLinkToken/lib/python/opentoken && pytest
 
 # Python CLI tests:
-cd /workspaces/OpenToken/lib/python/opentoken-cli && pytest
+cd /workspaces/OpenLinkToken/lib/python/opentoken-cli && pytest
 
 # Note: No unified build script exists - build each language separately
 ```

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Publish to GitHub Packages Apache Maven
         run: |
           set -euo pipefail
-          base_url="https://maven.pkg.github.com/TruvetaPublic/OpenToken/com/truveta"
+          base_url="https://maven.pkg.github.com/TruvetaPublic/OpenLinkToken/com/truveta"
           version="${VERSION}"
           parent_metadata_url="${base_url}/opentoken-parent/maven-metadata.xml"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /app
 
 RUN addgroup --system appuser && adduser --system --no-create-home --ingroup appuser appuser
 
-ARG VERSION=1.13.1
+ARG VERSION=1.13.2
 COPY --from=build /app/opentoken-cli/target/opentoken-cli-${VERSION}.jar /usr/local/lib/opentoken.jar
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -69,38 +69,38 @@ java -jar opentoken-cli/target/opentoken-cli-*.jar \
   -h "HashingKey" -e "Secret-Encryption-Key-Goes-Here."
 ```
 
-See <a href="https://truvetapublic.github.io/OpenToken/quickstarts/" target="_blank" rel="noopener noreferrer">Quickstarts</a> for Python CLI and detailed setup instructions.
+See <a href="https://truvetapublic.github.io/OpenLinkToken/quickstarts/" target="_blank" rel="noopener noreferrer">Quickstarts</a> for Python CLI and detailed setup instructions.
 
 ## Key Matching Ideas
 
-- **Token rules**: Five rules (T1–T5) combine attributes in different ways — see <a href="https://truvetapublic.github.io/OpenToken/concepts/token-rules.html" target="_blank" rel="noopener noreferrer">Token Rules</a>
-- **Normalization**: Names, dates, postal codes normalized before tokenization — see <a href="https://truvetapublic.github.io/OpenToken/concepts/normalization-and-validation.html" target="_blank" rel="noopener noreferrer">Normalization and Validation</a>
-- **Metadata**: Processing statistics and audit trail — see <a href="https://truvetapublic.github.io/OpenToken/reference/metadata-format.html" target="_blank" rel="noopener noreferrer">Metadata Format</a>
+- **Token rules**: Five rules (T1–T5) combine attributes in different ways — see <a href="https://truvetapublic.github.io/OpenLinkToken/concepts/token-rules.html" target="_blank" rel="noopener noreferrer">Token Rules</a>
+- **Normalization**: Names, dates, postal codes normalized before tokenization — see <a href="https://truvetapublic.github.io/OpenLinkToken/concepts/normalization-and-validation.html" target="_blank" rel="noopener noreferrer">Normalization and Validation</a>
+- **Metadata**: Processing statistics and audit trail — see <a href="https://truvetapublic.github.io/OpenLinkToken/reference/metadata-format.html" target="_blank" rel="noopener noreferrer">Metadata Format</a>
 
 ## Running OpenToken
 
-- **CLI modes**: Encrypt (default), hash-only (`--hash-only`), decrypt (`-d`) — see <a href="https://truvetapublic.github.io/OpenToken/running-opentoken/" target="_blank" rel="noopener noreferrer">Running OpenToken</a>
-- **Docker**: Convenience scripts for containerized runs — see <a href="https://truvetapublic.github.io/OpenToken/quickstarts/" target="_blank" rel="noopener noreferrer">Quickstarts</a>
-- **PySpark**: Distributed processing for large datasets — see <a href="https://truvetapublic.github.io/OpenToken/operations/spark-or-databricks.html" target="_blank" rel="noopener noreferrer">Spark or Databricks</a>
+- **CLI modes**: Encrypt (default), hash-only (`--hash-only`), decrypt (`-d`) — see <a href="https://truvetapublic.github.io/OpenLinkToken/running-opentoken/" target="_blank" rel="noopener noreferrer">Running OpenToken</a>
+- **Docker**: Convenience scripts for containerized runs — see <a href="https://truvetapublic.github.io/OpenLinkToken/quickstarts/" target="_blank" rel="noopener noreferrer">Quickstarts</a>
+- **PySpark**: Distributed processing for large datasets — see <a href="https://truvetapublic.github.io/OpenLinkToken/operations/spark-or-databricks.html" target="_blank" rel="noopener noreferrer">Spark or Databricks</a>
 
 ## Security Notes
 
-- **Crypto pipeline**: Token signature → SHA-256 → HMAC-SHA256 → AES-256 (or hash-only) — see <a href="https://truvetapublic.github.io/OpenToken/security.html" target="_blank" rel="noopener noreferrer">Security</a>
+- **Crypto pipeline**: Token signature → SHA-256 → HMAC-SHA256 → AES-256 (or hash-only) — see <a href="https://truvetapublic.github.io/OpenLinkToken/security.html" target="_blank" rel="noopener noreferrer">Security</a>
 - **Secret management**: Handle hashing/encryption secrets securely; avoid committing secrets; prefer env/secret stores
 - **Validation**: Reject placeholders and malformed attributes before tokenization
 
 ## Contributing & Community
 
-- <a href="https://truvetapublic.github.io/OpenToken/community/contributing.html" target="_blank" rel="noopener noreferrer">Contributing Guide</a> — Branching, PR expectations, coding standards
-- <a href="https://truvetapublic.github.io/OpenToken/community/code-of-conduct.html" target="_blank" rel="noopener noreferrer">Code of Conduct</a>
+- <a href="https://truvetapublic.github.io/OpenLinkToken/community/contributing.html" target="_blank" rel="noopener noreferrer">Contributing Guide</a> — Branching, PR expectations, coding standards
+- <a href="https://truvetapublic.github.io/OpenLinkToken/community/code-of-conduct.html" target="_blank" rel="noopener noreferrer">Code of Conduct</a>
 
 ## Documentation
 
-- <a href="https://truvetapublic.github.io/OpenToken/" target="_blank" rel="noopener noreferrer">Documentation Index</a>
-- <a href="https://truvetapublic.github.io/OpenToken/quickstarts/" target="_blank" rel="noopener noreferrer">Quickstarts</a>
-- <a href="https://truvetapublic.github.io/OpenToken/specification.html" target="_blank" rel="noopener noreferrer">Specification</a>
-- <a href="https://truvetapublic.github.io/OpenToken/reference/cli.html" target="_blank" rel="noopener noreferrer">CLI Reference</a>
-- <a href="https://truvetapublic.github.io/OpenToken/reference/metadata-format.html" target="_blank" rel="noopener noreferrer">Metadata Format</a>
+- <a href="https://truvetapublic.github.io/OpenLinkToken/" target="_blank" rel="noopener noreferrer">Documentation Index</a>
+- <a href="https://truvetapublic.github.io/OpenLinkToken/quickstarts/" target="_blank" rel="noopener noreferrer">Quickstarts</a>
+- <a href="https://truvetapublic.github.io/OpenLinkToken/specification.html" target="_blank" rel="noopener noreferrer">Specification</a>
+- <a href="https://truvetapublic.github.io/OpenLinkToken/reference/cli.html" target="_blank" rel="noopener noreferrer">CLI Reference</a>
+- <a href="https://truvetapublic.github.io/OpenLinkToken/reference/metadata-format.html" target="_blank" rel="noopener noreferrer">Metadata Format</a>
 
 For issues or support, file an issue in this repository.
 

--- a/demos/pprl-superhero-example/README.md
+++ b/demos/pprl-superhero-example/README.md
@@ -551,4 +551,4 @@ This demonstration can be adapted for:
 
 ### Questions? <!-- omit in toc -->
 
-For issues or questions about OpenToken, please visit the [GitHub repository](https://github.com/mattwise-42/OpenToken).
+For issues or questions about OpenToken, please visit the [GitHub repository](https://github.com/TruvetaPublic/OpenLinkToken).

--- a/lib/java/opentoken-cli/pom.xml
+++ b/lib/java/opentoken-cli/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.truveta</groupId>
         <artifactId>opentoken-parent</artifactId>
-        <version>1.13.1</version>
+        <version>1.13.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>opentoken-cli</artifactId>
     <packaging>jar</packaging>
-    <version>1.13.1</version>
+    <version>1.13.2</version>
 
     <name>opentoken-cli</name>
     <description>OpenToken CLI - Command-line interface with CSV and Parquet support for token generation</description>

--- a/lib/java/opentoken/pom.xml
+++ b/lib/java/opentoken/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>com.truveta</groupId>
         <artifactId>opentoken-parent</artifactId>
-        <version>1.13.1</version>
+        <version>1.13.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>opentoken</artifactId>
     <packaging>jar</packaging>
-    <version>1.13.1</version>
+    <version>1.13.2</version>
 
     <name>opentoken</name>
     <description>OpenToken Core Library - Privacy-preserving person matching using cryptographically secure token generation</description>

--- a/lib/java/opentoken/src/main/java/com/truveta/opentoken/Metadata.java
+++ b/lib/java/opentoken/src/main/java/com/truveta/opentoken/Metadata.java
@@ -25,7 +25,7 @@ public class Metadata {
     public static final String METADATA_FILE_EXTENSION = ".metadata.json";
     public static final String SYSTEM_JAVA_VERSION = System.getProperty("java.version");
 
-    public static final String DEFAULT_VERSION = "1.13.1";
+    public static final String DEFAULT_VERSION = "1.13.2";
 
     // Output format values
     public static final String OUTPUT_FORMAT_JSON = "JSON";

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.truveta</groupId>
     <artifactId>opentoken-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.13.1</version>
+    <version>1.13.2</version>
 
     <name>opentoken-parent</name>
     <description>OpenToken Parent POM - Privacy-preserving person matching library</description>
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>com.truveta</groupId>
                 <artifactId>opentoken</artifactId>
-                <version>1.13.1</version>
+                <version>1.13.2</version>
             </dependency>
 
             <!-- JUnit 5 -->

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -22,7 +22,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/TruvetaPublic/OpenToken</url>
+            <url>https://maven.pkg.github.com/TruvetaPublic/OpenLinkToken</url>
         </repository>
     </distributionManagement>
 

--- a/lib/python/opentoken-cli/requirements.txt
+++ b/lib/python/opentoken-cli/requirements.txt
@@ -1,5 +1,5 @@
 # Core opentoken dependency
-opentoken==1.13.1
+opentoken==1.13.2
 
 # Data processing for I/O formats
 pandas

--- a/lib/python/opentoken-cli/setup.py
+++ b/lib/python/opentoken-cli/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as
 
 setup(
     name="opentoken-cli",
-    version="1.13.1",
+    version="1.13.2",
     author="Truveta",
     description="OpenToken CLI - Command line interface for person matching",
     long_description=long_description,

--- a/lib/python/opentoken-cli/src/main/opentoken_cli/__init__.py
+++ b/lib/python/opentoken-cli/src/main/opentoken_cli/__init__.py
@@ -7,5 +7,5 @@ This package provides the command line interface for tokenizing and processing
 person attributes using the OpenToken library.
 """
 
-__version__ = "1.13.1"
+__version__ = "1.13.2"
 __author__ = "Truveta"

--- a/lib/python/opentoken-pyspark/requirements.txt
+++ b/lib/python/opentoken-pyspark/requirements.txt
@@ -1,5 +1,5 @@
 # Core opentoken dependency
-opentoken==1.13.1
+opentoken==1.13.2
 
 # Cryptography for token decryption in overlap analysis
 pycryptodome>=3.18.0

--- a/lib/python/opentoken-pyspark/setup.py
+++ b/lib/python/opentoken-pyspark/setup.py
@@ -17,13 +17,13 @@ except FileNotFoundError:
 
 # Core dependencies (version-agnostic, no PySpark)
 core_requirements = [
-    "opentoken==1.13.1",
+    "opentoken==1.13.2",
     "pycryptodome>=3.18.0",
 ]
 
 setup(
     name="opentoken-pyspark",
-    version="1.13.1",
+    version="1.13.2",
     author="Truveta",
     description="OpenToken PySpark bridge for distributed token generation",
     long_description=long_description,

--- a/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/__init__.py
+++ b/lib/python/opentoken-pyspark/src/main/opentoken_pyspark/__init__.py
@@ -4,7 +4,7 @@ Copyright (c) Truveta. All rights reserved.
 OpenToken PySpark Bridge - Distributed token generation for PySpark DataFrames.
 """
 
-__version__ = "1.13.1"
+__version__ = "1.13.2"
 
 from opentoken_pyspark.token_processor import OpenTokenProcessor
 from opentoken_pyspark.overlap_analyzer import OpenTokenOverlapAnalyzer

--- a/lib/python/opentoken/setup.py
+++ b/lib/python/opentoken/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(this_directory, "requirements.txt"), encoding="utf-8") as
 
 setup(
     name="opentoken",
-    version="1.13.1",
+    version="1.13.2",
     author="Truveta",
     description="OpenToken Python core library for person matching",
     long_description=long_description,

--- a/lib/python/opentoken/src/main/opentoken/__init__.py
+++ b/lib/python/opentoken/src/main/opentoken/__init__.py
@@ -7,7 +7,7 @@ This package provides utilities for tokenizing and processing person attributes
 using various cryptographic transformations.
 """
 
-__version__ = "1.13.1"
+__version__ = "1.13.2"
 __author__ = "Truveta"
 
 __all__ = [

--- a/lib/python/opentoken/src/main/opentoken/metadata.py
+++ b/lib/python/opentoken/src/main/opentoken/metadata.py
@@ -24,7 +24,7 @@ class Metadata:
     METADATA_FILE_EXTENSION = ".metadata.json"
     SYSTEM_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
-    DEFAULT_VERSION = "1.13.1"
+    DEFAULT_VERSION = "1.13.2"
 
     # Output format values
     OUTPUT_FORMAT_JSON = "JSON"

--- a/pages/community-development/index.md
+++ b/pages/community-development/index.md
@@ -70,7 +70,7 @@ dev/* (feature work) → develop → release/x.y.z → main → develop (auto-sy
 - Java: `mvn clean install` (includes unit tests, integration tests, Checkstyle, JaCoCo).
 - Python: `pytest` (run from `lib/python/opentoken` and `lib/python/opentoken-cli`).
 - Interoperability: `python tools/interoperability/java_python_interoperability_test.py`.
-- Sync check: [tools/sync-check.sh](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/sync-check.sh) to ensure Java/Python parity.
+- Sync check: [tools/sync-check.sh](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/tools/sync-check.sh) to ensure Java/Python parity.
 
 ## Dev Container
 
@@ -83,4 +83,4 @@ A VS Code dev container is provided with Java, Maven, Python, and Docker CLI pre
 
 ## License
 
-OpenToken is released under the MIT License. See the [LICENSE file on GitHub](https://github.com/TruvetaPublic/OpenToken/blob/main/LICENSE) for details.
+OpenToken is released under the MIT License. See the [LICENSE file on GitHub](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/LICENSE) for details.

--- a/pages/community-development/index.md
+++ b/pages/community-development/index.md
@@ -45,7 +45,7 @@ pip install -r requirements.txt -e .
 ### PySpark Bridge
 
 ```bash
-source /workspaces/OpenToken/.venv/bin/activate
+source /workspaces/OpenLinkToken/.venv/bin/activate
 cd lib/python/opentoken-pyspark
 pip install -r requirements.txt -e .
 ```

--- a/pages/community/contributing.md
+++ b/pages/community/contributing.md
@@ -23,8 +23,8 @@ This guide outlines how to contribute code, documentation, and bug reports to Op
 1. **Fork the repository** on GitHub
 2. **Clone your fork**:
    ```bash
-   git clone https://github.com/YOUR-USERNAME/OpenToken.git
-   cd OpenToken
+   git clone https://github.com/YOUR-USERNAME/OpenLinkToken.git
+   cd OpenLinkToken
    ```
 3. **Set up the Python environment** (at repo root):
    ```bash

--- a/pages/community/index.md
+++ b/pages/community/index.md
@@ -13,4 +13,4 @@ Join the OpenToken community.
 ## Next Steps
 
 - **Get started**: [Quickstarts](../quickstarts/index.md)
-- **Report issues**: [GitHub Issues](https://github.com/TruvetaPublic/OpenToken/issues)
+- **Report issues**: [GitHub Issues](https://github.com/TruvetaPublic/OpenLinkToken/issues)

--- a/pages/concepts/metadata-and-audit.md
+++ b/pages/concepts/metadata-and-audit.md
@@ -69,4 +69,4 @@ For full field descriptions, JSON schema, examples, and hash verification detail
 
 - **View metadata structure**: [Reference: Metadata Format](../reference/metadata-format.md)
 - **Understand validation rules**: [Normalization & Validation](normalization-and-validation.md)
-- **Use hash calculator**: [tools/hash_calculator.py](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/hash_calculator.py)
+- **Use hash calculator**: [tools/hash_calculator.py](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/tools/hash_calculator.py)

--- a/pages/config/configuration.md
+++ b/pages/config/configuration.md
@@ -174,7 +174,7 @@ java -jar opentoken-cli/target/opentoken-cli-*.jar \
   -h "HashingKey" -e "EncryptionKey32Characters!!!!!"
 
 # Python
-source /workspaces/OpenToken/.venv/bin/activate
+source /workspaces/OpenLinkToken/.venv/bin/activate
 python -m opentoken_cli.main \
   -i ../../../resources/sample.csv -t csv -o ../../../resources/output.csv \
   -h "HashingKey" -e "EncryptionKey32Characters!!!!!"

--- a/pages/dev-guide-development.md
+++ b/pages/dev-guide-development.md
@@ -356,11 +356,11 @@ Notebook Guides:
 - See `lib/python/opentoken-pyspark/notebooks/` for example workflows (custom tokens & overlap analysis).
 ### Multi-Language Sync Tool
 
-Java is the source of truth. The sync tool ([tools/java_language_syncer.py](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/java_language_syncer.py)) evaluates changed Java files against enabled target languages (currently Python). It will fail PR workflows if any modified Java file lacks a corresponding, up-to-date target implementation.
+Java is the source of truth. The sync tool ([tools/java_language_syncer.py](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/tools/java_language_syncer.py)) evaluates changed Java files against enabled target languages (currently Python). It will fail PR workflows if any modified Java file lacks a corresponding, up-to-date target implementation.
 
 Key concepts:
 
-- Source-centric config: [tools/java-language-mappings.json](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/java-language-mappings.json) defines `critical_java_files` (with optional priorities/manual review) and `directory_roots` for broad coverage.
+- Source-centric config: [tools/java-language-mappings.json](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/tools/java-language-mappings.json) defines `critical_java_files` (with optional priorities/manual review) and `directory_roots` for broad coverage.
 - Language overrides: Target-specific adjustments live under `target_languages.<lang>.overrides.critical_files`.
 - Auto-generation: If `auto_generate_unmapped` is true, unmapped Java files still produce inferred target paths via handlers.
 - Sync status logic: A target file is considered synced if it was modified after the Java file (timestamp) or, in simplified mode, if both were touched in the PR.

--- a/pages/operations/mock-data-workflows.md
+++ b/pages/operations/mock-data-workflows.md
@@ -16,7 +16,7 @@ OpenToken includes a mock data generator for testing and development. The tool c
 
 ## Mock Data Generator
 
-Location: [tools/mockdata/data_generator.py](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/mockdata/data_generator.py)
+Location: [tools/mockdata/data_generator.py](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/tools/mockdata/data_generator.py)
 
 ### Usage
 
@@ -145,14 +145,14 @@ For automated overlap analysis, see [Spark or Databricks](spark-or-databricks.md
 
 ## Sample Data Files
 
-Pre-generated sample files are available in [resources/](https://github.com/TruvetaPublic/OpenToken/tree/main/resources):
+Pre-generated sample files are available in [resources/](https://github.com/TruvetaPublic/OpenLinkToken/tree/main/resources):
 
 | File                                                                                                                    | Description                    |
 | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| [sample.csv](https://github.com/TruvetaPublic/OpenToken/blob/main/resources/sample.csv)                                 | Small test file for quickstart |
-| [mockdata/test_data.csv](https://github.com/TruvetaPublic/OpenToken/blob/main/resources/mockdata/test_data.csv)         | 100 records with duplicates    |
-| [mockdata/test_overlap1.csv](https://github.com/TruvetaPublic/OpenToken/blob/main/resources/mockdata/test_overlap1.csv) | Dataset for overlap testing    |
-| [mockdata/test_overlap2.csv](https://github.com/TruvetaPublic/OpenToken/blob/main/resources/mockdata/test_overlap2.csv) | Dataset for overlap testing    |
+| [sample.csv](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/resources/sample.csv)                                 | Small test file for quickstart |
+| [mockdata/test_data.csv](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/resources/mockdata/test_data.csv)         | 100 records with duplicates    |
+| [mockdata/test_overlap1.csv](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/resources/mockdata/test_overlap1.csv) | Dataset for overlap testing    |
+| [mockdata/test_overlap2.csv](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/resources/mockdata/test_overlap2.csv) | Dataset for overlap testing    |
 
 ---
 

--- a/pages/operations/pprl-demo-walkthrough.md
+++ b/pages/operations/pprl-demo-walkthrough.md
@@ -8,8 +8,8 @@ This walkthrough explains the **data flow and artifacts** produced by the demo u
 
 If you want the full, runnable demo guide, see:
 
-- [Demo notebook (PPRL_Superhero_Demo.ipynb)](https://github.com/TruvetaPublic/OpenToken/blob/main/demos/pprl-superhero-example/PPRL_Superhero_Demo.ipynb)
-- [Demo README](https://github.com/TruvetaPublic/OpenToken/blob/main/demos/pprl-superhero-example/README.md)
+- [Demo notebook (PPRL_Superhero_Demo.ipynb)](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/demos/pprl-superhero-example/PPRL_Superhero_Demo.ipynb)
+- [Demo README](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/demos/pprl-superhero-example/README.md)
 
 ## Scenario and roles
 

--- a/pages/operations/running-batch-jobs.md
+++ b/pages/operations/running-batch-jobs.md
@@ -80,7 +80,7 @@ python -m opentoken_cli.main \
 
 **Bash (Linux/Mac):**
 ```bash
-cd /path/to/OpenToken
+cd /path/to/OpenLinkToken
 
 ./run-opentoken.sh \
   -i ./resources/sample.csv \
@@ -92,7 +92,7 @@ cd /path/to/OpenToken
 
 **PowerShell (Windows):**
 ```powershell
-cd C:\path\to\OpenToken
+cd C:\path\to\OpenLinkToken
 
 .\run-opentoken.ps1 `
   -i .\resources\sample.csv `

--- a/pages/operations/spark-or-databricks.md
+++ b/pages/operations/spark-or-databricks.md
@@ -310,8 +310,8 @@ tokens_df.write.mode("overwrite").format("delta").saveAsTable("main.pprl.person_
 
 See the notebooks in `lib/python/opentoken-pyspark/notebooks/`:
 
-- [Custom_Token_Definition_Guide.ipynb](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken-pyspark/notebooks/Custom_Token_Definition_Guide.ipynb) – Define custom token rules
-- [Dataset_Overlap_Analysis_Guide.ipynb](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb) – Find overlapping records across datasets
+- [Custom_Token_Definition_Guide.ipynb](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken-pyspark/notebooks/Custom_Token_Definition_Guide.ipynb) – Define custom token rules
+- [Dataset_Overlap_Analysis_Guide.ipynb](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb) – Find overlapping records across datasets
 
 ---
 
@@ -326,4 +326,4 @@ See the notebooks in `lib/python/opentoken-pyspark/notebooks/`:
 ## Next Steps
 
 - **Batch processing**: [Running Batch Jobs](running-batch-jobs.md)
-- **Overlap analysis**: See the [Dataset_Overlap_Analysis_Guide.ipynb](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb) example notebook
+- **Overlap analysis**: See the [Dataset_Overlap_Analysis_Guide.ipynb](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb) example notebook

--- a/pages/operations/spark-or-databricks.md
+++ b/pages/operations/spark-or-databricks.md
@@ -32,7 +32,7 @@ How to use the PySpark bridge for distributed token generation on Spark clusters
 ### Local Development
 
 ```bash
-source /workspaces/OpenToken/.venv/bin/activate
+source /workspaces/OpenLinkToken/.venv/bin/activate
 
 cd lib/python/opentoken-pyspark
 pip install -e .[spark40]  # For Java 21

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -23,7 +23,7 @@ The fastest way to get started. No Java or Python installation required.
 ### Linux/Mac
 
 ```bash
-cd /path/to/OpenToken
+cd /path/to/OpenLinkToken
 
 ./run-opentoken.sh \
   -i ./resources/sample.csv \
@@ -36,7 +36,7 @@ cd /path/to/OpenToken
 ### Windows PowerShell
 
 ```powershell
-cd C:\path\to\OpenToken
+cd C:\path\to\OpenLinkToken
 
 .\run-opentoken.ps1 `
   -i .\resources\sample.csv `

--- a/pages/quickstarts/java-quickstart.md
+++ b/pages/quickstarts/java-quickstart.md
@@ -24,7 +24,7 @@ mvn -version    # Should show 3.8 or higher
 
 ```bash
 # Clone and navigate to the repository
-cd /path/to/OpenToken/lib/java
+cd /path/to/OpenLinkToken/lib/java
 
 # Build both opentoken core and CLI modules
 mvn clean install

--- a/pages/quickstarts/java-quickstart.md
+++ b/pages/quickstarts/java-quickstart.md
@@ -156,7 +156,7 @@ To use OpenToken in your Java project:
 <dependency>
     <groupId>com.truveta</groupId>
     <artifactId>opentoken</artifactId>
-    <version>1.13.1</version>
+    <version>1.13.2</version>
 </dependency>
 ```
 

--- a/pages/quickstarts/python-quickstart.md
+++ b/pages/quickstarts/python-quickstart.md
@@ -25,7 +25,7 @@ pip --version
 **Important:** The virtual environment should be created at the repository root.
 
 ```bash
-cd /path/to/OpenToken
+cd /path/to/OpenLinkToken
 
 # Create virtual environment at repo root
 python -m venv .venv
@@ -178,7 +178,7 @@ OpenToken requires Python 3.10+. Check with `python --version`.
 If commands fail, ensure venv is active:
 
 ```bash
-source /path/to/OpenToken/.venv/bin/activate
+source /path/to/OpenLinkToken/.venv/bin/activate
 ```
 
 ### Import Errors After Updates

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -135,7 +135,7 @@ Every run generates a `.metadata.json` file:
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.13.1",
+  "OpenTokenVersion": "1.13.2",
   "TotalRows": 100,
   "TotalRowsWithInvalidAttributes": 3,
   "InvalidAttributesByType": {

--- a/pages/reference/java-api.md
+++ b/pages/reference/java-api.md
@@ -236,14 +236,14 @@ for (Map<Class<? extends Attribute>, String> personAttributes : persons) {
 <dependency>
     <groupId>com.truveta</groupId>
     <artifactId>opentoken</artifactId>
-    <version>1.13.1</version>
+    <version>1.13.2</version>
 </dependency>
 
 <!-- For CLI/IO classes -->
 <dependency>
     <groupId>com.truveta</groupId>
     <artifactId>opentoken-cli</artifactId>
-    <version>1.13.1</version>
+    <version>1.13.2</version>
 </dependency>
 ```
 

--- a/pages/reference/metadata-format.md
+++ b/pages/reference/metadata-format.md
@@ -120,7 +120,7 @@ Extension: .metadata.json
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.13.1",
+  "OpenTokenVersion": "1.13.2",
   "TotalRows": 101,
   "TotalRowsWithInvalidAttributes": 9,
   "InvalidAttributesByType": {
@@ -148,7 +148,7 @@ Extension: .metadata.json
 {
   "Platform": "Python",
   "PythonVersion": "3.11.5",
-  "OpenTokenVersion": "1.13.1",
+  "OpenTokenVersion": "1.13.2",
   "TotalRows": 50,
   "TotalRowsWithInvalidAttributes": 2,
   "InvalidAttributesByType": {

--- a/pages/reference/token-registration.md
+++ b/pages/reference/token-registration.md
@@ -250,7 +250,7 @@ The Python `TokenRegistry.load_all_tokens()` implementation discovers `Token` su
 After making changes in both languages, verify parity:
 
 ```bash
-cd /workspaces/OpenToken/tools
+cd /workspaces/OpenLinkToken/tools
 python java_language_syncer.py
 ```
 
@@ -265,7 +265,7 @@ This tool checks:
 Run the interoperability test suite:
 
 ```bash
-cd /workspaces/OpenToken/tools/interoperability
+cd /workspaces/OpenLinkToken/tools/interoperability
 python java_python_interoperability_test.py
 ```
 

--- a/pages/reference/token-registration.md
+++ b/pages/reference/token-registration.md
@@ -64,7 +64,7 @@ public class MiddleNameAttribute extends BaseAttribute {
 }
 ```
 
-2. **Register in service file** at [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute):
+2. **Register in service file** at [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute):
 
 ```
 com.truveta.opentoken.attributes.general.DateAttribute
@@ -129,7 +129,7 @@ public class T6Token implements Token {
 }
 ```
 
-2. **Register in service file** at [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token):
+2. **Register in service file** at [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token):
 
 ```
 com.truveta.opentoken.tokens.definitions.T1Token
@@ -277,19 +277,19 @@ This verifies that identical inputs produce identical token outputs in both lang
 
 | Type                   | Location                                                                                                                                                                                                                                                      |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Attribute classes      | [lib/java/opentoken/src/main/java/com/truveta/opentoken/attributes/](https://github.com/TruvetaPublic/OpenToken/tree/main/lib/java/opentoken/src/main/java/com/truveta/opentoken/attributes)                                                                  |
-| Token classes          | [lib/java/opentoken/src/main/java/com/truveta/opentoken/tokens/definitions/](https://github.com/TruvetaPublic/OpenToken/tree/main/lib/java/opentoken/src/main/java/com/truveta/opentoken/tokens/definitions)                                                  |
-| Attribute service file | [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute) |
-| Token service file     | [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token)                 |
+| Attribute classes      | [lib/java/opentoken/src/main/java/com/truveta/opentoken/attributes/](https://github.com/TruvetaPublic/OpenLinkToken/tree/main/lib/java/opentoken/src/main/java/com/truveta/opentoken/attributes)                                                                  |
+| Token classes          | [lib/java/opentoken/src/main/java/com/truveta/opentoken/tokens/definitions/](https://github.com/TruvetaPublic/OpenLinkToken/tree/main/lib/java/opentoken/src/main/java/com/truveta/opentoken/tokens/definitions)                                                  |
+| Attribute service file | [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.attributes.Attribute) |
+| Token service file     | [lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/java/opentoken/src/main/resources/META-INF/services/com.truveta.opentoken.tokens.Token)                 |
 
 ### Python Files
 
 | Type              | Location                                                                                                                                                                                                               |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Attribute classes | [lib/python/opentoken/src/main/opentoken/attributes/](https://github.com/TruvetaPublic/OpenToken/tree/main/lib/python/opentoken/src/main/opentoken/attributes)                                                         |
-| Token classes     | [lib/python/opentoken/src/main/opentoken/tokens/definitions/](https://github.com/TruvetaPublic/OpenToken/tree/main/lib/python/opentoken/src/main/opentoken/tokens/definitions)                                         |
-| Attribute loader  | [lib/python/opentoken/src/main/opentoken/attributes/attribute_loader.py](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken/src/main/opentoken/attributes/attribute_loader.py)                  |
-| Token discovery   | [lib/python/opentoken/src/main/opentoken/tokens/token_registry.py](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken/src/main/opentoken/tokens/token_registry.py) (auto-discovers definitions) |
+| Attribute classes | [lib/python/opentoken/src/main/opentoken/attributes/](https://github.com/TruvetaPublic/OpenLinkToken/tree/main/lib/python/opentoken/src/main/opentoken/attributes)                                                         |
+| Token classes     | [lib/python/opentoken/src/main/opentoken/tokens/definitions/](https://github.com/TruvetaPublic/OpenLinkToken/tree/main/lib/python/opentoken/src/main/opentoken/tokens/definitions)                                         |
+| Attribute loader  | [lib/python/opentoken/src/main/opentoken/attributes/attribute_loader.py](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken/src/main/opentoken/attributes/attribute_loader.py)                  |
+| Token discovery   | [lib/python/opentoken/src/main/opentoken/tokens/token_registry.py](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken/src/main/opentoken/tokens/token_registry.py) (auto-discovers definitions) |
 
 ## Common Mistakes
 

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -133,7 +133,7 @@ record1,T2,pUxPgYL9+cMxkA+8928Pil+9W+dm9kISwHYPdkZS+I2nQ/bQ/8HyL3FOVf3NYPW5NKZZO
 ```json
 {
   "JavaVersion": "21.0.0",
-  "OpenTokenVersion": "1.13.1",
+  "OpenTokenVersion": "1.13.2",
   "Platform": "Java",
   "TotalRows": 1,
   "TotalRowsWithInvalidAttributes": 0,

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -158,7 +158,7 @@ Scripts automatically build and run the container.
 
 **Bash (Linux/Mac):**
 ```bash
-cd /path/to/OpenToken
+cd /path/to/OpenLinkToken
 
 ./run-opentoken.sh \
   -i ./resources/sample.csv \
@@ -170,7 +170,7 @@ cd /path/to/OpenToken
 
 **PowerShell (Windows):**
 ```powershell
-cd C:\path\to\OpenToken
+cd C:\path\to\OpenLinkToken
 
 .\run-opentoken.ps1 `
   -i .\resources\sample.csv `

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -275,8 +275,8 @@ tokens_df.coalesce(1).write \
 
 See example notebooks in `lib/python/opentoken-pyspark/notebooks/`:
 
-- [Custom_Token_Definition_Guide.ipynb](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken-pyspark/notebooks/Custom_Token_Definition_Guide.ipynb) – Define custom token rules
-- [Dataset_Overlap_Analysis_Guide.ipynb](https://github.com/TruvetaPublic/OpenToken/blob/main/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb) – Find overlapping records across datasets
+- [Custom_Token_Definition_Guide.ipynb](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken-pyspark/notebooks/Custom_Token_Definition_Guide.ipynb) – Define custom token rules
+- [Dataset_Overlap_Analysis_Guide.ipynb](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/python/opentoken-pyspark/notebooks/Dataset_Overlap_Analysis_Guide.ipynb) – Find overlapping records across datasets
 
 ---
 

--- a/pages/running-opentoken/index.md
+++ b/pages/running-opentoken/index.md
@@ -214,7 +214,7 @@ cat resources/output.metadata.json
 
 **Dev Container:** If running in a dev container, use absolute path:
 ```bash
-docker run --rm -v /workspaces/OpenToken/resources:/app/resources \
+docker run --rm -v /workspaces/OpenLinkToken/resources:/app/resources \
   opentoken:latest ...
 ```
 
@@ -236,7 +236,7 @@ For large-scale distributed token generation and dataset overlap analysis, use t
 Ensure the Python root venv is active, then install:
 
 ```bash
-source /workspaces/OpenToken/.venv/bin/activate
+source /workspaces/OpenLinkToken/.venv/bin/activate
 
 cd lib/python/opentoken-pyspark
 pip install -r requirements.txt -e .
@@ -340,7 +340,7 @@ Wrong:   1905-01-01, 2025-12-31, 01-15-80
 
 **Solution**:
 1. Ensure Docker is running: `docker --version`
-2. Use absolute paths, not relative: `/workspaces/OpenToken/resources`
+2. Use absolute paths, not relative: `/workspaces/OpenLinkToken/resources`
 3. Clear Docker cache if needed: `docker system prune`
 4. Check file permissions: `ls -la resources/sample.csv`
 

--- a/pages/security.md
+++ b/pages/security.md
@@ -206,7 +206,7 @@ Each run produces a `.metadata.json` with SHA-256 hashes of secrets:
 }
 ```
 
-Use [tools/hash_calculator.py](https://github.com/TruvetaPublic/OpenToken/blob/main/tools/hash_calculator.py) to verify:
+Use [tools/hash_calculator.py](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/tools/hash_calculator.py) to verify:
 
 ```bash
 python tools/hash_calculator.py \


### PR DESCRIPTION
## ⚠️ No Functional Changes

This release contains **no functional changes** to the OpenLinkToken library, CLI, or token generation logic. All existing tokens, attributes, and APIs remain identical.

This release solely ensures the project works correctly following the **repository rename from `OpenToken` → `OpenLinkToken`**.

---

## Changes

All changes are documentation, configuration, and tooling fixes to update references after the rename:

- Update GitHub Pages URLs in `README.md`
- Update Maven distribution URL in `pom.xml` and `maven-publish.yml`
- Update GitHub repo links across 10 `pages/` docs files
- Update `/workspaces/OpenToken` → `/workspaces/OpenLinkToken` paths in docs and config
- Update devcontainer.json venv mount path
- Update `configure-copilot.sh` trusted folder path
- Update CODEOWNERS comment
- Fix dead personal fork link in demo README
- Update contributor clone URL in `contributing.md`
- Update `/path/to/OpenToken` examples in quickstart docs