### PR TITLE
feat: add exchange envelope inspector

### DIFF
--- a/docs/exchange-config-format.md
+++ b/docs/exchange-config-format.md
@@ -175,6 +175,9 @@ Example decrypted payload:
   key must be available locally.
 - A validator or other tool can resolve a private key by the fingerprint-derived
   `kid`, even when operators primarily know the key by a friendly local filename.
+- `tools/exchange/print_exchange_envelope.py` prints the raw serialized envelope,
+  adds a `protectedDecoded` object for the shared JOSE header, and decrypts the inner
+  payload into `decryptedPayload` when a matching private key is available.
 - `tools/exchange/validate_exchange_secret.py` decrypts the payload, checks that a
   supplied private key matches one of the recipient `kid` values, or otherwise tries to
   resolve a matching private key from `~/.openlinktoken/`.

--- a/tools/exchange/print_exchange_envelope.py
+++ b/tools/exchange/print_exchange_envelope.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Print the contents of an Open Link Token exchange JWE envelope and payload."""
+
+from __future__ import annotations
+
+# ruff: noqa: E402
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from validate_exchange_secret import decrypt_exchange_payload, load_exchange_config, resolve_private_key_pem
+
+PROGRAM = "print_exchange_envelope.py"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for exchange envelope inspection."""
+    parser = argparse.ArgumentParser(
+        prog=PROGRAM,
+        description="Print an initiate-exchange JWE envelope, decode its protected header, and decrypt its payload.",
+    )
+    parser.add_argument(
+        "--exchange-config",
+        required=True,
+        help="Path to the .exchange.json file produced by `olt initiate-exchange`.",
+    )
+    private_key_group = parser.add_mutually_exclusive_group(required=False)
+    private_key_group.add_argument(
+        "--private-key",
+        required=False,
+        help="Optional path to a sender or recipient private key PEM that matches one JWE recipient entry.",
+    )
+    private_key_group.add_argument(
+        "--private-key-stdin",
+        action="store_true",
+        default=False,
+        help="Read a sender or recipient private key PEM from stdin instead of a file path.",
+    )
+    return parser.parse_args()
+
+
+def inspect_exchange_envelope(
+    exchange_config_path: Path,
+    private_key_path: Path | None,
+    private_key_stdin: bool = False,
+) -> dict[str, Any]:
+    """Load an exchange envelope and add decoded header and decrypted payload views."""
+    exchange_config = load_exchange_config(exchange_config_path)
+    rendered_envelope = dict(exchange_config)
+    rendered_envelope["protectedDecoded"] = _decode_protected_header(exchange_config["protected"])
+    private_pem = resolve_private_key_pem(exchange_config, private_key_path, private_key_stdin=private_key_stdin)
+    rendered_envelope["decryptedPayload"] = decrypt_exchange_payload(exchange_config, private_pem)
+    return rendered_envelope
+
+
+def _decode_protected_header(protected_header: str) -> dict[str, Any]:
+    """Decode the base64url-protected JOSE header into a JSON object."""
+    padding = "=" * (-len(protected_header) % 4)
+    try:
+        protected_header_bytes = base64.urlsafe_b64decode(protected_header + padding)
+        decoded_header = json.loads(protected_header_bytes)
+    except (ValueError, json.JSONDecodeError) as error:
+        raise ValueError("Exchange config protected header is not valid base64url JSON.") from error
+
+    if not isinstance(decoded_header, dict):
+        raise ValueError("Exchange config protected header must decode to a JSON object.")
+    return decoded_header
+
+
+def main() -> int:
+    """Run the helper and print the rendered envelope JSON."""
+    args = parse_args()
+    exchange_config_path = Path(args.exchange_config).expanduser()
+    private_key_path = Path(args.private_key).expanduser() if args.private_key is not None else None
+
+    try:
+        rendered_envelope = inspect_exchange_envelope(
+            exchange_config_path,
+            private_key_path,
+            private_key_stdin=args.private_key_stdin,
+        )
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"Failed to print exchange envelope: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(rendered_envelope, indent=2, sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/exchange/test_print_exchange_envelope.py
+++ b/tools/exchange/test_print_exchange_envelope.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Executable tests for the exchange envelope inspection helper."""
+
+from __future__ import annotations
+
+# ruff: noqa: E402
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSPECTOR_SCRIPT = REPO_ROOT / "tools" / "exchange" / "print_exchange_envelope.py"
+SAMPLE_EXCHANGE_CONFIG = REPO_ROOT / "lib" / "python" / "openlinktoken-cli" / "openlinktoken-2026-04-19.exchange.json"
+
+from test_validate_exchange_secret import _generate_exchange_fixture
+
+
+def test_inspector_help_lists_exchange_config() -> None:
+    """The inspector help text should advertise the exchange and private-key inputs."""
+    completed = subprocess.run(
+        [sys.executable, str(INSPECTOR_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert "--exchange-config" in completed.stdout
+    assert "--private-key" in completed.stdout
+    assert "--private-key-stdin" in completed.stdout
+
+
+def test_inspector_prints_decoded_protected_header() -> None:
+    """The inspector should print the raw envelope plus a decoded protected header."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        exchange_config_path, _, recipient_private_key_path = _generate_exchange_fixture(temp_path, "shared-secret")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(INSPECTOR_SCRIPT),
+                "--exchange-config",
+                str(exchange_config_path),
+                "--private-key",
+                str(recipient_private_key_path),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            check=False,
+        )
+
+    assert completed.returncode == 0, completed.stderr
+    rendered_envelope = json.loads(completed.stdout)
+    assert rendered_envelope["version"] == 1
+    assert rendered_envelope["protectedDecoded"] == {
+        "typ": "openlinktoken-exchange+jwe",
+        "cty": "application/openlinktoken-exchange+json",
+        "enc": "A256GCM",
+    }
+    assert len(rendered_envelope["recipients"]) == 2
+    assert rendered_envelope["ciphertext"]
+
+
+def test_inspector_prints_decrypted_payload_with_private_key() -> None:
+    """The inspector should decrypt the JWE payload when given a matching private key."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        expected_secret = "shared-secret"
+        exchange_config_path, _, recipient_private_key_path = _generate_exchange_fixture(temp_path, expected_secret)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(INSPECTOR_SCRIPT),
+                "--exchange-config",
+                str(exchange_config_path),
+                "--private-key",
+                str(recipient_private_key_path),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            check=False,
+        )
+
+    assert completed.returncode == 0, completed.stderr
+    rendered_envelope = json.loads(completed.stdout)
+    assert rendered_envelope["decryptedPayload"]["exchangeName"] == "sender-local"
+    assert rendered_envelope["decryptedPayload"]["hashingSecretEncoding"] == "base64url"
+
+
+def test_inspector_rejects_invalid_protected_header() -> None:
+    """The inspector should fail clearly when the protected header is not base64url JSON."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        invalid_exchange_config_path = temp_path / "invalid.exchange.json"
+        invalid_exchange_config = json.loads(SAMPLE_EXCHANGE_CONFIG.read_text(encoding="utf-8"))
+        invalid_exchange_config["protected"] = "not-valid-base64"
+        invalid_exchange_config_path.write_text(json.dumps(invalid_exchange_config), encoding="utf-8")
+
+        completed = subprocess.run(
+            [sys.executable, str(INSPECTOR_SCRIPT), "--exchange-config", str(invalid_exchange_config_path)],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            check=False,
+        )
+
+    assert completed.returncode == 1
+    assert "protected" in completed.stderr.lower()
+
+
+def main() -> int:
+    """Run the inspector tests as a simple executable script."""
+    tests = [
+        test_inspector_help_lists_exchange_config,
+        test_inspector_prints_decoded_protected_header,
+        test_inspector_prints_decrypted_payload_with_private_key,
+        test_inspector_rejects_invalid_protected_header,
+    ]
+
+    print("Running print_exchange_envelope.py tests")
+    print("=" * 48)
+    all_passed = True
+    for test in tests:
+        try:
+            test()
+        except AssertionError as error:
+            all_passed = False
+            print(f"FAIL: {test.__name__}: {error}")
+        except Exception as error:  # pragma: no cover - script-level failure reporting
+            all_passed = False
+            print(f"FAIL: {test.__name__}: {error}")
+        else:
+            print(f"PASS: {test.__name__}")
+
+    print("=" * 48)
+    if all_passed:
+        print("All inspector tests PASSED")
+        return 0
+
+    print("Inspector tests FAILED")
+    return 1
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exit_code)

--- a/tools/exchange/validate_exchange_secret.py
+++ b/tools/exchange/validate_exchange_secret.py
@@ -65,13 +65,13 @@ def decrypt_exchange_secret(
     private_key_stdin: bool = False,
 ) -> bytes:
     """Recover the plaintext hashing secret bytes from a JWE exchange config."""
-    exchange_config = _load_exchange_config(exchange_config_path)
-    private_pem = _resolve_private_key_pem(exchange_config, private_key_path, private_key_stdin=private_key_stdin)
-    payload = _decrypt_payload(exchange_config, private_pem)
+    exchange_config = load_exchange_config(exchange_config_path)
+    private_pem = resolve_private_key_pem(exchange_config, private_key_path, private_key_stdin=private_key_stdin)
+    payload = decrypt_exchange_payload(exchange_config, private_pem)
     return _extract_hashing_secret(payload)
 
 
-def _load_exchange_config(exchange_config_path: Path) -> dict[str, Any]:
+def load_exchange_config(exchange_config_path: Path) -> dict[str, Any]:
     """Load and validate the top-level exchange config structure."""
     exchange_config = json.loads(exchange_config_path.read_text(encoding="utf-8"))
     if not isinstance(exchange_config, dict):
@@ -87,7 +87,7 @@ def _load_exchange_config(exchange_config_path: Path) -> dict[str, Any]:
     return exchange_config
 
 
-def _resolve_private_key_pem(
+def resolve_private_key_pem(
     exchange_config: dict[str, Any],
     private_key_path: Path | None,
     private_key_stdin: bool = False,
@@ -151,7 +151,7 @@ def _kid_for_private_key(private_pem: bytes) -> str:
     return fingerprint_to_kid(public_key_fingerprint(public_pem))
 
 
-def _decrypt_payload(exchange_config: dict[str, Any], private_pem: bytes) -> dict[str, Any]:
+def decrypt_exchange_payload(exchange_config: dict[str, Any], private_pem: bytes) -> dict[str, Any]:
     """Decrypt the exchange envelope and parse the payload JSON."""
     try:
         payload_bytes = decrypt_exchange_envelope(exchange_config, private_pem)


### PR DESCRIPTION
## Summary

- Add a tooling helper that prints the exchange envelope, decodes the protected JOSE header, and decrypts the inner payload JSON.
- Reuse the validator's exchange loading and decryption helpers so both scripts resolve keys the same way.

## Related issues

- None.
- None.

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Added `tools/exchange/print_exchange_envelope.py` and executable coverage in `tools/exchange/test_print_exchange_envelope.py`.
- Exported shared exchange loading / payload decryption helpers from `tools/exchange/validate_exchange_secret.py`.
- Documented the new decrypted-payload workflow in `docs/exchange-config-format.md`.