### PR TITLE
feat: refresh CLI progress, summaries, and logging

### DIFF
--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -263,7 +263,7 @@ Example:
 # After installing openlinktoken-cli
 python -m openlinktoken_cli.main package \
   -i resources/sample.csv -o resources/output.csv \
-  -h "HashingKey" -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ./openlinktoken-YYYY-MM-DD.exchange.json
 ```
 
 Programmatic API (simplified):
@@ -691,18 +691,18 @@ Minimum required arguments:
 
 ```shell
 # Python
-python -m openlinktoken_cli.main package -i input.csv -o output.csv --exchange-config ./openlinktoken-YYYY-MM-DD.exchange.json --private-key ~/.openlinktoken/openlinktoken-YYYY-MM-DD.private.pem
+python -m openlinktoken_cli.main package -i input.csv -o output.csv --exchange-config ./openlinktoken-YYYY-MM-DD.exchange.json
 ```
 
 Arguments:
 
-| Flag                 | Description                                     |
-| -------------------- | ----------------------------------------------- |
-| `-i, --input`        | Input file path                                 |
-| `-o, --output`       | Output file path                                |
-| `--exchange-config`  | Exchange config JSON path                       |
-| `--private-key`      | Private key PEM used to decrypt the config      |
-| `--private-key-env`  | Environment variable containing the private key |
+| Flag                | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `-i, --input`       | Input file path                                 |
+| `-o, --output`      | Output file path                                |
+| `--exchange-config` | Exchange config JSON path                       |
+| `--private-key`     | Private key PEM used to decrypt the config      |
+| `--private-key-env` | Environment variable containing the private key |
 
 ### Key Pair Generation
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/decrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/decrypt_command.py
@@ -9,7 +9,9 @@ from openlinktoken_cli.io.csv.token_csv_writer import TokenCSVWriter
 from openlinktoken_cli.io.parquet.token_parquet_reader import TokenParquetReader
 from openlinktoken_cli.io.parquet.token_parquet_writer import TokenParquetWriter
 from openlinktoken_cli.processor.token_decryption_processor import TokenDecryptionProcessor
+from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
 
@@ -79,8 +81,6 @@ class DecryptCommand:
     @staticmethod
     def execute(args):
         """Execute the decrypt command."""
-        logger.info("Running decrypt command")
-
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -91,30 +91,42 @@ class DecryptCommand:
             logger.error("Unable to auto-detect output type. Supported output formats: csv, parquet, zip")
             return 1
 
-        # Log parameters (mask key)
-        logger.info(f"Input: {args.input_path} ({input_type})")
-        logger.info(f"Output: {args.output_path} ({output_type})")
+        reporter = CliRunReporter("decrypt")
 
         try:
-            exchange = resolve_exchange_config(
-                args.exchange_config,
-                private_key_path=args.private_key,
-                private_key_env=args.private_key_env,
-            )
-            encryption_key = derive_transport_encryption_key(exchange)
-            logger.info(f"Exchange config: {exchange.path}")
-            DecryptCommand._decrypt_tokens(
-                args.input_path,
-                args.output_path,
-                input_type,
-                output_type,
-                encryption_key,
-            )
-            logger.info("Token decryption completed successfully")
+            with reporter:
+                try:
+                    logger.info("Running decrypt command")
+                    logger.info(f"Input: {args.input_path} ({input_type})")
+                    logger.info(f"Output: {args.output_path} ({output_type})")
+
+                    reporter.update_status("Resolving exchange config")
+                    exchange = resolve_exchange_config(
+                        args.exchange_config,
+                        private_key_path=args.private_key,
+                        private_key_env=args.private_key_env,
+                    )
+                    encryption_key = derive_transport_encryption_key(exchange)
+                    logger.info(f"Exchange config: {exchange.path}")
+
+                    reporter.update_status("Decrypting tokens")
+                    summary = DecryptCommand._decrypt_tokens(
+                        args.input_path,
+                        args.output_path,
+                        input_type,
+                        output_type,
+                        encryption_key,
+                        progress_callback=reporter.make_progress_callback("Decrypting tokens", "tokens"),
+                    )
+                    logger.info("Token decryption completed successfully")
+                except Exception as error:
+                    logger.error("Error during token decryption: %s", error)
+                    raise
+            reporter.finish_success("Decrypt complete", DecryptCommand._build_summary_lines(args.output_path, summary))
             return 0
-        except (OSError, ValueError) as error:
-            logger.error("Error during token decryption: %s", error)
-            report = archive_cli_error(error, command_name="decrypt")
+        except Exception as error:
+            report = archive_cli_error(error, command_name="decrypt", existing_report=reporter.log_report)
+            print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
 
@@ -125,7 +137,8 @@ class DecryptCommand:
         input_type: str,
         output_type: str,
         encryption_key: bytes,
-    ):
+        progress_callback=None,
+    ) -> TokenTransformationSummary:
         """Decrypt tokens from input file."""
         try:
             decryptor = DecryptTokenTransformer(encryption_key)
@@ -134,10 +147,25 @@ class DecryptCommand:
                 DecryptCommand._create_token_reader(input_path, input_type) as reader,
                 DecryptCommand._create_token_writer(output_path, output_type) as writer,
             ):
-                TokenDecryptionProcessor.process_with_key(reader, writer, decryptor, encryption_key)
+                return TokenDecryptionProcessor.process_with_key(
+                    reader,
+                    writer,
+                    decryptor,
+                    encryption_key,
+                    progress_callback,
+                )
 
         except Exception:
             raise
+
+    @staticmethod
+    def _build_summary_lines(output_path: str, summary: TokenTransformationSummary) -> list[str]:
+        return [
+            f"Output: {output_path}",
+            f"Tokens processed: {summary.total_tokens:,}",
+            f"Successfully decrypted: {summary.transformed_tokens:,}",
+            f"Failed to decrypt: {summary.failed_tokens:,}",
+        ]
 
     @staticmethod
     def _create_token_reader(path: str, file_type: str):

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -12,7 +12,9 @@ from openlinktoken_cli.io.csv.token_csv_writer import TokenCSVWriter
 from openlinktoken_cli.io.parquet.token_parquet_reader import TokenParquetReader
 from openlinktoken_cli.io.parquet.token_parquet_writer import TokenParquetWriter
 from openlinktoken_cli.processor.token_constants import TokenConstants
+from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
 
@@ -89,8 +91,6 @@ class EncryptCommand:
     @staticmethod
     def execute(args):
         """Execute the encrypt command."""
-        logger.info("Running encrypt command")
-
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -102,33 +102,44 @@ class EncryptCommand:
             return 1
 
         ring_id = args.ring_id if args.ring_id and args.ring_id.strip() else str(uuid.uuid4())
-
-        # Log parameters (mask key)
-        logger.info(f"Input: {args.input_path} ({input_type})")
-        logger.info(f"Output: {args.output_path} ({output_type})")
-        logger.info(f"Ring ID: {ring_id}")
+        reporter = CliRunReporter("encrypt")
 
         try:
-            exchange = resolve_exchange_config(
-                args.exchange_config,
-                private_key_path=args.private_key,
-                private_key_env=args.private_key_env,
-            )
-            encryption_key = derive_transport_encryption_key(exchange)
-            logger.info(f"Exchange config: {exchange.path}")
-            EncryptCommand._encrypt_tokens(
-                args.input_path,
-                args.output_path,
-                input_type,
-                output_type,
-                encryption_key,
-                ring_id,
-            )
-            logger.info("Token encryption completed successfully")
+            with reporter:
+                try:
+                    logger.info("Running encrypt command")
+                    logger.info(f"Input: {args.input_path} ({input_type})")
+                    logger.info(f"Output: {args.output_path} ({output_type})")
+                    logger.info(f"Ring ID: {ring_id}")
+
+                    reporter.update_status("Resolving exchange config")
+                    exchange = resolve_exchange_config(
+                        args.exchange_config,
+                        private_key_path=args.private_key,
+                        private_key_env=args.private_key_env,
+                    )
+                    encryption_key = derive_transport_encryption_key(exchange)
+                    logger.info(f"Exchange config: {exchange.path}")
+
+                    reporter.update_status("Encrypting tokens")
+                    summary = EncryptCommand._encrypt_tokens(
+                        args.input_path,
+                        args.output_path,
+                        input_type,
+                        output_type,
+                        encryption_key,
+                        ring_id,
+                        progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
+                    )
+                    logger.info("Token encryption completed successfully")
+                except Exception as error:
+                    logger.error("Error during token encryption: %s", error)
+                    raise
+            reporter.finish_success("Encrypt complete", EncryptCommand._build_summary_lines(args.output_path, summary))
             return 0
-        except (OSError, ValueError) as error:
-            logger.error("Error during token encryption: %s", error)
-            report = archive_cli_error(error, command_name="encrypt")
+        except Exception as error:
+            report = archive_cli_error(error, command_name="encrypt", existing_report=reporter.log_report)
+            print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
 
@@ -140,7 +151,8 @@ class EncryptCommand:
         output_type: str,
         encryption_key: bytes,
         ring_id: str,
-    ):
+        progress_callback=None,
+    ) -> TokenTransformationSummary:
         """Encrypt tokens from input file."""
         try:
             encryptor = EncryptTokenTransformer(encryption_key)
@@ -148,6 +160,7 @@ class EncryptCommand:
             row_counter = 0
             encrypted_counter = 0
             error_counter = 0
+            last_reported_count = 0
 
             with (
                 EncryptCommand._create_token_reader(input_path, input_type) as reader,
@@ -180,14 +193,33 @@ class EncryptCommand:
 
                     if row_counter % 10000 == 0:
                         logger.info(f'Processed "{row_counter:,}" tokens')
+                        last_reported_count = row_counter
+                        if progress_callback is not None:
+                            progress_callback(row_counter)
 
             logger.info(f"Processed a total of {row_counter:,} tokens")
             logger.info(f"Successfully encrypted {encrypted_counter:,} tokens")
             if error_counter > 0:
                 logger.warning(f"Failed to encrypt {error_counter:,} tokens")
+            if progress_callback is not None and row_counter != last_reported_count:
+                progress_callback(row_counter)
+            return TokenTransformationSummary(
+                total_tokens=row_counter,
+                transformed_tokens=encrypted_counter,
+                failed_tokens=error_counter,
+            )
 
         except Exception:
             raise
+
+    @staticmethod
+    def _build_summary_lines(output_path: str, summary: TokenTransformationSummary) -> list[str]:
+        return [
+            f"Output: {output_path}",
+            f"Tokens processed: {summary.total_tokens:,}",
+            f"Successfully encrypted: {summary.transformed_tokens:,}",
+            f"Failed to encrypt: {summary.failed_tokens:,}",
+        ]
 
     @staticmethod
     def _wrap_as_v1_token(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/open_link_token_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/open_link_token_command.py
@@ -7,6 +7,7 @@ import sys
 
 from openlinktoken.metadata import Metadata
 from openlinktoken_cli.util.cli_error_reporter import archive_unexpected_error, format_unexpected_error_message
+from openlinktoken_cli.util.cli_run_reporter import configure_default_logging
 from openlinktoken_cli.util.version_checker import start_version_check
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,7 @@ class OpenLinkTokenCommand:
     @staticmethod
     def main(args=None):
         """Main entry point for the command-line application."""
+        configure_default_logging()
         parser = OpenLinkTokenCommand.create_parser()
 
         # Show banner for interactive runs.

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -14,8 +14,12 @@ from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttribut
 from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
 from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
-from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+from openlinktoken_cli.processor.person_attributes_processor import (
+    PersonAttributesProcessingSummary,
+    PersonAttributesProcessor,
+)
 from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
 
@@ -107,8 +111,6 @@ class PackageCommand:
     @staticmethod
     def execute(args):
         """Execute the package command."""
-        logger.info("Running package command (tokenize + encrypt)")
-
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -121,37 +123,51 @@ class PackageCommand:
 
         ring_id = args.ring_id if args.ring_id and args.ring_id.strip() else str(uuid.uuid4())
         hash_record_ids = getattr(args, "hash_record_ids", False)
-
-        # Log parameters (mask secrets)
-        logger.info(f"Input: {args.input_path} ({input_type})")
-        logger.info(f"Output: {args.output_path} ({output_type})")
-        logger.info(f"Ring ID: {ring_id}")
-        if hash_record_ids:
-            logger.info("Record ID hashing enabled: RecordIds will be SHA-256 hashed in output")
+        reporter = CliRunReporter("package")
 
         try:
-            exchange = resolve_exchange_config(
-                args.exchange_config,
-                private_key_path=args.private_key,
-                private_key_env=args.private_key_env,
+            with reporter:
+                try:
+                    logger.info("Running package command (tokenize + encrypt)")
+                    logger.info(f"Input: {args.input_path} ({input_type})")
+                    logger.info(f"Output: {args.output_path} ({output_type})")
+                    logger.info(f"Ring ID: {ring_id}")
+                    if hash_record_ids:
+                        logger.info("Record ID hashing enabled: RecordIds will be SHA-256 hashed in output")
+
+                    reporter.update_status("Resolving exchange config")
+                    exchange = resolve_exchange_config(
+                        args.exchange_config,
+                        private_key_path=args.private_key,
+                        private_key_env=args.private_key_env,
+                    )
+                    encryption_key = derive_transport_encryption_key(exchange)
+                    logger.info(f"Exchange config: {exchange.path}")
+
+                    reporter.update_status("Packaging records")
+                    summary, metadata_path = PackageCommand._process_tokens(
+                        args.input_path,
+                        args.output_path,
+                        input_type,
+                        output_type,
+                        exchange.hashing_secret,
+                        encryption_key,
+                        ring_id,
+                        hash_record_ids,
+                        progress_callback=reporter.make_progress_callback("Packaging records", "records"),
+                    )
+                    logger.info("Token generation and encryption completed successfully")
+                except Exception as error:
+                    logger.error("Error during token processing: %s", error)
+                    raise
+            reporter.finish_success(
+                "Package complete",
+                PackageCommand._build_summary_lines(args.output_path, metadata_path, summary, hash_record_ids),
             )
-            encryption_key = derive_transport_encryption_key(exchange)
-            logger.info(f"Exchange config: {exchange.path}")
-            PackageCommand._process_tokens(
-                args.input_path,
-                args.output_path,
-                input_type,
-                output_type,
-                exchange.hashing_secret,
-                encryption_key,
-                ring_id,
-                hash_record_ids,
-            )
-            logger.info("Token generation and encryption completed successfully")
             return 0
-        except (OSError, ValueError) as error:
-            logger.error("Error during token processing: %s", error)
-            report = archive_cli_error(error, command_name="package")
+        except Exception as error:
+            report = archive_cli_error(error, command_name="package", existing_report=reporter.log_report)
+            print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
 
@@ -165,7 +181,8 @@ class PackageCommand:
         encryption_key: bytes,
         ring_id: str,
         hash_record_ids: bool = False,
-    ):
+        progress_callback=None,
+    ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens from person attributes."""
         token_transformer_list: List[TokenTransformer] = []
 
@@ -188,7 +205,7 @@ class PackageCommand:
                 metadata.add_hashed_secret(Metadata.ENCRYPTION_SECRET_HASH, encryption_key)
 
                 # Process data with JWE wrapping support for v1 token format
-                PersonAttributesProcessor.process(
+                summary = PersonAttributesProcessor.process(
                     reader,
                     writer,
                     token_transformer_list,
@@ -196,14 +213,37 @@ class PackageCommand:
                     encryption_key,
                     ring_id,
                     hash_record_ids,
+                    progress_callback=progress_callback,
                 )
 
                 # Write metadata
                 metadata_writer = MetadataJsonWriter(output_path)
                 metadata_writer.write(metadata_map)
+                return summary, metadata_writer.metadata_file_path
 
         except Exception:
             raise
+
+    @staticmethod
+    def _build_summary_lines(
+        output_path: str,
+        metadata_path: str,
+        summary: PersonAttributesProcessingSummary,
+        hash_record_ids: bool,
+    ) -> list[str]:
+        lines = [
+            f"Output: {output_path}",
+            f"Metadata: {metadata_path}",
+            f"Rows processed: {summary.total_rows:,}",
+            f"Rows with invalid attributes: {summary.total_rows_with_invalid_attributes:,}",
+        ]
+        lines.extend(
+            CliRunReporter.summarize_count_lines("Top invalid attributes", summary.invalid_attributes_by_type, limit=3)
+        )
+        lines.extend(CliRunReporter.summarize_count_lines("Blank tokens by rule", summary.blank_tokens_by_rule))
+        if hash_record_ids:
+            lines.append("Record ID hashing: enabled")
+        return lines
 
     @staticmethod
     def _create_reader(path: str, file_type: str):

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
@@ -18,9 +18,11 @@ from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import (
     PersonAttributesParquetWriter,
 )
 from openlinktoken_cli.processor.person_attributes_processor import (
+    PersonAttributesProcessingSummary,
     PersonAttributesProcessor,
 )
 from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import resolve_exchange_config
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
 
@@ -39,8 +41,6 @@ class TokenizeCommand:
     to explore the output without managing secrets. Demo-mode output is
     **not** suitable for production or cross-organisation exchange.
     """
-
-
 
     @staticmethod
     def register_subcommand(subparsers):
@@ -78,8 +78,6 @@ class TokenizeCommand:
             dest="output_path",
             help="Output file path",
         )
-
-
 
         parser.add_argument(
             "--demo-mode",
@@ -135,14 +133,6 @@ class TokenizeCommand:
         demo_mode = getattr(args, "demo_mode", False)
         hash_record_ids = getattr(args, "hash_record_ids", False)
 
-        if demo_mode:
-            logger.warning(
-                "Running in DEMO MODE - tokens are raw attribute signature strings with no hashing. "
-                "Do not use demo-mode output in production or share it externally."
-            )
-        else:
-            logger.info("Running tokenize command (normal mode)")
-
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -153,43 +143,71 @@ class TokenizeCommand:
             logger.error("Unable to auto-detect output type. Supported output formats: csv, parquet, zip")
             return 1
 
-        logger.info(f"Input: {args.input_path} ({input_type})")
-        logger.info(f"Output: {args.output_path} ({output_type})")
-        if hash_record_ids:
-            logger.info("Record ID hashing enabled: RecordIds will be SHA-256 hashed in output")
-
         if demo_mode and args.exchange_config:
             logger.error("--demo-mode cannot be combined with --exchange-config.")
             return 1
 
+        reporter = CliRunReporter("tokenize")
         try:
-            if demo_mode:
-                TokenizeCommand._process_tokens_demo(
-                    args.input_path,
+            with reporter:
+                try:
+                    if demo_mode:
+                        logger.warning(
+                            "Running in DEMO MODE - tokens are raw attribute signature strings with no hashing. "
+                            "Do not use demo-mode output in production or share it externally."
+                        )
+                    else:
+                        logger.info("Running tokenize command (normal mode)")
+                    logger.info(f"Input: {args.input_path} ({input_type})")
+                    logger.info(f"Output: {args.output_path} ({output_type})")
+                    if hash_record_ids:
+                        logger.info("Record ID hashing enabled: RecordIds will be SHA-256 hashed in output")
+
+                    if demo_mode:
+                        reporter.update_status("Tokenizing records")
+                        summary, metadata_path = TokenizeCommand._process_tokens_demo(
+                            args.input_path,
+                            args.output_path,
+                            input_type,
+                            output_type,
+                            progress_callback=reporter.make_progress_callback("Tokenizing records", "records"),
+                        )
+                    else:
+                        reporter.update_status("Resolving exchange config")
+                        exchange = resolve_exchange_config(
+                            args.exchange_config,
+                            private_key_path=args.private_key,
+                            private_key_env=args.private_key_env,
+                        )
+                        logger.info(f"Exchange config: {exchange.path}")
+                        reporter.update_status("Tokenizing records")
+                        summary, metadata_path = TokenizeCommand._process_tokens(
+                            args.input_path,
+                            args.output_path,
+                            input_type,
+                            output_type,
+                            exchange.hashing_secret,
+                            hash_record_ids,
+                            progress_callback=reporter.make_progress_callback("Tokenizing records", "records"),
+                        )
+                    logger.info("Token generation completed successfully")
+                except Exception as error:
+                    logger.error("Error during token generation: %s", error)
+                    raise
+            reporter.finish_success(
+                "Tokenize complete",
+                TokenizeCommand._build_summary_lines(
                     args.output_path,
-                    input_type,
-                    output_type,
-                )
-            else:
-                exchange = resolve_exchange_config(
-                    args.exchange_config,
-                    private_key_path=args.private_key,
-                    private_key_env=args.private_key_env,
-                )
-                logger.info(f"Exchange config: {exchange.path}")
-                TokenizeCommand._process_tokens(
-                    args.input_path,
-                    args.output_path,
-                    input_type,
-                    output_type,
-                    exchange.hashing_secret,
+                    metadata_path,
+                    summary,
+                    demo_mode,
                     hash_record_ids,
-                )
-            logger.info("Token generation completed successfully")
+                ),
+            )
             return 0
-        except (OSError, ValueError) as error:
-            logger.error("Error during token generation: %s", error)
-            report = archive_cli_error(error, command_name="tokenize")
+        except Exception as error:
+            report = archive_cli_error(error, command_name="tokenize", existing_report=reporter.log_report)
+            print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
 
@@ -201,7 +219,8 @@ class TokenizeCommand:
         output_type: str,
         hashing_secret: str | bytes,
         hash_record_ids: bool = False,
-    ):
+        progress_callback=None,
+    ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in normal mode using SHA-256 + HMAC-SHA256."""
         token_transformer_list: List[TokenTransformer] = []
 
@@ -221,11 +240,18 @@ class TokenizeCommand:
                 # Only record the hashing-secret hash in normal mode
                 metadata.add_hashed_secret(Metadata.HASHING_SECRET_HASH, hashing_secret)
 
-                PersonAttributesProcessor.process(
-                    reader, writer, token_transformer_list, metadata_map, hash_record_ids=hash_record_ids
+                summary = PersonAttributesProcessor.process(
+                    reader,
+                    writer,
+                    token_transformer_list,
+                    metadata_map,
+                    hash_record_ids=hash_record_ids,
+                    progress_callback=progress_callback,
                 )
 
-                MetadataJsonWriter(output_path).write(metadata_map)
+                metadata_writer = MetadataJsonWriter(output_path)
+                metadata_writer.write(metadata_map)
+                return summary, metadata_writer.metadata_file_path
 
         except Exception:
             raise
@@ -236,7 +262,8 @@ class TokenizeCommand:
         output_path: str,
         input_type: str,
         output_type: str,
-    ):
+        progress_callback=None,
+    ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in demo mode using PassthroughTokenizer (no hashing)."""
         try:
             with (
@@ -247,12 +274,43 @@ class TokenizeCommand:
                 metadata_map = metadata.initialize()
                 # Deliberately omit add_hashed_secret — no secret used in demo mode
 
-                PersonAttributesProcessor.process_with_tokenizer(reader, writer, PassthroughTokenizer([]), metadata_map)
+                summary = PersonAttributesProcessor.process_with_tokenizer(
+                    reader,
+                    writer,
+                    PassthroughTokenizer([]),
+                    metadata_map,
+                    progress_callback=progress_callback,
+                )
 
-                MetadataJsonWriter(output_path).write(metadata_map)
+                metadata_writer = MetadataJsonWriter(output_path)
+                metadata_writer.write(metadata_map)
+                return summary, metadata_writer.metadata_file_path
 
         except Exception:
             raise
+
+    @staticmethod
+    def _build_summary_lines(
+        output_path: str,
+        metadata_path: str,
+        summary: PersonAttributesProcessingSummary,
+        demo_mode: bool,
+        hash_record_ids: bool,
+    ) -> list[str]:
+        lines = [
+            f"Output: {output_path}",
+            f"Metadata: {metadata_path}",
+            f"Mode: {'demo' if demo_mode else 'hashed'}",
+            f"Rows processed: {summary.total_rows:,}",
+            f"Rows with invalid attributes: {summary.total_rows_with_invalid_attributes:,}",
+        ]
+        lines.extend(
+            CliRunReporter.summarize_count_lines("Top invalid attributes", summary.invalid_attributes_by_type, limit=3)
+        )
+        lines.extend(CliRunReporter.summarize_count_lines("Blank tokens by rule", summary.blank_tokens_by_rule))
+        if hash_record_ids:
+            lines.append("Record ID hashing: enabled")
+        return lines
 
     @staticmethod
     def _create_reader(path: str, file_type: str):

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/main.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/main.py
@@ -4,8 +4,9 @@ import logging
 import sys
 
 from openlinktoken_cli.commands import OpenLinkTokenCommand
+from openlinktoken_cli.util.cli_run_reporter import configure_default_logging
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+configure_default_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
@@ -2,6 +2,7 @@
 
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Any, Dict, List, Set, Type
 
 from openlinktoken.attributes.attribute import Attribute
@@ -19,6 +20,16 @@ from openlinktoken_cli.processor.token_constants import TokenConstants
 from openlinktoken_cli.util.record_id_hasher import RecordIdHasher
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PersonAttributesProcessingSummary:
+    """Summary counters for a token generation run."""
+
+    total_rows: int
+    total_rows_with_invalid_attributes: int
+    invalid_attributes_by_type: Dict[str, int]
+    blank_tokens_by_rule: Dict[str, int]
 
 
 class PersonAttributesProcessor:
@@ -47,7 +58,8 @@ class PersonAttributesProcessor:
         encryption_key: str = None,
         ring_id: str = None,
         hash_record_ids: bool = False,
-    ) -> None:
+        progress_callback=None,
+    ) -> PersonAttributesProcessingSummary:
         """
         Read person attributes from the input data source, generate tokens, and
         write the result back to the output data source. The tokens can be optionally
@@ -66,7 +78,7 @@ class PersonAttributesProcessor:
         """
         # TokenGenerator code
         token_definition = TokenDefinition()
-        PersonAttributesProcessor._process_with_tokenizer(
+        return PersonAttributesProcessor._process_with_tokenizer(
             reader,
             writer,
             SHA256Tokenizer(token_transformer_list),
@@ -75,6 +87,7 @@ class PersonAttributesProcessor:
             encryption_key,
             ring_id,
             hash_record_ids,
+            progress_callback,
         )
 
     @staticmethod
@@ -83,7 +96,8 @@ class PersonAttributesProcessor:
         writer: PersonAttributesWriter,
         tokenizer: Tokenizer,
         metadata_map: Dict[str, Any] = None,
-    ) -> None:
+        progress_callback=None,
+    ) -> PersonAttributesProcessingSummary:
         """
         Read person attributes from the input data source, generate tokens using
         the provided tokenizer, and write the result to the output data source.
@@ -98,7 +112,14 @@ class PersonAttributesProcessor:
             metadata_map: Optional metadata map to update with processing statistics.
         """
         token_definition = TokenDefinition()
-        PersonAttributesProcessor._process_with_tokenizer(reader, writer, tokenizer, token_definition, metadata_map)
+        return PersonAttributesProcessor._process_with_tokenizer(
+            reader,
+            writer,
+            tokenizer,
+            token_definition,
+            metadata_map,
+            progress_callback=progress_callback,
+        )
 
     @staticmethod
     def _process_with_tokenizer(
@@ -110,7 +131,8 @@ class PersonAttributesProcessor:
         encryption_key: str = None,
         ring_id: str = None,
         hash_record_ids: bool = False,
-    ) -> None:
+        progress_callback=None,
+    ) -> PersonAttributesProcessingSummary:
         """
         Core row-processing logic shared by all process() overloads.
 
@@ -127,6 +149,7 @@ class PersonAttributesProcessor:
         token_generator = TokenGenerator(token_definition, tokenizer)
 
         row_counter = 0
+        last_reported_count = 0
         invalid_attribute_count: Dict[str, int] = PersonAttributesProcessor._initialize_invalid_attribute_count(
             token_definition
         )
@@ -175,6 +198,9 @@ class PersonAttributesProcessor:
 
                 if row_counter % 10000 == 0:
                     logger.info(f"Processed {row_counter:,} records")
+                    last_reported_count = row_counter
+                    if progress_callback is not None:
+                        progress_callback(row_counter)
 
         except Exception as e:
             logger.error("Error processing records: %s", e)
@@ -195,6 +221,8 @@ class PersonAttributesProcessor:
 
         total_blank_tokens = sum(blank_tokens_by_rule_count.values())
         logger.info(f"Total blank tokens generated: {total_blank_tokens:,}")
+        if progress_callback is not None and row_counter != last_reported_count:
+            progress_callback(row_counter)
 
         # Update metadata if provided
         if metadata_map is not None:
@@ -207,6 +235,13 @@ class PersonAttributesProcessor:
             metadata_map[PersonAttributesProcessor.BLANK_TOKENS_BY_RULE] = dict(
                 sorted(blank_tokens_by_rule_count.items())
             )
+
+        return PersonAttributesProcessingSummary(
+            total_rows=row_counter,
+            total_rows_with_invalid_attributes=total_invalid_records,
+            invalid_attributes_by_type=dict(sorted(invalid_attribute_count.items())),
+            blank_tokens_by_rule=dict(sorted(blank_tokens_by_rule_count.items())),
+        )
 
     @staticmethod
     def _write_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/token_decryption_processor.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/token_decryption_processor.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+from typing import Callable
 
 from jwcrypto import jwe, jwk
 
@@ -16,6 +17,7 @@ from openlinktoken.tokentransformer.match_token_constants import (
 from openlinktoken_cli.io.token_reader import TokenReader
 from openlinktoken_cli.io.token_writer import TokenWriter
 from openlinktoken_cli.processor.token_constants import TokenConstants
+from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +31,12 @@ class TokenDecryptionProcessor:
     """
 
     @staticmethod
-    def process(reader: TokenReader, writer: TokenWriter, decryptor: DecryptTokenTransformer):
+    def process(
+        reader: TokenReader,
+        writer: TokenWriter,
+        decryptor: DecryptTokenTransformer,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> TokenTransformationSummary:
         """
         Reads encrypted tokens from the input data source, decrypts them, and
         writes the result back to the output data source.
@@ -39,7 +46,7 @@ class TokenDecryptionProcessor:
             writer: Writer instance with write_token method
             decryptor: The decryption transformer
         """
-        TokenDecryptionProcessor.process_with_key(reader, writer, decryptor, None)
+        return TokenDecryptionProcessor.process_with_key(reader, writer, decryptor, None, progress_callback)
 
     @staticmethod
     def process_with_key(
@@ -47,7 +54,8 @@ class TokenDecryptionProcessor:
         writer: TokenWriter,
         decryptor: DecryptTokenTransformer,
         encryption_key: str | bytes | None,
-    ):
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> TokenTransformationSummary:
         """
         Reads encrypted tokens from the input data source, decrypts them, and
         writes the result back to the output data source.
@@ -61,6 +69,7 @@ class TokenDecryptionProcessor:
         row_counter = 0
         decrypted_counter = 0
         error_counter = 0
+        last_reported_count = 0
 
         for row in reader:
             row_counter += 1
@@ -85,11 +94,22 @@ class TokenDecryptionProcessor:
 
             if row_counter % 10000 == 0:
                 logger.info(f'Processed "{row_counter:,}" tokens')
+                last_reported_count = row_counter
+                if progress_callback is not None:
+                    progress_callback(row_counter)
 
         logger.info(f"Processed a total of {row_counter:,} tokens")
         logger.info(f"Successfully decrypted {decrypted_counter:,} tokens")
         if error_counter > 0:
             logger.warning(f"Failed to decrypt {error_counter:,} tokens")
+        if progress_callback is not None and row_counter != last_reported_count:
+            progress_callback(row_counter)
+
+        return TokenTransformationSummary(
+            total_tokens=row_counter,
+            transformed_tokens=decrypted_counter,
+            failed_tokens=error_counter,
+        )
 
     @staticmethod
     def _decrypt_token(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/token_transformation_processor.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/token_transformation_processor.py
@@ -4,7 +4,8 @@ Unified processor for token transformations (encryption/decryption).
 """
 
 import logging
-from typing import Protocol
+from dataclasses import dataclass
+from typing import Callable, Protocol
 
 from openlinktoken.tokens import Token
 
@@ -19,6 +20,15 @@ class TokenTransformer(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class TokenTransformationSummary:
+    """Summary counters for token encryption or decryption runs."""
+
+    total_tokens: int
+    transformed_tokens: int
+    failed_tokens: int
+
+
 class TokenTransformationProcessor:
     """
     Unified processor for token transformations (encryption/decryption).
@@ -28,7 +38,13 @@ class TokenTransformationProcessor:
     """
 
     @staticmethod
-    def process(reader, writer, transformer: TokenTransformer, operation: str):
+    def process(
+        reader,
+        writer,
+        transformer: TokenTransformer,
+        operation: str,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> TokenTransformationSummary:
         """
         Read tokens from input, transform them, and write to output.
 
@@ -41,6 +57,7 @@ class TokenTransformationProcessor:
         row_counter = 0
         transformed_counter = 0
         error_counter = 0
+        last_reported_count = 0
 
         for row in reader:
             row_counter += 1
@@ -66,8 +83,19 @@ class TokenTransformationProcessor:
 
             if row_counter % 10000 == 0:
                 logger.info(f'Processed "{row_counter:,}" tokens')
+                last_reported_count = row_counter
+                if progress_callback is not None:
+                    progress_callback(row_counter)
 
         logger.info(f"Processed a total of {row_counter:,} tokens")
         logger.info(f"Successfully {operation} {transformed_counter:,} tokens")
         if error_counter > 0:
             logger.warning(f"Failed to {operation} {error_counter:,} tokens")
+        if progress_callback is not None and row_counter != last_reported_count:
+            progress_callback(row_counter)
+
+        return TokenTransformationSummary(
+            total_tokens=row_counter,
+            transformed_tokens=transformed_counter,
+            failed_tokens=error_counter,
+        )

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/cli_error_reporter.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/cli_error_reporter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import logging
 import os
 import re
 import sys
@@ -29,7 +30,7 @@ _SENSITIVE_KV_PATTERN = re.compile(
 )
 
 
-def _redact_sensitive_text(value: str) -> str:
+def redact_sensitive_text(value: str) -> str:
     redacted = value
     for pattern in _SENSITIVE_FLAG_PATTERNS:
         redacted = pattern.sub(
@@ -42,33 +43,58 @@ def _redact_sensitive_text(value: str) -> str:
     return redacted
 
 
-def archive_cli_error(error: BaseException, command_name: str | None = None) -> CliErrorReport:
-    """Persist an exception traceback under the Open Link Token logs directory."""
+class RedactingFormatter(logging.Formatter):
+    """Formatter that redacts sensitive values before writing log output."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return redact_sensitive_text(super().format(record))
+
+
+def create_cli_log_report(command_name: str | None = None) -> CliErrorReport:
+    """Create a log reference under the Open Link Token logs directory."""
     logs_dir = get_logs_dir()
     logs_dir.mkdir(parents=True, exist_ok=True)
 
     reference_id = uuid.uuid4().hex[:8]
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    log_path = logs_dir / f"{timestamp}-{reference_id}.log"
-
-    command_line = _redact_sensitive_text(command_name or "<unknown>")
-    traceback_text = _redact_sensitive_text(
-        "".join(traceback.format_exception(type(error), error, error.__traceback__))
-    )
-    log_path.write_text(
-        "\n".join(
-            [
-                f"Reference: {reference_id}",
-                f"Timestamp: {timestamp}",
-                f"Command: {command_line}",
-                "",
-                traceback_text,
-            ]
-        ),
-        encoding="utf-8",
-    )
+    command_prefix = ""
+    if command_name:
+        command_prefix = f"{command_name.strip().replace(' ', '-')}-"
+    log_path = logs_dir / f"{timestamp}-{command_prefix}{reference_id}.log"
 
     return CliErrorReport(reference_id=reference_id, log_path=log_path)
+
+
+def archive_cli_error(
+    error: BaseException,
+    command_name: str | None = None,
+    existing_report: CliErrorReport | None = None,
+) -> CliErrorReport:
+    """Persist an exception traceback under the Open Link Token logs directory."""
+    report = existing_report or create_cli_log_report(command_name)
+
+    command_line = redact_sensitive_text(command_name or "<unknown>")
+    traceback_text = redact_sensitive_text("".join(traceback.format_exception(type(error), error, error.__traceback__)))
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    report.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    write_mode = "a" if report.log_path.exists() else "w"
+    with report.log_path.open(write_mode, encoding="utf-8") as log_file:
+        if write_mode == "a":
+            log_file.write("\n\n")
+        log_file.write(
+            "\n".join(
+                [
+                    f"Reference: {report.reference_id}",
+                    f"Timestamp: {timestamp}",
+                    f"Command: {command_line}",
+                    "",
+                    traceback_text,
+                ]
+            )
+        )
+
+    return report
 
 
 def archive_unexpected_error(error: BaseException, command_name: str | None = None) -> CliErrorReport:
@@ -79,12 +105,17 @@ def archive_unexpected_error(error: BaseException, command_name: str | None = No
 def format_error_reference_message(report: CliErrorReport) -> str:
     """Build the shared stderr handoff for archived CLI failures."""
     stack_trace_message = f"Stack trace: {report.log_path}"
+    return format_dimmed_stderr_message(stack_trace_message)
+
+
+def format_dimmed_stderr_message(message: str) -> str:
+    """Render a dimmed stderr message when the current terminal supports color."""
     isatty = getattr(sys.stderr, "isatty", None)
     use_color = not os.getenv("NO_COLOR") and bool(isatty and isatty())
     if not use_color:
-        return stack_trace_message
+        return message
 
-    return f"\033[90m{stack_trace_message}\033[0m"
+    return f"\033[90m{message}\033[0m"
 
 
 def format_unexpected_error_message(report: CliErrorReport, command_name: str | None = None) -> str:

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/cli_run_reporter.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/cli_run_reporter.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from openlinktoken_cli.util.cli_error_reporter import (
+    RedactingFormatter,
+    create_cli_log_report,
+    format_dimmed_stderr_message,
+)
+
+_DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+_CONSOLE_HANDLER_MARKER = "_openlinktoken_console_handler"
+
+
+def configure_default_logging() -> None:
+    """Attach the default console logger once for the CLI process."""
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if getattr(handler, _CONSOLE_HANDLER_MARKER, False):
+            return
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(RedactingFormatter(_DEFAULT_LOG_FORMAT))
+    setattr(console_handler, _CONSOLE_HANDLER_MARKER, True)
+    root_logger.addHandler(console_handler)
+    if root_logger.level == logging.NOTSET or root_logger.level > logging.INFO:
+        root_logger.setLevel(logging.INFO)
+
+
+def _get_default_console_handler() -> logging.Handler | None:
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if getattr(handler, _CONSOLE_HANDLER_MARKER, False):
+            return handler
+    return None
+
+
+@dataclass(frozen=True)
+class CountSummary:
+    """Summary item for a named count."""
+
+    name: str
+    count: int
+
+
+class _ProgressIndicator:
+    """Minimal TTY spinner with a mutable status line."""
+
+    _FRAMES = ("-", "\\", "|", "/")
+
+    def __init__(self, enabled: bool):
+        self._enabled = enabled
+        self._message = ""
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self, initial_message: str) -> None:
+        if not self._enabled:
+            return
+        self.update(initial_message)
+        self._thread = threading.Thread(target=self._render, daemon=True)
+        self._thread.start()
+
+    def update(self, message: str) -> None:
+        if not self._enabled:
+            return
+        with self._lock:
+            self._message = message
+
+    def stop(self) -> None:
+        if not self._enabled:
+            return
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+        self._clear_line()
+
+    def _render(self) -> None:
+        frame_index = 0
+        while not self._stop_event.is_set():
+            with self._lock:
+                message = self._message
+            frame = self._FRAMES[frame_index % len(self._FRAMES)]
+            print(f"\r{frame} {message}", end="", file=sys.stderr, flush=True)
+            frame_index += 1
+            time.sleep(0.1)
+
+    @staticmethod
+    def _clear_line() -> None:
+        print("\r\033[K", end="", file=sys.stderr, flush=True)
+
+
+class CliRunReporter:
+    """Manage per-run logging, TTY progress, and end-of-run summaries."""
+
+    def __init__(self, command_name: str):
+        self.command_name = command_name
+        self.log_report = create_cli_log_report(command_name)
+        self._console_handler: logging.Handler | None = None
+        self._console_handler_level: int | None = None
+        self._file_handler: logging.Handler | None = None
+        self._interactive = bool(getattr(sys.stderr, "isatty", None) and sys.stderr.isatty())
+        self._interactive = self._interactive and not os.getenv("NO_COLOR")
+        self._progress_indicator = _ProgressIndicator(self._interactive)
+
+    def __enter__(self) -> "CliRunReporter":
+        self._attach_file_logging()
+        self._mute_console_logging()
+        self._progress_indicator.start(f"Starting {self.command_name}...")
+        logging.getLogger(__name__).info("Starting %s command", self.command_name)
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb) -> None:
+        self._progress_indicator.stop()
+        self._restore_console_logging()
+        self._detach_file_logging()
+
+    def update_status(self, stage: str, processed_count: int | None = None, unit_label: str | None = None) -> None:
+        """Update the live progress status shown in interactive terminals."""
+        message = stage
+        if processed_count is not None and unit_label:
+            message = f"{stage} ({processed_count:,} {unit_label})"
+        self._progress_indicator.update(message)
+
+    def make_progress_callback(self, stage: str, unit_label: str) -> Callable[[int], None]:
+        """Return a callback that updates the shared progress indicator."""
+
+        def _callback(processed_count: int) -> None:
+            self.update_status(stage, processed_count=processed_count, unit_label=unit_label)
+
+        return _callback
+
+    def finish_success(self, title: str, lines: Sequence[str]) -> None:
+        """Render a concise success summary for the completed run."""
+        detail_log_line = format_dimmed_stderr_message(f"  Detailed log: {self.log_report.log_path}")
+        summary_lines = [title, *[f"  {line}" for line in lines], detail_log_line]
+        print("\n".join(summary_lines), file=sys.stderr)
+
+    @staticmethod
+    def summarize_count_lines(label: str, counts: Mapping[str, int], limit: int | None = None) -> list[str]:
+        """Format named counts for CLI summary output."""
+        non_zero_items = [CountSummary(name=name, count=count) for name, count in counts.items() if count > 0]
+        if not non_zero_items:
+            return [f"{label}: none"]
+
+        if limit is not None:
+            non_zero_items = sorted(non_zero_items, key=lambda item: (-item.count, item.name))[:limit]
+
+        summary_items = sorted(non_zero_items, key=lambda item: item.name)
+        if len(summary_items) == 1:
+            item = summary_items[0]
+            return [f"{label}: {item.name}={item.count:,}"]
+
+        return [f"{label}:", *[f"  {item.name}: {item.count:,}" for item in summary_items]]
+
+    def _attach_file_logging(self) -> None:
+        self.log_report.log_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(self.log_report.log_path, encoding="utf-8")
+        file_handler.setLevel(logging.INFO)
+        file_handler.setFormatter(RedactingFormatter(_DEFAULT_LOG_FORMAT))
+        logging.getLogger().addHandler(file_handler)
+        self._file_handler = file_handler
+
+    def _detach_file_logging(self) -> None:
+        if self._file_handler is None:
+            return
+        logging.getLogger().removeHandler(self._file_handler)
+        self._file_handler.close()
+        self._file_handler = None
+
+    def _mute_console_logging(self) -> None:
+        self._console_handler = _get_default_console_handler()
+        if self._console_handler is None:
+            return
+        self._console_handler_level = self._console_handler.level
+        self._console_handler.setLevel(logging.CRITICAL + 1)
+
+    def _restore_console_logging(self) -> None:
+        if self._console_handler is None or self._console_handler_level is None:
+            return
+        self._console_handler.setLevel(self._console_handler_level)
+        self._console_handler_level = None

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/cli_run_reporter.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/cli_run_reporter.py
@@ -15,6 +15,7 @@ from openlinktoken_cli.util.cli_error_reporter import (
 )
 
 _DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+_DEFAULT_CONSOLE_FORMAT = "%(message)s"
 _CONSOLE_HANDLER_MARKER = "_openlinktoken_console_handler"
 
 
@@ -27,7 +28,7 @@ def configure_default_logging() -> None:
 
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.INFO)
-    console_handler.setFormatter(RedactingFormatter(_DEFAULT_LOG_FORMAT))
+    console_handler.setFormatter(RedactingFormatter(_DEFAULT_CONSOLE_FORMAT))
     setattr(console_handler, _CONSOLE_HANDLER_MARKER, True)
     root_logger.addHandler(console_handler)
     if root_logger.level == logging.NOTSET or root_logger.level > logging.INFO:

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -4,6 +4,7 @@ Integration tests for the main module.
 Tests the end-to-end workflows for token generation and decryption using new subcommand interface.
 """
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -281,17 +282,22 @@ class TestOpenLinkTokenCommand:
         """Test that missing exchange-config input is caught."""
         input_csv = temp_dir / "input.csv"
         output_csv = temp_dir / "output.csv"
+        original_cwd = Path.cwd()
 
-        args = [
-            "tokenize",
-            "-i",
-            str(input_csv),
-            "-o",
-            str(output_csv),
-            # Missing --exchange-config
-        ]
+        try:
+            os.chdir(temp_dir)
+            args = [
+                "tokenize",
+                "-i",
+                str(input_csv),
+                "-o",
+                str(output_csv),
+                # Missing --exchange-config
+            ]
 
-        exit_code = OpenLinkTokenCommand.execute(args)
+            exit_code = OpenLinkTokenCommand.execute(args)
+        finally:
+            os.chdir(original_cwd)
         assert exit_code != 0, "Command should fail with missing required parameter"
 
     def test_missing_required_parameter_exchange_config_for_encrypt(self, temp_dir):
@@ -417,17 +423,22 @@ class TestOpenLinkTokenCommand:
         """Test that package command fails when no exchange config can be resolved."""
         input_csv = temp_dir / "input.csv"
         output_csv = temp_dir / "output.csv"
+        original_cwd = Path.cwd()
 
-        args = [
-            "package",
-            "-i",
-            str(input_csv),
-            "-o",
-            str(output_csv),
-            # Missing --exchange-config
-        ]
+        try:
+            os.chdir(temp_dir)
+            args = [
+                "package",
+                "-i",
+                str(input_csv),
+                "-o",
+                str(output_csv),
+                # Missing --exchange-config
+            ]
 
-        exit_code = OpenLinkTokenCommand.execute(args)
+            exit_code = OpenLinkTokenCommand.execute(args)
+        finally:
+            os.chdir(original_cwd)
         assert exit_code != 0, "Command should fail with missing required parameters"
 
     def test_invalid_subcommand(self, temp_dir):
@@ -460,8 +471,6 @@ class TestOpenLinkTokenCommand:
                         "tokenize",
                         "-i",
                         "input.csv",
-                        "-t",
-                        "csv",
                         "-o",
                         "output.csv",
                     ]
@@ -480,6 +489,43 @@ class TestOpenLinkTokenCommand:
         assert "Traceback" in log_files[0].read_text()
         assert "RuntimeError: boom" in log_files[0].read_text()
 
+    def test_package_command_success_summary_references_run_log(self, temp_dir, capsys, monkeypatch):
+        """Successful package runs should print a summary and point at the detailed log."""
+        input_csv = temp_dir / "input.csv"
+        output_csv = temp_dir / "output.csv"
+        exchange_config, private_key = self._create_exchange_config(temp_dir, "package-summary")
+        monkeypatch.setattr("sys.stderr.isatty", lambda: False)
+
+        with patch("pathlib.Path.home", return_value=temp_dir):
+            exit_code = OpenLinkTokenCommand.execute(
+                [
+                    "--no-update-check",
+                    "package",
+                    "-i",
+                    str(input_csv),
+                    "-o",
+                    str(output_csv),
+                    "--exchange-config",
+                    str(exchange_config),
+                    "--private-key",
+                    str(private_key),
+                ]
+            )
+
+        captured = capsys.readouterr()
+        log_dir = temp_dir / ".openlinktoken" / "logs"
+        log_files = list(log_dir.glob("*.log"))
+
+        assert exit_code == 0
+        assert "Package complete" in captured.err
+        assert f"Output: {output_csv}" in captured.err
+        assert "Rows processed: 2" in captured.err
+        assert len(log_files) == 1
+        assert f"Detailed log: {log_files[0]}" in captured.err
+        assert "Running package command (tokenize + encrypt)" not in captured.err
+        assert "Running package command (tokenize + encrypt)" in log_files[0].read_text()
+        assert "Processed a total of 2 records" in log_files[0].read_text()
+
     def test_tokenize_command_allows_basename_output_path_in_current_directory(self, tmp_path, monkeypatch):
         """Tokenize should support basename-only output paths in the current directory."""
         input_csv = tmp_path / "input.csv"
@@ -497,8 +543,6 @@ class TestOpenLinkTokenCommand:
                 "tokenize",
                 "-i",
                 "input.csv",
-                "-t",
-                "csv",
                 "-o",
                 "output.csv",
                 "--demo-mode",
@@ -530,8 +574,6 @@ class TestOpenLinkTokenCommand:
                         "tokenize",
                         "-i",
                         str(input_csv),
-                        "-t",
-                        "csv",
                         "-o",
                         "output.csv",
                         "--demo-mode",
@@ -549,6 +591,45 @@ class TestOpenLinkTokenCommand:
         assert len(log_files) == 1
         assert str(log_files[0]) in captured.err
         assert "Traceback" in log_files[0].read_text()
+        assert "RuntimeError: boom" in log_files[0].read_text()
+
+    def test_tokenize_unexpected_processing_error_reuses_run_log(self, tmp_path, capsys, monkeypatch):
+        """Processing failures should append the traceback to the same per-run log file."""
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        input_csv = tmp_path / "input.csv"
+        input_csv.write_text(
+            "RecordId,FirstName,LastName,PostalCode,Sex,BirthDate,SocialSecurityNumber\n"
+            "test-001,John,Doe,98004,Male,2000-01-01,123-45-6789\n",
+            encoding="utf-8",
+        )
+
+        with patch(
+            "openlinktoken_cli.commands.tokenize_command.TokenizeCommand._process_tokens_demo",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch("pathlib.Path.home", return_value=tmp_path):
+                exit_code = OpenLinkTokenCommand.execute(
+                    [
+                        "--no-update-check",
+                        "tokenize",
+                        "-i",
+                        str(input_csv),
+                        "-o",
+                        "output.csv",
+                        "--demo-mode",
+                    ]
+                )
+
+        captured = capsys.readouterr()
+        log_dir = tmp_path / ".openlinktoken" / "logs"
+        log_files = list(log_dir.glob("*.log"))
+
+        assert exit_code != 0
+        assert "Error: boom" in captured.err
+        assert "\x1b[90mStack trace:" in captured.err
+        assert len(log_files) == 1
+        assert str(log_files[0]) in captured.err
+        assert "Running in DEMO MODE" in log_files[0].read_text()
         assert "RuntimeError: boom" in log_files[0].read_text()
 
     def test_package_missing_exchange_config_writes_reference_log(self, tmp_path, monkeypatch, capsys):
@@ -569,8 +650,6 @@ class TestOpenLinkTokenCommand:
                     "package",
                     "-i",
                     str(input_csv),
-                    "-t",
-                    "csv",
                     "-o",
                     "output.csv",
                 ]

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/test_initiate_exchange_command.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/test_initiate_exchange_command.py
@@ -6,6 +6,7 @@ Unit and integration tests for InitiateExchangeCommand.
 import base64
 import io
 import json
+import logging
 import os
 import sys
 from pathlib import Path
@@ -16,6 +17,7 @@ import pytest
 from openlinktoken.exchange_jwe import decrypt_exchange_envelope
 from openlinktoken_cli.commands.initiate_exchange_command import InitiateExchangeCommand
 from openlinktoken_cli.commands.open_link_token_command import OpenLinkTokenCommand
+from openlinktoken_cli.util.cli_run_reporter import configure_default_logging
 from openlinktoken_cli.util.ec_key_utils import SUPPORTED_CURVES, generate_key_pair, public_key_fingerprint
 from openlinktoken_cli.util.stdin_utils import read_required_env_bytes
 
@@ -232,6 +234,45 @@ class TestInitiateExchangeCommandIntegration:
         assert (openlinktoken_dir / "stdin-exchange.private.pem").exists()
         assert (openlinktoken_dir / "stdin-exchange.public.pem").exists()
         assert output_path.exists()
+
+    def test_basic_exchange_existing_key_files_prints_concise_stderr(self, tmp_path):
+        """initiate-exchange should surface quick-command validation errors without raw log formatting."""
+        partner_pem = _partner_key_pem(tmp_path)
+        output_path = tmp_path / "existing-keys.exchange.json"
+        openlinktoken_dir = tmp_path / ".openlinktoken"
+        openlinktoken_dir.mkdir(parents=True, exist_ok=True)
+        (openlinktoken_dir / "existing-keys.private.pem").write_text("private", encoding="utf-8")
+        (openlinktoken_dir / "existing-keys.public.pem").write_text("public", encoding="utf-8")
+        configure_default_logging()
+        console_handler = next(
+            handler
+            for handler in logging.getLogger().handlers
+            if getattr(handler, "_openlinktoken_console_handler", False)
+        )
+        stderr_buffer = io.StringIO()
+        original_stream = console_handler.setStream(stderr_buffer)
+
+        try:
+            with patch("pathlib.Path.home", return_value=tmp_path):
+                exit_code = OpenLinkTokenCommand.execute(
+                    [
+                        "initiate-exchange",
+                        "--name",
+                        "existing-keys",
+                        "--public-key",
+                        str(partner_pem),
+                        "--output",
+                        str(output_path),
+                    ]
+                )
+        finally:
+            console_handler.setStream(original_stream)
+
+        assert exit_code == 1
+        assert "Key files for 'existing-keys' already exist" in stderr_buffer.getvalue()
+        assert " - ERROR - " not in stderr_buffer.getvalue()
+        assert "openlinktoken_cli.commands" not in stderr_buffer.getvalue()
+        assert not output_path.exists()
 
     def test_basic_exchange_accepts_public_and_sender_key_refs_from_env(self, tmp_path, monkeypatch):
         """initiate-exchange accepts env-var references for both partner and sender keys in one command."""

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokenize_command_demo_mode_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokenize_command_demo_mode_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -76,14 +77,19 @@ class TestTokenizeCommandDemoMode:
 
     def test_normal_mode_fails_without_exchange_config(self, temp_dir: Path):
         """Normal mode must reject execution when no exchange config can be resolved."""
-        args = [
-            "tokenize",
-            "-i",
-            str(temp_dir / "input.csv"),
-            "-o",
-            str(temp_dir / "output.csv"),
-        ]
-        exit_code = OpenLinkTokenCommand.execute(args)
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(temp_dir)
+            args = [
+                "tokenize",
+                "-i",
+                str(temp_dir / "input.csv"),
+                "-o",
+                str(temp_dir / "output.csv"),
+            ]
+            exit_code = OpenLinkTokenCommand.execute(args)
+        finally:
+            os.chdir(original_cwd)
         assert exit_code != 0
 
     def test_demo_mode_rejects_exchange_config(self, temp_dir: Path):

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/util/cli_run_reporter_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/util/cli_run_reporter_test.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+from openlinktoken_cli.util.cli_error_reporter import format_dimmed_stderr_message
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
+
+class TestCliRunReporter:
+    """Unit tests for CLI run summary rendering helpers."""
+
+    def test_summarize_count_lines_sorts_multiple_items_alphabetically(self):
+        """Multi-item summaries should be expanded into alphabetized detail lines."""
+        lines = CliRunReporter.summarize_count_lines(
+            "Blank tokens by rule",
+            {"T2": 8, "T4": 7, "T1": 6},
+        )
+
+        assert lines == [
+            "Blank tokens by rule:",
+            "  T1: 6",
+            "  T2: 8",
+            "  T4: 7",
+        ]
+
+    def test_summarize_count_lines_limits_invalid_attributes_before_sorting(self):
+        """Limited summaries should keep the highest counts, then render them alphabetically."""
+        lines = CliRunReporter.summarize_count_lines(
+            "Top invalid attributes",
+            {
+                "SocialSecurityNumber": 4,
+                "BirthDate": 3,
+                "LastName": 2,
+                "PostalCode": 1,
+            },
+            limit=3,
+        )
+
+        assert lines == [
+            "Top invalid attributes:",
+            "  BirthDate: 3",
+            "  LastName: 2",
+            "  SocialSecurityNumber: 4",
+        ]
+
+    def test_format_dimmed_stderr_message_uses_dark_grey_for_interactive_terminals(self, monkeypatch):
+        """Interactive terminals should render reference lines with the shared dim styling."""
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+
+        message = format_dimmed_stderr_message(f"Detailed log: {Path('/tmp/run.log')}")
+
+        assert message == "\x1b[90mDetailed log: /tmp/run.log\x1b[0m"

--- a/pages/config/configuration.md
+++ b/pages/config/configuration.md
@@ -16,8 +16,8 @@ At a high level you must always specify:
 
 - the input path and type (CSV or Parquet)
 - an output path for tokens
-- a hashing secret (required)
-- either an encryption key (for `package`) or the `tokenize` subcommand to skip encryption
+- an exchange config for consumer commands (`package`, `tokenize`, `encrypt`, `decrypt`)
+- either a matching private key, a private-key environment variable, or a locally discoverable key under `~/.openlinktoken/`
 - optionally the `decrypt` subcommand when reading previously encrypted tokens
 
 For the complete, authoritative list of flags, short options, and defaults, see the [CLI Reference](../reference/cli.md).
@@ -26,30 +26,27 @@ For the complete, authoritative list of flags, short options, and defaults, see 
 
 ## Environment Variables
 
-Secrets can be passed via environment variables for security:
+Consumer commands usually auto-discover the matching private key from `~/.openlinktoken/` when you provide the exchange config:
 
 ```bash
-export OLT_HASHING_SECRET="MyHashingKey"
-export OLT_ENCRYPTION_KEY="MyEncryptionKey32CharactersLong"
-
 olt package \
   -i data.csv -o tokens.csv \
-  -h "$OLT_HASHING_SECRET" \
-  -e "$OLT_ENCRYPTION_KEY"
+  --exchange-config ./openlinktoken-2026-05-01.exchange.json
 ```
 
 ### Docker Environment
 
+If the runtime cannot auto-discover the matching key, override it explicitly with `--private-key-env`:
+
 ```bash
 docker run --rm \
-  -e OLT_HASHING_SECRET="MyHashingKey" \
-  -e OLT_ENCRYPTION_KEY="MyEncryptionKey32CharactersLong" \
+  -e OLT_PRIVATE_KEY_PEM="$(cat ~/.openlinktoken/openlinktoken-2026-05-01.private.pem)" \
   -v $(pwd)/resources:/app/resources \
   openlinktoken:latest package \
   -i /app/resources/sample.csv \
   -o /app/resources/output.csv \
-  -h "$OLT_HASHING_SECRET" \
-  -e "$OLT_ENCRYPTION_KEY"
+  --exchange-config /app/resources/openlinktoken-2026-05-01.exchange.json \
+  --private-key-env OLT_PRIVATE_KEY_PEM
 ```
 
 ---
@@ -122,7 +119,7 @@ Use `-ot` to specify a different output format:
 olt package \
   -i data.csv \
   -o tokens.parquet \
-  -h "HashingKey" -e "EncryptionKey"
+  --exchange-config ./openlinktoken-2026-05-01.exchange.json
 ```
 
 ### Output Files Generated
@@ -138,9 +135,9 @@ Each run produces two files:
 
 Open Link Token supports three processing modes that control how token signatures are transformed:
 
-- **Encryption (default)** – produces encrypted tokens suitable for external exchange; requires both a hashing secret and an encryption key.
-- **Tokenize** – produces one-way hashed tokens for internal matching and overlap analysis; requires only the hashing secret.
-- **Decrypt** – takes previously encrypted tokens and decrypts them back to their hashed form (equivalent to `tokenize` output).
+- **Encryption (default)** – produces encrypted tokens suitable for external exchange; resolves the hashing secret and transport key from an exchange config plus a matching private key.
+- **Tokenize** – produces one-way hashed tokens for internal matching and overlap analysis; resolves the hashing secret from the same exchange-config workflow.
+- **Decrypt** – takes previously encrypted tokens and decrypts them back to their hashed form (equivalent to `tokenize` output) using the exchange config and a matching private key.
 
 For the exact CLI flags that enable each mode, see the [CLI Reference](../reference/cli.md).
 
@@ -171,7 +168,7 @@ For the exact CLI flags that enable each mode, see the [CLI Reference](../refere
 source ../../.venv/bin/activate
 python -m openlinktoken_cli.main package \
   -i ../../resources/sample.csv -o ../../resources/output.csv \
-  -h "HashingKey" -e "EncryptionKey32Characters!!!!!"
+  --exchange-config ../../resources/openlinktoken-2026-05-01.exchange.json
 ```
 
 ### Docker Container
@@ -180,8 +177,7 @@ python -m openlinktoken_cli.main package \
 ./run-openlinktoken.sh package \
   -i ./resources/sample.csv \
   -o ./resources/output.csv \
-  -h "HashingKey" \
-  -e "EncryptionKey32Characters!!!!!"
+  --exchange-config ./resources/openlinktoken-2026-05-01.exchange.json
 ```
 
 ### Spark/Databricks Cluster

--- a/pages/configuration-tuning/index.md
+++ b/pages/configuration-tuning/index.md
@@ -166,7 +166,7 @@ Generates encrypted `olt.V1` match tokens using HMAC-SHA256 + JWE/AES-256-GCM.
 ```bash
 olt package \
   -i data.csv -o tokens.csv \
-  -h "HashingKey" -e "EncryptionKey"
+  --exchange-config ./tuning.exchange.json
 ```
 
 **Process:**
@@ -175,7 +175,7 @@ olt package \
 Token Signature → SHA-256 Hash → HMAC-SHA256(hash, key) → JWE (AES-256-GCM) → Prefix `olt.V1.`
 ```
 
-**Requires:** Hashing secret (`-h`) and encryption key (`-e`)
+**Requires:** Exchange config plus a matching private key that the CLI can auto-discover (or an explicit override)
 
 Encrypted `olt.V1` tokens include randomized IVs, so ciphertext values are not deterministic across runs.
 
@@ -186,7 +186,7 @@ Generates hashed tokens without encryption. Useful for token matching scenarios 
 ```bash
 olt tokenize \
   -i data.csv -o tokens.csv \
-  -h "HashingKey"
+  --exchange-config ./tuning.exchange.json
 ```
 
 **Process:**
@@ -195,7 +195,7 @@ olt tokenize \
 Token Signature → SHA-256 Hash → HMAC-SHA256(hash, key) → Base64 Encode
 ```
 
-**Requires:** Hashing secret only (`-h`)
+**Requires:** Exchange config plus a matching private key that the CLI can auto-discover (or an explicit override)
 
 **Benefits:**
 
@@ -211,7 +211,7 @@ Reverse previous encryption to inspect or verify token generation.
 ```bash
 olt decrypt \
   -i encrypted-tokens.csv -o decrypted-tokens.csv \
-  -e "EncryptionKey"
+  --exchange-config ./tuning.exchange.json
 ```
 
 **Output:** HMAC-SHA256 hashed tokens (base64 encoded) **before** AES encryption—equivalent to `tokenize` output.

--- a/pages/matching-concepts/index.md
+++ b/pages/matching-concepts/index.md
@@ -141,12 +141,12 @@ Tokens are encrypted to prevent re-identification, but can be decrypted to debug
 # Generate encrypted tokens (default mode)
 olt package \
   -i data.csv -o output.csv \
-  -h "HashingKey" -e "EncryptionKey"
+  --exchange-config ./matching.exchange.json
 
 # Decrypt previously encrypted tokens
 olt decrypt \
   -i output.csv -o decrypted.csv \
-  -e "EncryptionKey"
+  --exchange-config ./matching.exchange.json
 ```
 
 Decrypted tokens show the HMAC-SHA256 hash (base64 encoded) before AES encryption—useful for debugging attribute normalization issues.

--- a/pages/operations/decrypting-tokens.md
+++ b/pages/operations/decrypting-tokens.md
@@ -23,7 +23,7 @@ Decryption is useful for:
 
 ## CLI Decrypt Mode
 
-Use the `decrypt` subcommand with the same encryption key used for token generation.
+Use the `decrypt` subcommand with the same exchange config used for token generation. The CLI auto-discovers the matching private key by default.
 
 ### Open Link Token CLI (Python)
 
@@ -31,17 +31,22 @@ Use the `decrypt` subcommand with the same encryption key used for token generat
 olt decrypt \
   -i ../../resources/output.csv \
   -o ../../resources/decrypted.csv \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ../../resources/decrypt.exchange.json
 ```
 
 ### Docker
 
+If the container cannot auto-discover the matching key under `~/.openlinktoken/`, pass it explicitly:
+
 ```bash
-docker run --rm -v $(pwd)/resources:/app/resources \
+docker run --rm \
+  -e OLT_PRIVATE_KEY_PEM="$(cat ~/.openlinktoken/decrypt.private.pem)" \
+  -v $(pwd)/resources:/app/resources \
   openlinktoken:latest decrypt \
   -i /app/resources/output.csv \
   -o /app/resources/decrypted.csv \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config /app/resources/decrypt.exchange.json \
+  --private-key-env OLT_PRIVATE_KEY_PEM
 ```
 
 ---
@@ -95,19 +100,20 @@ Tokens can be encrypted by one Open Link Token implementation and decrypted by a
 # Encrypt with Open Link Token CLI
 olt package \
   -i data.csv -o tokens.csv \
-  -h "HashingKey" -e "EncryptionKey32Characters!!!!!"
+  --exchange-config ./interop.exchange.json
 
 # Decrypt with Open Link Token CLI
 olt decrypt \
   -i tokens.csv -o decrypted.csv \
-  -e "EncryptionKey32Characters!!!!!"
+  --exchange-config ./interop.exchange.json
 ```
 
 **Requirements for cross-language compatibility:**
 
-- Same encryption key (exactly 32 characters/bytes)
+- Same exchange config (or an equivalent config that resolves to the same hashing secret and transport key)
+- Matching private key for one of the exchange recipients
 - Same token file format
-- Both implementations use AES-256-GCM with identical parameters
+- Both implementations use the same JWE/AES-256-GCM token format
 
 ---
 
@@ -115,17 +121,17 @@ olt decrypt \
 
 ### Key Handling
 
-- **Never commit encryption keys** to version control
-- **Use environment variables** or secret stores:
+- **Never commit private keys** to version control
+- **Use environment variables** or secret stores when you need to override local key auto-discovery:
   ```bash
-  export OLT_ENCRYPTION_KEY="YourKey32Characters!!!!!!!!!!!!"
-  olt decrypt -e "$OLT_ENCRYPTION_KEY" ...
+  export OLT_PRIVATE_KEY_PEM="$(cat ~/.openlinktoken/interop.private.pem)"
+  olt decrypt --exchange-config ./interop.exchange.json --private-key-env OLT_PRIVATE_KEY_PEM ...
   ```
-- **Rotate keys periodically** and re-encrypt tokens as needed
+- **Rotate keys periodically** and issue a fresh exchange config as needed
 
 ### Access Control
 
-- **Limit decryption access**: Only authorized personnel should have encryption keys
+- **Limit decryption access**: Only authorized personnel should have the matching private key
 - **Audit decryption events**: Log when and why tokens are decrypted
 - **Secure decrypted output**: Decrypted tokens are still sensitive (HMAC hashes)
 

--- a/pages/operations/mock-data-workflows.md
+++ b/pages/operations/mock-data-workflows.md
@@ -117,8 +117,7 @@ cd ../../
 ./run-openlinktoken.sh package \
   -i tools/mockdata/test_data.csv \
   -o resources/test_output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ./resources/mockdata.exchange.json
 
 # 3. Check output
 cat resources/test_output.csv
@@ -136,7 +135,7 @@ python data_generator.py 1000 0.0 dataset_a.csv
 python data_generator.py 1000 0.0 dataset_b.csv
 
 # Add some common records manually or use a script
-# Then process both with Open Link Token using the same secrets
+# Then process both with Open Link Token using the same exchange config
 ```
 
 For automated overlap analysis, see [Spark or Databricks](spark-or-databricks.md).
@@ -202,7 +201,7 @@ df.to_parquet('large_test.parquet')
 olt package \
   -i large_test.parquet \
   -o tokens.parquet \
-  -h "HashingKey" -e "EncryptionKey"
+  --exchange-config ./large-test.exchange.json
 ```
 
 ---

--- a/pages/operations/running-batch-jobs.md
+++ b/pages/operations/running-batch-jobs.md
@@ -27,19 +27,20 @@ olt <subcommand> [OPTIONS]
 
 ### Required Arguments
 
-| Argument | Alias             | Description                | Example         |
-| -------- | ----------------- | -------------------------- | --------------- |
-| `-i`     | `--input`         | Input file path            | `-i data.csv`   |
-| `-o`     | `--output`        | Output file path           | `-o tokens.csv` |
-| `-h`     | `--hashingsecret` | HMAC-SHA256 hashing secret | `-h "MyKey"`    |
+| Argument            | Alias      | Description               | Example                                   |
+| ------------------- | ---------- | ------------------------- | ----------------------------------------- |
+| `-i`                | `--input`  | Input file path           | `-i data.csv`                             |
+| `-o`                | `--output` | Output file path          | `-o tokens.csv`                           |
+| `--exchange-config` |            | Exchange config JSON path | `--exchange-config ./batch.exchange.json` |
 
 ### Optional Arguments
 
-| Argument | Alias             | Description                 | Default                    |
-| -------- | ----------------- | --------------------------- | -------------------------- |
-| `-e`     | `--encryptionkey` | AES-256 encryption key      | Required in `package` mode |
-|          | `tokenize`        | Tokenize without encryption | Subcommand                 |
-|          | `decrypt`         | Decrypt mode                | Subcommand                 |
+| Argument            | Alias | Description                                         | Default                       |
+| ------------------- | ----- | --------------------------------------------------- | ----------------------------- |
+| `--private-key`     |       | Private key PEM used to decrypt the exchange config | Auto-discovered when possible |
+| `--private-key-env` |       | Environment variable containing the private key PEM |                               |
+| `tokenize`          |       | Tokenize without encryption                         | Subcommand                    |
+| `decrypt`           |       | Decrypt mode                                        | Subcommand                    |
 
 ### CLI Example
 
@@ -50,10 +51,8 @@ uv pip install -r requirements.txt -e . -e ../openlinktoken
 
 olt package \
   -i ../../../resources/sample.csv \
-
   -o ../../../resources/output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ../../../resources/batch.exchange.json
 ```
 
 ---
@@ -70,9 +69,7 @@ cd /path/to/OpenLinkToken
 ./run-openlinktoken.sh package \
   -i ./resources/sample.csv \
   -o ./resources/output.csv \
-
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ./resources/batch.exchange.json
 ```
 
 **PowerShell (Windows):**
@@ -83,8 +80,7 @@ cd C:\path\to\Open Link Token
 .\run-openlinktoken.ps1 package `
   -i .\resources\sample.csv `
   -o .\resources\output.csv `
-  -h "HashingKey" `
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config .\resources\batch.exchange.json
 ```
 
 ### Script Options
@@ -104,10 +100,8 @@ docker build -t openlinktoken:latest .
 docker run --rm -v $(pwd)/resources:/app/resources \
   openlinktoken:latest package \
   -i /app/resources/sample.csv \
-
   -o /app/resources/output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config /app/resources/batch.exchange.json
 
 # View output
 cat resources/output.csv
@@ -161,16 +155,17 @@ See [Reference: Metadata Format](../reference/metadata-format.md) for complete f
 
 ## Common Patterns
 
-### Environment Variables for Secrets
+### Environment Variables for Private Keys
+
+Use this override when the CLI cannot auto-discover a matching key from `~/.openlinktoken/`.
 
 ```bash
-export OLT_HASHING_SECRET="MyHashingKey"
-export OLT_ENCRYPTION_KEY="MyEncryptionKey32CharactersLong"
+export OLT_PRIVATE_KEY_PEM="$(cat ~/.openlinktoken/batch.private.pem)"
 
 olt package \
   -i data.csv -o tokens.csv \
-  -h "$OLT_HASHING_SECRET" \
-  -e "$OLT_ENCRYPTION_KEY"
+  --exchange-config ./batch.exchange.json \
+  --private-key-env OLT_PRIVATE_KEY_PEM
 ```
 
 ### Logging and Monitoring
@@ -185,12 +180,12 @@ Check the metadata file after each run for:
 
 ## Troubleshooting
 
-| Problem                       | Solution                                                                |
-| ----------------------------- | ----------------------------------------------------------------------- |
-| "Encryption key not provided" | Add `-e "YourKey"` or run `tokenize` subcommand                         |
-| "Invalid BirthDate"           | Use YYYY-MM-DD format; date must be 1910-01-01 to today                 |
-| "Column not found"            | Check column names match [accepted aliases](../config/configuration.md) |
-| Docker build fails            | Ensure Docker is running; use absolute paths                            |
+| Problem                                                  | Solution                                                                                          |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| "No private key matching this exchange config was found" | Pass `--private-key` / `--private-key-env`, or install the matching key under `~/.openlinktoken/` |
+| "Invalid BirthDate"                                      | Use YYYY-MM-DD format; date must be 1910-01-01 to today                                           |
+| "Column not found"                                       | Check column names match [accepted aliases](../config/configuration.md)                           |
+| Docker build fails                                       | Ensure Docker is running; use absolute paths                                                      |
 
 ---
 

--- a/pages/operations/running-batch-jobs.md
+++ b/pages/operations/running-batch-jobs.md
@@ -27,11 +27,11 @@ olt <subcommand> [OPTIONS]
 
 ### Required Arguments
 
-| Argument | Alias             | Description                          | Example         |
-| -------- | ----------------- | ------------------------------------ | --------------- |
-| `-i`     | `--input`         | Input file path                      | `-i data.csv`   |
-| `-o`     | `--output`        | Output file path                     | `-o tokens.csv` |
-| `-h`     | `--hashingsecret` | HMAC-SHA256 hashing secret           | `-h "MyKey"`    |
+| Argument | Alias             | Description                | Example         |
+| -------- | ----------------- | -------------------------- | --------------- |
+| `-i`     | `--input`         | Input file path            | `-i data.csv`   |
+| `-o`     | `--output`        | Output file path           | `-o tokens.csv` |
+| `-h`     | `--hashingsecret` | HMAC-SHA256 hashing secret | `-h "MyKey"`    |
 
 ### Optional Arguments
 
@@ -83,7 +83,6 @@ cd C:\path\to\Open Link Token
 .\run-openlinktoken.ps1 package `
   -i .\resources\sample.csv `
   -o .\resources\output.csv `
-  -FileType csv `
   -h "HashingKey" `
   -e "Secret-Encryption-Key-Goes-Here."
 ```
@@ -92,7 +91,6 @@ cd C:\path\to\Open Link Token
 
 | Option       | Bash | PowerShell   | Description          |
 | ------------ | ---- | ------------ | -------------------- |
-| File type    | `-t` | `-FileType`  | `csv` or `parquet`   |
 | Skip rebuild | `-s` | `-SkipBuild` | Reuse existing image |
 | Verbose      | `-v` | `-Verbose`   | Show detailed output |
 

--- a/pages/operations/sharing-tokenized-data.md
+++ b/pages/operations/sharing-tokenized-data.md
@@ -15,7 +15,7 @@ Organizations often need to identify overlapping individuals across datasets wit
 **Typical scenario:**
 
 1. Organization A and Organization B each hold patient records
-2. Both organizations run Open Link Token on their data using **the same secrets**
+2. Both organizations run Open Link Token on their data using **the same exchange config**
 3. They exchange only the token output (no raw PII)
 4. Matching tokens indicate the same person exists in both datasets
 
@@ -28,7 +28,7 @@ Organizations often need to identify overlapping individuals across datasets wit
          ▼                                      ▼
 ┌─────────────────┐                    ┌─────────────────┐
 │ Open Link Token │                    │ Open Link Token │
-│ (same secrets)  │                    │ (same secrets)  │
+│ (same exchange) │                    │ (same exchange) │
 └────────┬────────┘                    └────────┬────────┘
          │                                      │
          ▼                                      ▼
@@ -211,28 +211,27 @@ Once both parties have the exchange artifact and the matching private key, they 
 olt package \
   -i patient_data.csv \
   -o tokens_for_partner.csv \
-  --exchange-config sender-q2.exchange.json \
-  --private-key ~/.openlinktoken/sender-q2.private.pem
+  --exchange-config sender-q2.exchange.json
 ```
 
 ---
 
-## Sender Workflow (manual secret agreement)
+## Sender Workflow (shared exchange config)
 
 The sending organization prepares tokenized data for sharing.
 
-### Step 1: Agree on Shared Secrets
+### Step 1: Confirm the Shared Exchange Config
 
-Before tokenization, both parties must agree on:
+Before tokenization, both parties must use the same exchange config:
 
-- **Hashing secret** (required): Used for HMAC-SHA256
-- **Encryption key** (recommended for external sharing): Used for AES-256-GCM
+- **Exchange config** (required): Carries the encrypted hashing secret and the public-key metadata for transport encryption
+- **Private key** (required per party): Each side keeps its own matching private key locally and never shares it
 
-**Best practice:** Use a secure channel (encrypted email, secure file transfer, or direct key exchange in person) to share secrets. Never send secrets alongside token files.
+**Best practice:** Share the exchange config over your normal transfer channel, but distribute private keys through your standard secret-management process only.
 
 ### Step 2: Run Open Link Token
 
-Generate tokens using the agreed-upon secrets.
+Generate tokens using the shared exchange config.
 
 **Encrypted mode (recommended for external sharing):**
 
@@ -240,8 +239,7 @@ Generate tokens using the agreed-upon secrets.
 olt package \
   -i patient_data.csv \
   -o tokens_for_partner.csv \
-  -h "$SHARED_HASHING_SECRET" \
-  -e "$SHARED_ENCRYPTION_KEY"
+  --exchange-config sender-q2.exchange.json
 ```
 
 **Tokenize (overlap analysis helper, internal artifact):**
@@ -252,7 +250,7 @@ Tokenized (unencrypted) output is primarily used **inside your environment** to 
 olt tokenize \
   -i local_patient_data.csv \
   -o local_hash_only_tokens.csv \
-  -h "$SHARED_HASHING_SECRET"
+  --exchange-config sender-q2.exchange.json
 ```
 
 Typical pattern:
@@ -289,22 +287,23 @@ Check the generated `.metadata.json` for processing statistics:
 
 - `TotalRowsWithInvalidAttributes`: High counts may indicate data quality issues
 - `BlankTokensByRule`: T1 and T3 require SSN; blanks are expected if SSN is often missing
-- `HashingSecretHash` / `EncryptionSecretHash`: Share these hashes (not the secrets) so the recipient can verify they used the correct keys
+- `HashingSecretHash` / `EncryptionSecretHash`: Compare these hashes across both runs to confirm each side resolved the same exchange-config secrets
 
 ### Step 4: Prepare Transfer Package
 
 Include in the transfer:
 
-| File                         | Purpose                              | Contains Secrets?         |
-| ---------------------------- | ------------------------------------ | ------------------------- |
-| `tokens.csv` (or `.parquet`) | Token output                         | No                        |
-| `tokens.metadata.json`       | Processing stats, secret hashes      | Hashes only (not secrets) |
-| Data dictionary (optional)   | Column definitions, RecordId mapping | No                        |
+| File                         | Purpose                                                          | Contains Secrets?         |
+| ---------------------------- | ---------------------------------------------------------------- | ------------------------- |
+| `sender-q2.exchange.json`    | Shared exchange config if the recipient does not already have it | No private key material   |
+| `tokens.csv` (or `.parquet`) | Token output                                                     | No                        |
+| `tokens.metadata.json`       | Processing stats, secret hashes                                  | Hashes only (not secrets) |
+| Data dictionary (optional)   | Column definitions, RecordId mapping                             | No                        |
 
 **Do NOT include:**
 
 - Raw input data (PII)
-- Hashing secret or encryption key (share separately via secure channel)
+- Any private key
 - Decrypted tokens
 
 ### Step 5: Transfer Securely
@@ -321,32 +320,31 @@ Use encrypted file transfer:
 
 The receiving organization ingests shared tokens and matches against their own data.
 
-### Step 1: Obtain Shared Secrets
+### Step 1: Obtain the Exchange Config and Your Private Key
 
-Receive the hashing secret (and encryption key, if applicable) through a secure channel separate from the token files.
+Receive the shared exchange config and make sure your organization has the matching private key available locally or in a secret store.
 
-### Step 2: Verify Secret Hashes
+### Step 2: Verify You Can Open the Exchange Config
 
-Before processing, verify that your secrets match the sender's:
+Before processing, verify that your private key matches the shared exchange config:
 
 ```bash
-python tools/hash_calculator.py \
-  --hashing-secret "$SHARED_HASHING_SECRET" \
-  --encryption-key "$SHARED_ENCRYPTION_KEY"
+python tools/exchange/validate_exchange_secret.py \
+  --exchange-config sender-q2.exchange.json \
+  --private-key ~/.openlinktoken/recipient-org.private.pem
 ```
 
-Compare the output hashes with `HashingSecretHash` and `EncryptionSecretHash` in the received metadata file. If they don't match, tokens will not match correctly.
+If decryption succeeds, your private key matches one of the exchange recipients and the CLI will be able to resolve the same hashing secret and transport key as the sender.
 
 ### Step 3: Generate Your Own Tokens
 
-Run Open Link Token on your local data using the **same secrets**:
+Run Open Link Token on your local data using the **same exchange config**:
 
 ```bash
 olt package \
   -i local_patient_data.csv \
   -o local_tokens.csv \
-  -h "$SHARED_HASHING_SECRET" \
-  -e "$SHARED_ENCRYPTION_KEY"
+  --exchange-config sender-q2.exchange.json
 ```
 
 ### Step 4: Match Tokens
@@ -381,7 +379,7 @@ If tokens are encrypted and you need to debug or verify:
 olt decrypt \
   -i partner_tokens.csv \
   -o partner_decrypted.csv \
-  -e "$SHARED_ENCRYPTION_KEY"
+  --exchange-config sender-q2.exchange.json
 ```
 
 See [Decrypting Tokens](decrypting-tokens.md) for details.
@@ -392,21 +390,21 @@ See [Decrypting Tokens](decrypting-tokens.md) for details.
 
 ### Use Encrypted Tokens for External Sharing
 
-Encrypted mode (`-e` flag) adds AES-256-GCM encryption on top of HMAC-SHA256:
+Encrypted mode (`package` with an exchange config) adds AES-256-GCM encryption on top of HMAC-SHA256:
 
-| Mode      | External Sharing    | Defense in Depth | Reversible              |
-| --------- | ------------------- | ---------------- | ----------------------- |
-| Encrypted | ✓ Recommended       | Yes              | To HMAC hash (with key) |
-| Tokenize  | ⚠ Use with caution | No               | Not reversible          |
+| Mode      | External Sharing    | Defense in Depth | Reversible                               |
+| --------- | ------------------- | ---------------- | ---------------------------------------- |
+| Encrypted | ✓ Recommended       | Yes              | To HMAC hash (with matching private key) |
+| Tokenize  | ⚠ Use with caution | No               | Not reversible                           |
 
 Encrypted tokens provide an additional security layer if token files are intercepted.
 
-### Protect Shared Secrets
+### Protect Exchange Configs and Private Keys
 
-- **Never send secrets with token files.** Use a separate secure channel.
-- **Store secrets in a vault** (AWS Secrets Manager, HashiCorp Vault, Azure Key Vault)
-- **Limit access** to secrets to authorized personnel only
-- **Rotate secrets periodically** and re-tokenize as needed
+- **Never send private keys with token files.** Each organization keeps its own key material.
+- **Store private keys in a vault** (AWS Secrets Manager, HashiCorp Vault, Azure Key Vault)
+- **Limit access** to private keys to authorized personnel only
+- **Rotate private keys periodically** and reissue exchange configs as needed
 
 ### Verify Partner Identity
 
@@ -456,17 +454,17 @@ With only the token file, an attacker cannot identify individuals.
 
 **Sender:**
 
-- [ ] Agreed on secrets with recipient (via secure channel)
-- [ ] Generated tokens with correct secrets
+- [ ] Confirmed the shared exchange config and local private key
+- [ ] Generated tokens with the correct exchange config
 - [ ] Verified metadata shows expected row counts
 - [ ] Prepared transfer package (tokens + metadata only)
 - [ ] Using encrypted file transfer
 
 **Recipient:**
 
-- [ ] Received secrets via secure channel (separate from token files)
-- [ ] Verified secret hashes match sender's metadata
-- [ ] Generated own tokens with same secrets
+- [ ] Received the exchange config and confirmed local private-key access
+- [ ] Verified the exchange config can be decrypted locally
+- [ ] Generated own tokens with the same exchange config
 - [ ] Matching logic uses correct RuleId and Token columns
 
 ---

--- a/pages/operations/tokenize.md
+++ b/pages/operations/tokenize.md
@@ -63,23 +63,28 @@ The `tokenize` subcommand is primarily used to support **overlap analysis workfl
 
 ### Normal Mode
 
-Use the `tokenize` subcommand. Only the hashing secret is required (no encryption key).
+Use the `tokenize` subcommand with an exchange config. The CLI resolves the hashing secret from the exchange config and auto-discovers the matching private key by default.
 
 ```bash
 olt tokenize \
   -i resources/sample.csv \
   -o resources/hashed-output.csv \
-  -h "HashingKey"
+  --exchange-config ./tokenize.exchange.json
 ```
 
-#### Normal Mode — Docker
+#### Normal Mode — Docker Override Example
+
+If the container cannot auto-discover the matching key under `~/.openlinktoken/`, pass it explicitly:
 
 ```bash
-docker run --rm -v $(pwd)/resources:/app/resources \
+docker run --rm \
+  -e OLT_PRIVATE_KEY_PEM="$(cat ~/.openlinktoken/tokenize.private.pem)" \
+  -v $(pwd)/resources:/app/resources \
   openlinktoken:latest tokenize \
   -i /app/resources/sample.csv \
   -o /app/resources/hashed-output.csv \
-  -h "HashingKey"
+  --exchange-config /app/resources/tokenize.exchange.json \
+  --private-key-env OLT_PRIVATE_KEY_PEM
 ```
 
 ### Hashing Record IDs (`--hash-record-ids`)
@@ -92,7 +97,7 @@ The `--hash-record-ids` flag is also supported by the `package` subcommand.
 olt tokenize \
   -i resources/sample.csv \
   -o resources/hashed-output.csv \
-  -h "HashingKey" \
+  --exchange-config ./tokenize.exchange.json \
   --hash-record-ids
 ```
 
@@ -108,7 +113,7 @@ Each `RecordId` is replaced with a 64-character lowercase SHA-256 hex digest. Th
 
 ### Demo Mode (`--demo-mode`)
 
-In demo mode the full hashing pipeline is skipped. No `--hashingsecret` is required.
+In demo mode the full hashing pipeline is skipped. No exchange config or private key is required.
 
 ```bash
 olt tokenize \
@@ -197,15 +202,15 @@ neither `HashingSecretHash` nor `EncryptionSecretHash` appears in demo-mode meta
 
 ## Security Trade-offs
 
-| Aspect               | `package`                       | `tokenize`          | `tokenize --demo-mode`         |
-| -------------------- | ------------------------------- | ------------------- | ------------------------------ |
-| **Token length**     | ~80-100 chars                   | 44 chars (base64)   | Varies (plain text)            |
-| **Processing speed** | Slower                          | Faster              | Fastest                        |
-| **Secret required**  | Hashing secret + encryption key | Hashing secret only | None                           |
-| **Reversibility**    | Decryptable (to HMAC hash)      | Not decryptable     | Directly readable (plain text) |
-| **External sharing** | Recommended                     | Not recommended     | Never — contains raw PII       |
-| **Defense in depth** | Yes                             | No                  | No                             |
-| **Use case**         | Production / sharing            | Internal analysis   | Exploration / debugging only   |
+| Aspect                  | `package`                     | `tokenize`                    | `tokenize --demo-mode`         |
+| ----------------------- | ----------------------------- | ----------------------------- | ------------------------------ |
+| **Token length**        | ~80-100 chars                 | 44 chars (base64)             | Varies (plain text)            |
+| **Processing speed**    | Slower                        | Faster                        | Fastest                        |
+| **CLI inputs required** | Exchange config + private key | Exchange config + private key | None                           |
+| **Reversibility**       | Decryptable (to HMAC hash)    | Not decryptable               | Directly readable (plain text) |
+| **External sharing**    | Recommended                   | Not recommended               | Never — contains raw PII       |
+| **Defense in depth**    | Yes                           | No                            | No                             |
+| **Use case**            | Production / sharing          | Internal analysis             | Exploration / debugging only   |
 
 ### Security Notes
 
@@ -220,7 +225,7 @@ Tokenized (unencrypted) tokens can be matched directly without decryption when *
 
 1. Partner generates and shares **encrypted tokens**.
 2. You run [Decrypting Tokens](decrypting-tokens.md) to convert the partner's encrypted tokens to their unencrypted equivalent.
-3. You generate **tokenized output** for your own dataset using the same hashing secret.
+3. You generate **tokenized output** for your own dataset using the same exchange config.
 4. You join the two tokenized datasets to measure overlap.
 
 ```sql
@@ -231,10 +236,7 @@ JOIN tokens_b b ON a.Token = b.Token AND a.RuleId = b.RuleId
 WHERE a.RuleId = 'T1';
 ```
 
-For encrypted tokens, either:
-
-1. Decrypt both datasets first, then match
-2. Use the same encryption key for both datasets and match encrypted tokens directly
+For encrypted tokens, decrypt them to their hashed form first and then match on `RuleId` plus `Token`.
 
 ---
 
@@ -242,23 +244,26 @@ For encrypted tokens, either:
 
 ### Tokens Don't Match Between Runs
 
-**Cause:** Different hashing secrets.
+**Cause:** Different exchange configs resolved different hashing secrets.
 
-**Solution:** Verify the same hashing secret is used for both runs:
+**Solution:** Verify both runs produced the same secret hashes in metadata:
 
 ```bash
 # Check metadata for secret hash
 cat output.metadata.json | jq '.HashingSecretHash'
 ```
 
-### "Encryption key not provided" Error
+### "No private key matching this exchange config was found" Error
 
-**Cause:** Using package mode without an encryption key.
+**Cause:** The CLI found the exchange config but could not auto-discover a matching private key.
 
-**Solution:** Use the `tokenize` subcommand to skip encryption:
+**Solution:** Provide the correct key explicitly:
 
 ```bash
-olt tokenize -i data.csv -o out.csv -h "Key"
+olt tokenize \
+  -i data.csv \
+  -o out.csv \
+  --exchange-config ./tokenize.exchange.json
 ```
 
 ---

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -133,7 +133,6 @@ These arguments are shared across all subcommands:
 | ------------------- | ----- | --------------------------------------------------------------------------------------------------------------------- |
 | `--input`           | `-i`  | Input file path (CSV or Parquet)                                                                                      |
 | `--output`          | `-o`  | Output file path                                                                                                      |
-| `--type`            | `-t`  | File type: `csv` or `parquet`                                                                                         |
 | `--exchange-config` |       | Exchange config JSON path. Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted on consumer commands.  |
 | `--private-key`     |       | Private key PEM used to decrypt the exchange config and derive later transport keys                                   |
 | `--private-key-env` |       | Environment variable containing the private key PEM                                                                   |

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -48,8 +48,7 @@ chmod +x openlinktoken
 ./olt package \
   -i /path/to/sample.csv \
   -o /path/to/output.csv \
-  --exchange-config /path/to/quickstart.exchange.json \
-  --private-key "$HOME/.openlinktoken/quickstart.private.pem"
+  --exchange-config /path/to/quickstart.exchange.json
 ```
 
 **Windows PowerShell:**
@@ -65,8 +64,7 @@ cd openlinktoken-cli-2.0.0-alpha-windows-x64
 .\olt.exe package `
   -i C:\path\to\sample.csv `
   -o C:\path\to\output.csv `
-  --exchange-config C:\path\to\quickstart.exchange.json `
-  --private-key "$HOME/.openlinktoken/quickstart.private.pem"
+  --exchange-config C:\path\to\quickstart.exchange.json
 ```
 
 ### Verifying the Executable
@@ -91,8 +89,7 @@ cd /path/to/OpenLinkToken
 ./run-openlinktoken.sh package \
   -i ./resources/sample.csv \
   -o ./resources/output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ./resources/quickstart.exchange.json
 ```
 
 ### Windows PowerShell
@@ -103,8 +100,7 @@ cd C:\path\to\Open Link Token
 .\run-openlinktoken.ps1 package `
   -i .\resources\sample.csv `
   -o .\resources\output.csv `
-  -h "HashingKey" `
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config .\resources\quickstart.exchange.json
 ```
 
 ## Subcommands
@@ -161,8 +157,7 @@ olt initiate-exchange --name quickstart --public-key ~/.openlinktoken/recipient.
 olt package \
   -i sample.csv \
   -o tokens.csv \
-  --exchange-config ./quickstart.exchange.json \
-  --private-key ~/.openlinktoken/quickstart.private.pem
+  --exchange-config ./quickstart.exchange.json
 ```
 
 **Output (`tokens.csv`):**
@@ -183,8 +178,7 @@ patient_002,T1,...
 olt package \
   -i input.parquet \
   -o tokens.parquet \
-  --exchange-config ./quickstart.exchange.json \
-  --private-key ~/.openlinktoken/quickstart.private.pem
+  --exchange-config ./quickstart.exchange.json
 ```
 
 ## Other Subcommands
@@ -249,9 +243,9 @@ A `.metadata.json` file is created alongside the output:
 
 ## Troubleshooting
 
-### "Encryption key not provided"
+### "No private key matching this exchange config was found"
 
-Either provide `-e "YourKey"` with `package` or use the `tokenize` subcommand.
+Pass `--private-key` or `--private-key-env`, or place the matching key under `~/.openlinktoken/`.
 
 ### "Invalid BirthDate"
 

--- a/pages/quickstarts/index.md
+++ b/pages/quickstarts/index.md
@@ -83,8 +83,8 @@ See [Configuration](../config/configuration.md) for detailed column mapping and 
 
 ## Common Issues
 
-**"Encryption key not provided"**
-→ Either add `-e "YourKey"` with `package` or use `tokenize` to skip encryption.
+**"No private key matching this exchange config was found"**
+→ Pass `--private-key` or `--private-key-env`, or place the matching key under `~/.openlinktoken/`.
 
 **"Invalid BirthDate"**
 → Use YYYY-MM-DD format or one of the accepted formats. Date must be between 1910-01-01 and today.

--- a/pages/quickstarts/python-quickstart.md
+++ b/pages/quickstarts/python-quickstart.md
@@ -58,14 +58,23 @@ uv pip install -r requirements.txt -e .
 
 ## Run Token Generation
 
+Create a local exchange config once before running the consumer commands:
+
+```bash
+olt generate-key-pair --name recipient --force
+olt initiate-exchange \
+  --name quickstart \
+  --public-key ~/.openlinktoken/recipient.public.pem \
+  --output ../../../resources/quickstart.exchange.json
+```
+
 ### Package Command (Tokenize + Encrypt)
 
 ```bash
 olt package \
   -i ../../../resources/sample.csv \
   -o ../../../resources/output.csv \
-  -h "YourHashingSecret" \
-  -e "YourEncryptionKey-32Chars-Here!"
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 ### Tokenize Command (Hash-Only, No Encryption)
@@ -74,7 +83,7 @@ olt package \
 olt tokenize \
   -i ../../../resources/sample.csv \
   -o ../../../resources/output.csv \
-  -h "YourHashingSecret"
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 ### Parquet Format
@@ -83,8 +92,7 @@ olt tokenize \
 olt package \
   -i input.parquet \
   -o output.parquet \
-  -h "YourHashingSecret" \
-  -e "YourEncryptionKey-32Chars-Here!"
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 ### Decrypt Command
@@ -93,7 +101,7 @@ olt package \
 olt decrypt \
   -i ../../../resources/output.csv \
   -o ../../../resources/decrypted.csv \
-  -e "YourEncryptionKey-32Chars-Here!"
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 ### Generate ECDH Key Pair

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -254,13 +254,12 @@ Release assets are published with SHA-256 sidecars, and `olt update` verifies th
 
 ### Encrypted Mode (Default)
 
-Generates fully encrypted tokens using AES-256-GCM. Tokens can be decrypted later with the encryption key.
+Generates fully encrypted tokens using the transport key derived from the exchange config. Tokens can be decrypted later by a party with a matching private key.
 
 ```bash
 olt package \
   -i input.csv -o output.csv \
-  -h "HashingSecret" \
-  -e "EncryptionKey-Exactly32Chars!!"
+  --exchange-config ./partner.exchange.json
 ```
 
 **Token Pipeline:**
@@ -276,7 +275,7 @@ Generates one-way hashed tokens. Faster but tokens cannot be decrypted.
 ```bash
 olt tokenize \
   -i input.csv -o output.csv \
-  -h "HashingSecret"
+  --exchange-config ./partner.exchange.json
 
 ```
 
@@ -289,7 +288,7 @@ Signature → SHA-256 → HMAC-SHA256 → Base64
 ### Demo Mode (`tokenize --demo-mode`)
 
 Outputs raw attribute signature strings without any hashing. Both the SHA-256 and HMAC
-steps are skipped. No `--hashingsecret` is required, making it easy to inspect which
+steps are skipped. No exchange config or private key is required, making it easy to inspect which
 attribute values compose each token for development, testing, or demos.
 
 > ⚠️ **Demo-mode output must not be used in production or shared externally.** The raw
@@ -318,7 +317,7 @@ JOHN|DOE|19800115
 
 | Aspect                          | Normal mode                    | Demo mode                                  |
 | ------------------------------- | ------------------------------ | ------------------------------------------ |
-| `--hashingsecret`               | Required                       | Not required (ignored if supplied)         |
+| Exchange config / private key   | Required in normal mode        | Not required                               |
 | Token pipeline                  | SHA-256 → HMAC-SHA256 → Base64 | Passthrough → raw signature string         |
 | Token format                    | Base64-encoded HMAC-SHA256     | Pipe-separated normalised attribute values |
 | `HashingSecretHash` in metadata | Present                        | Absent                                     |
@@ -417,9 +416,7 @@ For long-running processing commands (`package`, `tokenize`, `encrypt`, and `dec
 ./run-openlinktoken.sh package \
   -i ./input.csv \
   -o ./output.csv \
-
-  -h "HashingKey" \
-  -e "EncryptionKey" \
+  --exchange-config ./partner.exchange.json \
   [--skip-build] \
   [--verbose]
 ```
@@ -436,8 +433,7 @@ For long-running processing commands (`package`, `tokenize`, `encrypt`, and `dec
 .\run-openlinktoken.ps1 package `
   -i .\input.csv `
   -o .\output.csv `
-  -h "HashingKey" `
-  -e "EncryptionKey" `
+  --exchange-config .\partner.exchange.json `
   [-SkipBuild] `
   [-Verbose]
 ```
@@ -499,15 +495,15 @@ When `OLT_EXTENSIONS_DIR` is set, the registry is stored in that directory inste
 
 ## Error Messages
 
-| Error                                  | Cause                        | Solution                         |
-| -------------------------------------- | ---------------------------- | -------------------------------- |
-| "Encryption key not provided"          | Missing `-e` in package mode | Add `-e "key"` or use `tokenize` |
-| "Encryption key must be 32 characters" | Key length wrong             | Use exactly 32 characters        |
-| "Input file not found"                 | Invalid path                 | Check file exists                |
-| "Unknown file type"                    | Unsupported file extension   | Use `.csv` or `.parquet` paths   |
-| "Invalid attribute: BirthDate"         | Date validation failed       | Use YYYY-MM-DD format            |
-| "Unsupported curve '…'"                | Invalid `--curve` value      | Use `P-256`, `P-384`, or `P-521` |
-| "Key files for '…' already exist"      | Name collision without force | Use `--force` to overwrite       |
+| Error                                                    | Cause                                                           | Solution                                                               |
+| -------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| "Exchange config '<path>' was not found"                 | Missing default exchange config or bad `--exchange-config` path | Create or pass the correct exchange config JSON                        |
+| "No private key matching this exchange config was found" | No matching key under `~/.openlinktoken/`                       | Pass `--private-key` / `--private-key-env` or install the matching key |
+| "Input file not found"                                   | Invalid path                                                    | Check file exists                                                      |
+| "Unknown file type"                                      | Unsupported file extension                                      | Use `.csv` or `.parquet` paths                                         |
+| "Invalid attribute: BirthDate"                           | Date validation failed                                          | Use YYYY-MM-DD format                                                  |
+| "Unsupported curve '…'"                                  | Invalid `--curve` value                                         | Use `P-256`, `P-384`, or `P-521`                                       |
+| "Key files for '…' already exist"                        | Name collision without force                                    | Use `--force` to overwrite                                             |
 
 Unexpected internal CLI errors archive a redacted traceback under the Open Link Token logs directory. The CLI prints the exact archive path to **stderr** as `Stack trace: <path>`. By default, logs are written to `~/.openlinktoken/logs` on Linux and macOS and `%APPDATA%\.openlinktoken\logs` on Windows.
 

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -403,6 +403,12 @@ Every run generates a `.metadata.json` file:
 }
 ```
 
+For long-running processing commands (`package`, `tokenize`, `encrypt`, and `decrypt`), the CLI now keeps the terminal output concise:
+
+- Interactive terminals show a progress indicator instead of streaming every log line
+- The command ends with a short summary that highlights the most important counts and output paths
+- A per-run detailed log is written under the Open Link Token logs directory and referenced as `Detailed log: <path>`
+
 ## Docker Script Options
 
 ### Bash (run-openlinktoken.sh)
@@ -430,7 +436,6 @@ Every run generates a `.metadata.json` file:
 .\run-openlinktoken.ps1 package `
   -i .\input.csv `
   -o .\output.csv `
-  -FileType csv `
   -h "HashingKey" `
   -e "EncryptionKey" `
   [-SkipBuild] `
@@ -499,12 +504,14 @@ When `OLT_EXTENSIONS_DIR` is set, the registry is stored in that directory inste
 | "Encryption key not provided"          | Missing `-e` in package mode | Add `-e "key"` or use `tokenize` |
 | "Encryption key must be 32 characters" | Key length wrong             | Use exactly 32 characters        |
 | "Input file not found"                 | Invalid path                 | Check file exists                |
-| "Unknown file type"                    | Invalid `-t` value           | Use `csv` or `parquet`           |
+| "Unknown file type"                    | Unsupported file extension   | Use `.csv` or `.parquet` paths   |
 | "Invalid attribute: BirthDate"         | Date validation failed       | Use YYYY-MM-DD format            |
 | "Unsupported curve '…'"                | Invalid `--curve` value      | Use `P-256`, `P-384`, or `P-521` |
 | "Key files for '…' already exist"      | Name collision without force | Use `--force` to overwrite       |
 
 Unexpected internal CLI errors archive a redacted traceback under the Open Link Token logs directory. The CLI prints the exact archive path to **stderr** as `Stack trace: <path>`. By default, logs are written to `~/.openlinktoken/logs` on Linux and macOS and `%APPDATA%\.openlinktoken\logs` on Windows.
+
+For `package`, `tokenize`, `encrypt`, and `decrypt`, the same logs directory also stores the normal per-run detailed logs that back the concise end-of-run summary. If one of those commands fails after it has started processing, the traceback is appended to that same per-run log so there is a single file to inspect.
 
 ## Exit Codes
 

--- a/pages/reference/index.md
+++ b/pages/reference/index.md
@@ -137,7 +137,7 @@ The CLI processes CSV or Parquet files without writing code.
 ```bash
 olt package \
   -i input.csv -o output.csv \
-  -h "HashingSecret" -e "EncryptionKey32Chars!!!!!!!!!!"
+  --exchange-config ./partner.exchange.json
 ```
 
 Or with Python:
@@ -145,18 +145,18 @@ Or with Python:
 ```bash
 python -m openlinktoken_cli.main package \
   -i input.csv -o output.csv \
-  -h "HashingSecret" -e "EncryptionKey32Chars!!!!!!!!!!"
+  --exchange-config ./partner.exchange.json
 ```
 
 **Key options:**
 
-| Flag                     | Purpose                     |
-| ------------------------ | --------------------------- |
-| `-i` / `--input`         | Input file path             |
-| `-o` / `--output`        | Output file path            |
-| `-h` / `--hashingsecret` | HMAC-SHA256 secret          |
-| `-e` / `--encryptionkey` | AES-256 key (32 chars)      |
-| `tokenize`               | Tokenize without encryption |
+| Flag                                  | Purpose                                                |
+| ------------------------------------- | ------------------------------------------------------ |
+| `-i` / `--input`                      | Input file path                                        |
+| `-o` / `--output`                     | Output file path                                       |
+| `--exchange-config`                   | Exchange config JSON path                              |
+| `--private-key` / `--private-key-env` | Private key used to decrypt the exchange config        |
+| `tokenize`                            | Hash-only mode using the same exchange-config workflow |
 
 **Full reference:** [CLI Reference](cli.md)
 

--- a/pages/reference/index.md
+++ b/pages/reference/index.md
@@ -150,14 +150,13 @@ python -m openlinktoken_cli.main package \
 
 **Key options:**
 
-| Flag                     | Purpose                        |
-| ------------------------ | ------------------------------ |
-| `-i` / `--input`         | Input file path                |
-| `-o` / `--output`        | Output file path               |
-| `-t` / `--type`          | File type (`csv` or `parquet`) |
-| `-h` / `--hashingsecret` | HMAC-SHA256 secret             |
-| `-e` / `--encryptionkey` | AES-256 key (32 chars)         |
-| `tokenize`               | Tokenize without encryption    |
+| Flag                     | Purpose                     |
+| ------------------------ | --------------------------- |
+| `-i` / `--input`         | Input file path             |
+| `-o` / `--output`        | Output file path            |
+| `-h` / `--hashingsecret` | HMAC-SHA256 secret          |
+| `-e` / `--encryptionkey` | AES-256 key (32 chars)      |
+| `tokenize`               | Tokenize without encryption |
 
 **Full reference:** [CLI Reference](cli.md)
 

--- a/pages/running-openlinktoken/index.md
+++ b/pages/running-openlinktoken/index.md
@@ -20,17 +20,17 @@ olt <subcommand> [OPTIONS]
 
 #### Required Arguments (All Subcommands)
 
-| Argument | Alias      | Description                      | Example       |
-| -------- | ---------- | -------------------------------- | ------------- |
-| `-i`     | `--input`  | Input file path (CSV or Parquet) | `-i data.csv` |
+| Argument | Alias      | Description                      | Example         |
+| -------- | ---------- | -------------------------------- | --------------- |
+| `-i`     | `--input`  | Input file path (CSV or Parquet) | `-i data.csv`   |
 | `-o`     | `--output` | Output file path                 | `-o tokens.csv` |
 
 #### Optional Arguments by Subcommand
 
-| Argument | Alias             | `package` | `tokenize` | `decrypt` | Description                       | Default            | Example                |
-| -------- | ----------------- | --------- | ---------- | --------- | --------------------------------- | ------------------ | ---------------------- |
-| `-h`     | `--hashingkey`    | ✓         | ✓          |           | HMAC-SHA256 hashing secret        | Required           | `-h "HashingKey"`      |
-| `-e`     | `--encryptionkey` | ✓         |            | ✓         | AES-256 encryption key            | Required           | `-e "MyEncryptionKey"` |
+| Argument | Alias             | `package` | `tokenize` | `decrypt` | Description                | Default  | Example                |
+| -------- | ----------------- | --------- | ---------- | --------- | -------------------------- | -------- | ---------------------- |
+| `-h`     | `--hashingkey`    | ✓         | ✓          |           | HMAC-SHA256 hashing secret | Required | `-h "HashingKey"`      |
+| `-e`     | `--encryptionkey` | ✓         |            | ✓         | AES-256 encryption key     | Required | `-e "MyEncryptionKey"` |
 
 ### Usage Examples
 
@@ -138,6 +138,18 @@ record1,T2,pUxPgYL9+cMxkA+8928Pil+9W+dm9kISwHYPdkZS+I2nQ/bQ/8HyL3FOVf3NYPW5NKZZO
 
 See [Reference: Metadata Format](../reference/metadata-format.md) for detailed field descriptions.
 
+### Console Output and Detailed Logs
+
+For the long-running processing commands (`package`, `tokenize`, `encrypt`, and `decrypt`), the CLI keeps terminal output brief:
+
+- Interactive terminals show a progress indicator while the command runs
+- The command finishes with a short summary that surfaces the output path and the most important counts
+- A detailed per-run log is written under the Open Link Token logs directory:
+  - Linux / macOS: `~/.openlinktoken/logs`
+  - Windows: `%APPDATA%\.openlinktoken\logs`
+
+If a processing command fails after it starts, the CLI prints `Stack trace: <path>` and the traceback is appended to that same detailed log file.
+
 ---
 
 ## Docker
@@ -169,7 +181,6 @@ cd C:\path\to\Open Link Token
 .\run-openlinktoken.ps1 package `
   -i .\resources\sample.csv `
   -o .\resources\output.csv `
-  -FileType csv `
   -h "HashingKey" `
   -e "Secret-Encryption-Key-Goes-Here."
 ```
@@ -178,7 +189,6 @@ cd C:\path\to\Open Link Token
 
 | Option       | Bash Alias | PowerShell   | Description          |
 | ------------ | ---------- | ------------ | -------------------- |
-| File type    | `-t`       | `-FileType`  | `csv` or `parquet`   |
 | Skip rebuild | `-s`       | `-SkipBuild` | Reuse existing image |
 | Verbose      | `-v`       | `-Verbose`   | Show detailed output |
 

--- a/pages/running-openlinktoken/index.md
+++ b/pages/running-openlinktoken/index.md
@@ -27,16 +27,20 @@ olt <subcommand> [OPTIONS]
 
 #### Optional Arguments by Subcommand
 
-| Argument | Alias             | `package` | `tokenize` | `decrypt` | Description                | Default  | Example                |
-| -------- | ----------------- | --------- | ---------- | --------- | -------------------------- | -------- | ---------------------- |
-| `-h`     | `--hashingkey`    | ✓         | ✓          |           | HMAC-SHA256 hashing secret | Required | `-h "HashingKey"`      |
-| `-e`     | `--encryptionkey` | ✓         |            | ✓         | AES-256 encryption key     | Required | `-e "MyEncryptionKey"` |
+| Argument            | Alias | `package` | `tokenize` | `encrypt` | `decrypt` | Description                                         | Default                       | Example                                                 |
+| ------------------- | ----- | --------- | ---------- | --------- | --------- | --------------------------------------------------- | ----------------------------- | ------------------------------------------------------- |
+| `--exchange-config` |       | ✓         | ✓          | ✓         | ✓         | Exchange config JSON path                           | Date-based default path       | `--exchange-config ./quickstart.exchange.json`          |
+| `--private-key`     |       | ✓         | ✓          | ✓         | ✓         | Private key PEM used to decrypt the exchange config | Auto-discovered when possible | `--private-key ~/.openlinktoken/quickstart.private.pem` |
+| `--private-key-env` |       | ✓         | ✓          | ✓         | ✓         | Environment variable containing the private key PEM |                               | `--private-key-env OLT_PRIVATE_KEY_PEM`                 |
+| `--demo-mode`       |       |           | ✓          |           |           | Skip hashing and emit raw attribute signatures      | `false`                       | `tokenize --demo-mode`                                  |
+
+If a matching key already exists under `~/.openlinktoken/`, you can omit `--private-key` and `--private-key-env`.
 
 ### Usage Examples
 
 #### Token Generation (Encryption Mode)
 
-Generates encrypted tokens. Both hashing secret and encryption key required.
+Generates encrypted tokens. Consumer commands resolve the hashing secret and transport key from an exchange config plus a matching private key.
 
 ```bash
 cd lib/python/openlinktoken-cli
@@ -45,34 +49,30 @@ uv pip install -r requirements.txt -e . -e ../openlinktoken
 
 olt package \
   -i ../../../resources/sample.csv \
-
   -o ../../../resources/output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 #### Token Generation (Tokenize)
 
-Generates HMAC-SHA256 hashed tokens without AES encryption. Only hashing secret required.
+Generates HMAC-SHA256 hashed tokens without transport encryption, using the same exchange-config workflow.
 
 ```bash
 olt tokenize \
   -i ../../../resources/sample.csv \
-
   -o ../../../resources/hashed-output.csv \
-  -h "HashingKey"
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 #### Token Decryption
 
-Decrypts previously encrypted tokens. Only encryption key required.
+Decrypts previously encrypted tokens using the same exchange config and a matching private key.
 
 ```bash
 olt decrypt \
   -i ../../../resources/output.csv \
-
   -o ../../../resources/decrypted.csv \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ../../../resources/quickstart.exchange.json
 ```
 
 #### Key Pair Generation
@@ -168,9 +168,7 @@ cd /path/to/OpenLinkToken
 ./run-openlinktoken.sh package \
   -i ./resources/sample.csv \
   -o ./resources/output.csv \
-
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ./resources/quickstart.exchange.json
 ```
 
 **PowerShell (Windows):**
@@ -181,8 +179,7 @@ cd C:\path\to\Open Link Token
 .\run-openlinktoken.ps1 package `
   -i .\resources\sample.csv `
   -o .\resources\output.csv `
-  -h "HashingKey" `
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config .\resources\quickstart.exchange.json
 ```
 
 #### Script Options
@@ -206,10 +203,8 @@ docker build -t openlinktoken:latest .
 docker run --rm -v $(pwd)/resources:/app/resources \
   openlinktoken:latest package \
   -i /app/resources/sample.csv \
-
   -o /app/resources/output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config /app/resources/quickstart.exchange.json
 
 # View output
 cat resources/output.csv
@@ -288,14 +283,18 @@ See example notebooks in `lib/python/openlinktoken-pyspark/notebooks/`:
 
 ## Troubleshooting
 
-### "Encryption key not provided"
+### "No private key matching this exchange config was found"
 
-**Problem**: Error when running `package` mode without `-e`.
+**Problem**: The CLI found the exchange config but could not auto-discover a matching key under `~/.openlinktoken/`.
 
-**Solution**: Either provide encryption key `-e "YourKey"` or use `tokenize`:
+**Solution**: Pass the correct key explicitly or provide it through an environment variable:
 
 ```bash
-olt tokenize -i data.csv -o output.csv -h "HashingKey"
+olt package \
+  -i data.csv \
+  -o output.csv \
+  --exchange-config ./quickstart.exchange.json \
+  --private-key ~/.openlinktoken/quickstart.private.pem
 ```
 
 ### "Invalid BirthDate" or "Date out of range"

--- a/pages/security.md
+++ b/pages/security.md
@@ -107,37 +107,40 @@ HMAC-SHA256(message, key) = SHA256((key ⊕ opad) || SHA256((key ⊕ ipad) || me
 
 ## Key Management & Secrets
 
-This section consolidates practical guidance for managing the cryptographic secrets Open Link Token requires.
+This section consolidates practical guidance for managing the cryptographic material Open Link Token requires.
 
 ### Types of Secrets
 
-Open Link Token uses two secrets. Which secrets are required depends on the subcommand:
+Open Link Token still relies on a hashing secret and a transport encryption key internally, but the consumer commands no longer take those values directly on the command line. Instead, they resolve them from an exchange config plus a matching private key:
 
-| Secret             | CLI Flag                 | Purpose                                   | Required for subcommands        | Requirements                         |
-| ------------------ | ------------------------ | ----------------------------------------- | ------------------------------- | ------------------------------------ |
-| **Hashing Secret** | `-h` / `--hashingsecret` | HMAC-SHA256 key for deterministic hashing | `package`, `tokenize`           | 8+ characters recommended, 16+ ideal |
-| **Encryption Key** | `-e` / `--encryptionkey` | AES-256-GCM symmetric key                 | `package`, `encrypt`, `decrypt` | **Exactly 32 characters**            |
+| Material            | CLI Input                             | Purpose                                                                                  | Used by subcommands                         | Requirements                                                                       |
+| ------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Exchange config** | `--exchange-config`                   | Carries the encrypted hashing secret and the metadata needed to derive the transport key | `package`, `tokenize`, `encrypt`, `decrypt` | Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted                |
+| **Private key**     | `--private-key` / `--private-key-env` | Decrypts the exchange config so the CLI can recover the hashing secret and transport key | `package`, `tokenize`, `encrypt`, `decrypt` | Optional only when a matching key can be auto-discovered under `~/.openlinktoken/` |
 
 ### Handling Secrets in Practice
 
 #### Development / Local Testing
 
-Use clearly marked placeholder values:
+Use clearly marked local file names:
 
 ```bash
-# Placeholder secrets for local testing only
+olt generate-key-pair --name local-test --force
+olt initiate-exchange \
+  --name local-test \
+  --public-key ~/.openlinktoken/local-test.public.pem \
+  --output ./local-test.exchange.json
+
 olt package \
   -i sample.csv -o output.csv \
-  -h "HashingKey" \
-  -e "Secret-Encryption-Key-Goes-Here."
+  --exchange-config ./local-test.exchange.json
 ```
 
-Store these in a local `.env` file (not committed):
+Store reusable paths in a local `.env` file (not committed):
 
 ```bash
 # .env (add to .gitignore)
-OLT_HASHING_SECRET=HashingKey
-OLT_ENCRYPTION_KEY=Secret-Encryption-Key-Goes-Here.
+OLT_EXCHANGE_CONFIG=./local-test.exchange.json
 ```
 
 Load and use:
@@ -146,8 +149,7 @@ Load and use:
 source .env
 olt package \
   -i sample.csv -o output.csv \
-  -h "$OLT_HASHING_SECRET" \
-  -e "$OLT_ENCRYPTION_KEY"
+  --exchange-config "$OLT_EXCHANGE_CONFIG"
 ```
 
 #### Production
@@ -162,18 +164,16 @@ Store secrets in a managed secret store and inject via environment variables at 
 | On-prem    | HashiCorp Vault    | `vault kv get` or agent auto-auth                           |
 | Databricks | Databricks Secrets | `dbutils.secrets.get("scope", "key")`                       |
 
-**Example (AWS Secrets Manager):**
+**Example (AWS Secrets Manager override):**
 
 ```bash
-export OLT_HASHING_SECRET=$(aws secretsmanager get-secret-value \
-  --secret-id openlinktoken-hash-key --query SecretString --output text)
-export OLT_ENCRYPTION_KEY=$(aws secretsmanager get-secret-value \
-  --secret-id openlinktoken-enc-key --query SecretString --output text)
+export OLT_PRIVATE_KEY_PEM=$(aws secretsmanager get-secret-value \
+  --secret-id openlinktoken-private-key --query SecretString --output text)
 
 olt package \
   -i data.csv -o tokens.csv \
-  -h "$OLT_HASHING_SECRET" \
-  -e "$OLT_ENCRYPTION_KEY"
+  --exchange-config ./sender-q2.exchange.json \
+  --private-key-env OLT_PRIVATE_KEY_PEM
 ```
 
 **Example (Databricks):**
@@ -191,9 +191,9 @@ processor = SparkPersonTokenProcessor(
 ### Secret Rotation
 
 1. **Generate new secrets** – use a cryptographically secure generator.
-2. **Re-run token generation** – tokens are deterministic; same input + same secrets = same tokens. New secrets = new tokens.
+2. **Re-run token generation** – tokens are deterministic; same input plus the same resolved exchange-config secrets produces the same tokens. New exchange material produces new tokens.
 3. **Version secrets in your store** – keep old versions for auditability.
-4. **Coordinate downstream** – any system that decrypts tokens needs the matching encryption key.
+4. **Coordinate downstream** – any system that decrypts tokens needs a matching private key for the updated exchange config.
 
 ### What NOT to Do
 
@@ -223,7 +223,7 @@ python tools/hash_calculator.py \
 
 ### Cross-References
 
-- **CLI flags for secrets**: [CLI Reference](reference/cli.md)
+- **CLI flags for exchange configs and private keys**: [CLI Reference](reference/cli.md)
 - **Environment variable usage**: [Configuration](config/configuration.md#environment-variables)
 - **Databricks / Spark secrets**: [Spark or Databricks](operations/spark-or-databricks.md)
 - **Running the CLI**: [Running Open Link Token](running-openlinktoken/index.md)

--- a/run-openlinktoken.ps1
+++ b/run-openlinktoken.ps1
@@ -16,11 +16,6 @@ param(
     [Alias("o")]
     [string]$OutputFile,
 
-    [Parameter(Mandatory=$false, HelpMessage="File type: csv or parquet (default: csv)")]
-    [Alias("t")]
-    [ValidateSet("csv", "parquet")]
-    [string]$FileType = "csv",
-
     [Parameter(Mandatory=$false, HelpMessage="Hashing secret key")]
     [Alias("h")]
     [string]$HashingSecret,
@@ -72,7 +67,6 @@ SUBCOMMAND-SPECIFIC PARAMETERS:
     -EncryptionKey, -e <key>    32-character encryption key (package, encrypt, decrypt)
 
 OPTIONAL PARAMETERS:
-    -FileType, -t <type>        File type: csv or parquet (default: csv)
     -SkipBuild, -s              Skip Docker image build (use existing image)
     -DockerImage <name>         Docker image name (default: openlinktoken:latest)
     -Verbose, -v                Enable verbose output
@@ -221,7 +215,6 @@ if ($VerboseOutput) {
     Write-Info "Subcommand: $Subcommand"
     Write-Info "Input file: $InputFile"
     Write-Info "Output file: $OutputFile"
-    Write-Info "File type: $FileType"
     Write-Info "Docker image: $DockerImage"
 }
 
@@ -293,7 +286,6 @@ if ($InputDir -eq $OutputDir) {
         $DockerImage `
         $Subcommand `
         -i "/data/$InputFilename" `
-        -t $FileType `
         -o "/data/$OutputFilename" `
         @CliArgs
 } else {
@@ -309,7 +301,6 @@ if ($InputDir -eq $OutputDir) {
         $DockerImage `
         $Subcommand `
         -i "/data/input/$InputFilename" `
-        -t $FileType `
         -o "/data/output/$OutputFilename" `
         @CliArgs
 }

--- a/run-openlinktoken.sh
+++ b/run-openlinktoken.sh
@@ -10,7 +10,6 @@ set -e  # Exit on error
 SUBCOMMAND="package"
 INPUT_FILE=""
 OUTPUT_FILE=""
-FILE_TYPE="csv"
 HASHING_SECRET=""
 ENCRYPTION_KEY=""
 DOCKER_IMAGE="openlinktoken:latest"
@@ -53,7 +52,6 @@ SUBCOMMAND-SPECIFIC OPTIONS:
     -e, --encrypt KEY       Encryption key            (package, encrypt, decrypt)
 
 OPTIONAL:
-    -t, --type TYPE         File type: csv or parquet (default: csv)
     -s, --skip-build        Skip Docker image build (use existing image)
     --image NAME            Docker image name (default: openlinktoken:latest)
     -v, --verbose           Enable verbose output
@@ -105,14 +103,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         -o|--output)
             OUTPUT_FILE="$2"
-            shift 2
-            ;;
-        -t|--type)
-            FILE_TYPE="$2"
-            if [[ ! "$FILE_TYPE" =~ ^(csv|parquet)$ ]]; then
-                log_error "Invalid file type: $FILE_TYPE. Must be: csv, parquet"
-                exit 1
-            fi
             shift 2
             ;;
         -h|--hash)
@@ -296,7 +286,6 @@ if [[ "$INPUT_DIR" == "$OUTPUT_DIR" ]]; then
         "$DOCKER_IMAGE" \
         "$SUBCOMMAND" \
         -i "/data/$INPUT_FILENAME" \
-        -t "$FILE_TYPE" \
         -o "/data/$OUTPUT_FILENAME" \
         "${CLI_ARGS[@]}"
 else
@@ -312,7 +301,6 @@ else
         "$DOCKER_IMAGE" \
         "$SUBCOMMAND" \
         -i "/data/input/$INPUT_FILENAME" \
-        -t "$FILE_TYPE" \
         -o "/data/output/$OUTPUT_FILENAME" \
         "${CLI_ARGS[@]}"
 fi


### PR DESCRIPTION
## Summary

- Refresh the Python CLI runtime UX for long-running processing commands so users see progress and a concise completion summary instead of raw log spam.
- Move detailed processing output into per-run log files, reuse the same log for archived stack traces on failures, and clean up quick-command stderr formatting.
- Remove the deprecated `-t` / `--type` processing option and align wrapper scripts, tests, and docs with extension-based file type detection.
- Update the CLI documentation to reflect the exchange-config workflow, including auto-discovery of matching private keys for consumer commands and explicit override guidance only where needed.

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Added a shared CLI run reporter that manages per-run log files, TTY progress rendering, and success summaries for `package`, `tokenize`, `encrypt`, and `decrypt`.
- Refactored processors and command handlers to return structured summary counters, print expanded alphabetized summary sections, and dim detailed log references the same way as stack-trace references.
- Updated quick-command console logging to use concise message-only stderr output, added regression tests, and removed `-t` passthrough from the Docker wrapper scripts.
- Refreshed quickstarts, reference pages, operations guides, and the developer guide so consumer-command examples use `--exchange-config` by default, describe private-key auto-discovery under `~/.openlinktoken/`, and reserve `--private-key` / `--private-key-env` examples for override and validation scenarios.

## Example output

```text
$ uv run olt package -i ../../../resources/sample.csv -o ./output.csv
  ___                   _    _      _     _____    _
 / _ \ _ __  ___ _ _   | |  (_)_ _ | |__ |_   _|__| |_____ _ _
| (_) | '_ \/ -_) ' \  | |__| | ' \| / /   | |/ _ \ / / -_) ' \
 \___/| .__/\___|_||_| |____|_|_||_|_\_\   |_|\___/_\_\___|_||_|
      |_|
Privacy-Preserving Record Linkage v2.0.0-alpha

Package complete
  Output: ./output.csv
  Metadata: output.metadata.json
  Rows processed: 19,927
  Rows with invalid attributes: 2,817
  Top invalid attributes:
    BirthDate: 751
    LastName: 376
    SocialSecurityNumber: 939
  Blank tokens by rule:
    T1: 1,315
    T2: 1,691
    T3: 1,315
    T4: 1,503
    T5: 751
  Detailed log: /home/vscode/.openlinktoken/logs/20260501T193534Z-package-5b9c2562.log
```
