### PR TITLE
feat: add Latin Extended transliteration for names

### DIFF
--- a/.devcontainer/scripts/unified-setup.sh
+++ b/.devcontainer/scripts/unified-setup.sh
@@ -155,10 +155,12 @@ step_setup_apm() {
     ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null || true
   fi
 
-  if [ -d "$REPO_ROOT/.git" ]; then
+  git config --global --add safe.directory "$REPO_ROOT" 2>/dev/null || true
+
+  if git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
     echo "→ Running apm install"
     cd "$REPO_ROOT"
-    apm install || echo "⚠ Warning: apm install failed (continuing anyway)"
+    apm install --target copilot || echo "⚠ Warning: apm install failed (continuing anyway)"
 
     # Update .gitignore with apm-installed paths
     GITIGNORE="$REPO_ROOT/.gitignore"
@@ -230,6 +232,8 @@ main() {
       ;;
     post-start)
       run_core_setup
+      step_install_apm_cli
+      step_setup_apm
       ;;
     post-attach)
       run_refresh_setup

--- a/.gitignore
+++ b/.gitignore
@@ -99,19 +99,4 @@ apm_modules/
 # APM integrated skills
 
 # Added by apm install
-.github/skills/brainstorming/
-.github/skills/dispatching-parallel-agents/
-.github/skills/executing-plans/
-.github/skills/finishing-a-development-branch/
-.github/skills/receiving-code-review/
-.github/skills/requesting-code-review/
-.github/skills/subagent-driven-development/
-.github/skills/systematic-debugging/
-.github/skills/test-driven-development/
-.github/skills/using-git-worktrees/
-.github/skills/using-superpowers/
-.github/skills/verification-before-completion/
-.github/skills/writing-plans/
-.github/skills/writing-skills/
-.github/skills/documentation-writer/
-.github/skills/gh-cli/
+.agents/

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -298,6 +298,7 @@ Key dependencies:
 Parity notes:
 
 - Outputs identical tokens to Java for the same normalized input & secrets.
+- `FirstName` and `LastName` remove diacritics and transliterate supported Latin Extended letters before ASCII-only filtering (`Ł` → `L`, `Ø` → `O`, `Æ` → `AE`).
 - Maintain consistency when adding new token or attribute logic.
 
 Contributing notes:
@@ -412,7 +413,7 @@ When adding attributes/tokens: update all applicable language implementations, r
 | Add Token       | SPI entry & class                  | new module in `tokens/definitions` |
 | Add Attribute   | SPI entry & class                  | class + loader import              |
 
-Maintain the same functional behavior and normalization between languages.
+Maintain the same functional behavior and normalization between languages. For `FirstName` and `LastName`, keep diacritic removal and supported Latin Extended transliteration ahead of ASCII-only filtering.
 
 ## Coding Standards
 
@@ -632,7 +633,7 @@ Python Troubleshooting:
 
 ### Cross-language Parity Checklist
 
-- Same normalization logic unaffected.
+- Same `FirstName`/`LastName` normalization logic, including diacritic removal and supported Latin Extended transliteration before ASCII-only filtering.
 - Matching token definitions (order & components) across Java & Python.
 - Tests confirming identical hash/encryption output for shared fixtures.
 
@@ -855,13 +856,13 @@ Before opening a PR:
 
 ## Troubleshooting
 
-| Issue                            | Hint                                                                                |
-| -------------------------------- | ----------------------------------------------------------------------------------- |
-| Java class not discovered        | Confirm fully qualified name in `META-INF/services/*` file & no trailing spaces     |
-| Python attribute not loaded      | Ensure it is imported & added in `attribute_loader.py`                              |
-| Token mismatch between languages | Verify hashing & encryption secrets are identical and normalization logic unchanged |
-| Build fails on Checkstyle        | Run `mvn -q checkstyle:check` locally & fix warnings                                |
-| Import errors or style issues    | See [Coding Standards](#coding-standards) for language-specific guidelines          |
+| Issue                            | Hint                                                                                                                                                                                                |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Java class not discovered        | Confirm fully qualified name in `META-INF/services/*` file & no trailing spaces                                                                                                                     |
+| Python attribute not loaded      | Ensure it is imported & added in `attribute_loader.py`                                                                                                                                              |
+| Token mismatch between languages | Verify hashing & encryption secrets are identical and `FirstName`/`LastName` normalization still removes diacritics and transliterates supported Latin Extended letters before ASCII-only filtering |
+| Build fails on Checkstyle        | Run `mvn -q checkstyle:check` locally & fix warnings                                                                                                                                                |
+| Import errors or style issues    | See [Coding Standards](#coding-standards) for language-specific guidelines                                                                                                                          |
 
 ---
 

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/utilities/AttributeUtilities.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/utilities/AttributeUtilities.java
@@ -2,6 +2,7 @@
 package org.openlinktoken.attributes.utilities;
 
 import java.text.Normalizer;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -12,6 +13,54 @@ import java.util.regex.Pattern;
  */
 public class AttributeUtilities {
     private static final Pattern DIACRITICS = Pattern.compile("\\p{M}");
+    private static final Map<Character, String> LATIN_EXTENDED_TRANSLITERATION_MAP = Map.ofEntries(
+            Map.entry('Æ', "AE"),
+            Map.entry('æ', "ae"),
+            Map.entry('Ð', "D"),
+            Map.entry('ð', "d"),
+            Map.entry('Ø', "O"),
+            Map.entry('ø', "o"),
+            Map.entry('Þ', "TH"),
+            Map.entry('þ', "th"),
+            Map.entry('ß', "ss"),
+            Map.entry('ẞ', "SS"),
+            Map.entry('Đ', "D"),
+            Map.entry('đ', "d"),
+            Map.entry('Ħ', "H"),
+            Map.entry('ħ', "h"),
+            Map.entry('ı', "i"),
+            Map.entry('Ĳ', "IJ"),
+            Map.entry('ĳ', "ij"),
+            Map.entry('Ŀ', "L"),
+            Map.entry('ŀ', "l"),
+            Map.entry('Ł', "L"),
+            Map.entry('ł', "l"),
+            Map.entry('ŉ', "n"),
+            Map.entry('Ŋ', "NG"),
+            Map.entry('ŋ', "ng"),
+            Map.entry('Œ', "OE"),
+            Map.entry('œ', "oe"),
+            Map.entry('Ŧ', "T"),
+            Map.entry('ŧ', "t"),
+            Map.entry('ſ', "s"),
+            Map.entry('Ƒ', "F"),
+            Map.entry('ƒ', "f"),
+            Map.entry('Ǆ', "DZ"),
+            Map.entry('ǅ', "Dz"),
+            Map.entry('ǆ', "dz"),
+            Map.entry('Ǉ', "LJ"),
+            Map.entry('ǈ', "Lj"),
+            Map.entry('ǉ', "lj"),
+            Map.entry('Ǌ', "NJ"),
+            Map.entry('ǋ', "Nj"),
+            Map.entry('ǌ', "nj"),
+            Map.entry('Ǳ', "DZ"),
+            Map.entry('ǲ', "Dz"),
+            Map.entry('ǳ', "dz"),
+            Map.entry('Ǽ', "AE"),
+            Map.entry('ǽ', "ae"),
+            Map.entry('Ǿ', "O"),
+            Map.entry('ǿ', "o"));
 
     /**
      * Pattern that matches any character that is not an alphabetic character (a-z
@@ -106,6 +155,16 @@ public class AttributeUtilities {
      * @return A new string with all diacritical marks removed
      */
     public static String normalizeDiacritics(String value) {
-        return DIACRITICS.matcher(Normalizer.normalize(value.trim(), Normalizer.Form.NFD)).replaceAll("");
+        String trimmedValue = value.trim();
+        StringBuilder transliteratedValue = new StringBuilder(trimmedValue.length());
+
+        for (int index = 0; index < trimmedValue.length(); index++) {
+            char character = trimmedValue.charAt(index);
+            transliteratedValue.append(LATIN_EXTENDED_TRANSLITERATION_MAP.getOrDefault(character,
+                    String.valueOf(character)));
+        }
+
+        return DIACRITICS.matcher(Normalizer.normalize(transliteratedValue.toString(), Normalizer.Form.NFD))
+                .replaceAll("");
     }
 }

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
@@ -60,6 +60,23 @@ class FirstNameAttributeTest {
     }
 
     @Test
+    void normalize_ShouldTransliterateLatinExtendedNames() {
+        assertEquals("Lukasz", firstNameAttribute.normalize("Łukasz"));
+        assertEquals("Soren", firstNameAttribute.normalize("Søren"));
+        assertEquals("AEgir", firstNameAttribute.normalize("Ægir"));
+    }
+
+    @Test
+    void validate_ShouldAcceptLatinExtendedNames() {
+        assertTrue(firstNameAttribute.validate("Łukasz"));
+        assertTrue(firstNameAttribute.validate(firstNameAttribute.normalize("Łukasz")));
+        assertTrue(firstNameAttribute.validate("Søren"));
+        assertTrue(firstNameAttribute.validate(firstNameAttribute.normalize("Søren")));
+        assertTrue(firstNameAttribute.validate("Ægir"));
+        assertTrue(firstNameAttribute.validate(firstNameAttribute.normalize("Ægir")));
+    }
+
+    @Test
     void validate_ShouldReturnTrueForAnyNonEmptyString() {
         assertTrue(firstNameAttribute.validate("John"));
         assertTrue(firstNameAttribute.validate("Jane Doe"));

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/LastNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/LastNameAttributeTest.java
@@ -59,6 +59,23 @@ class LastNameAttributeTest {
     }
 
     @Test
+    void normalize_ShouldTransliterateLatinExtendedLastNames() {
+        assertEquals("Ost", lastNameAttribute.normalize("Øst"));
+        assertEquals("Do", lastNameAttribute.normalize("Đỗ"));
+        assertEquals("OEberg", lastNameAttribute.normalize("Œberg"));
+    }
+
+    @Test
+    void validate_ShouldAcceptLatinExtendedLastNames() {
+        assertTrue(lastNameAttribute.validate("Øst"));
+        assertTrue(lastNameAttribute.validate(lastNameAttribute.normalize("Øst")));
+        assertTrue(lastNameAttribute.validate("Đỗ"));
+        assertTrue(lastNameAttribute.validate(lastNameAttribute.normalize("Đỗ")));
+        assertTrue(lastNameAttribute.validate("Œberg"));
+        assertTrue(lastNameAttribute.validate(lastNameAttribute.normalize("Œberg")));
+    }
+
+    @Test
     void validate_ShouldReturnTrueForValidLastNames_Part1() {
         // Names with 3+ characters
         assertTrue(lastNameAttribute.validate("Doe"), "3+ character last name should be allowed");

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/utilities/AttributeUtilitiesTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/utilities/AttributeUtilitiesTest.java
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.attributes.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+class AttributeUtilitiesTest {
+
+    @Test
+    void normalizeDiacritics_ShouldTransliterateLatinExtendedCharacters() {
+        String[][] cases = {
+                { "Æ", "AE" },
+                { "æ", "ae" },
+                { "Ð", "D" },
+                { "ð", "d" },
+                { "Ø", "O" },
+                { "ø", "o" },
+                { "Þ", "TH" },
+                { "þ", "th" },
+                { "ß", "ss" },
+                { "ẞ", "SS" },
+                { "Đ", "D" },
+                { "đ", "d" },
+                { "Ħ", "H" },
+                { "ħ", "h" },
+                { "ı", "i" },
+                { "Ĳ", "IJ" },
+                { "ĳ", "ij" },
+                { "Ŀ", "L" },
+                { "ŀ", "l" },
+                { "Ł", "L" },
+                { "ł", "l" },
+                { "ŉ", "n" },
+                { "Ŋ", "NG" },
+                { "ŋ", "ng" },
+                { "Œ", "OE" },
+                { "œ", "oe" },
+                { "Ŧ", "T" },
+                { "ŧ", "t" },
+                { "ſ", "s" },
+                { "Ƒ", "F" },
+                { "ƒ", "f" },
+                { "Ǆ", "DZ" },
+                { "ǅ", "Dz" },
+                { "ǆ", "dz" },
+                { "Ǉ", "LJ" },
+                { "ǈ", "Lj" },
+                { "ǉ", "lj" },
+                { "Ǌ", "NJ" },
+                { "ǋ", "Nj" },
+                { "ǌ", "nj" },
+                { "Ǳ", "DZ" },
+                { "ǲ", "Dz" },
+                { "ǳ", "dz" },
+                { "Ǽ", "AE" },
+                { "ǽ", "ae" },
+                { "Ǿ", "O" },
+                { "ǿ", "o" }
+        };
+
+        for (String[] testCase : cases) {
+            assertEquals(testCase[1], AttributeUtilities.normalizeDiacritics(testCase[0]), testCase[0]);
+        }
+    }
+
+    @Test
+    void normalizeDiacritics_ShouldHandleRealNameExamples() {
+        String[][] cases = {
+                { "Łukasz", "Lukasz" },
+                { "Søren Kierkegård", "Soren Kierkegard" },
+                { "Ægir Þór", "AEgir THor" },
+                { "Đỗ", "Do" },
+                { "Dvořák⃝", "Dvorak" }
+        };
+
+        for (String[] testCase : cases) {
+            assertEquals(testCase[1], AttributeUtilities.normalizeDiacritics(testCase[0]), testCase[0]);
+        }
+    }
+}

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/utilities/attribute_utilities.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/utilities/attribute_utilities.py
@@ -2,7 +2,7 @@
 
 import re
 import unicodedata
-from typing import Set
+from typing import Dict, Set
 
 
 class AttributeUtilities:
@@ -25,6 +25,58 @@ class AttributeUtilities:
     # "\r\n" -> carriage return + newline
     # "   " -> multiple spaces
     WHITESPACE_PATTERN = re.compile(r"\s+")
+
+    # Characters from Latin-1 Supplement and Latin Extended blocks that do not
+    # decompose to ASCII-compatible forms with NFD alone.
+    LATIN_EXTENDED_TRANSLITERATION_MAP: Dict[str, str] = {
+        "Æ": "AE",
+        "æ": "ae",
+        "Ð": "D",
+        "ð": "d",
+        "Ø": "O",
+        "ø": "o",
+        "Þ": "TH",
+        "þ": "th",
+        "ß": "ss",
+        "ẞ": "SS",
+        "Đ": "D",
+        "đ": "d",
+        "Ħ": "H",
+        "ħ": "h",
+        "ı": "i",
+        "Ĳ": "IJ",
+        "ĳ": "ij",
+        "Ŀ": "L",
+        "ŀ": "l",
+        "Ł": "L",
+        "ł": "l",
+        "ŉ": "n",
+        "Ŋ": "NG",
+        "ŋ": "ng",
+        "Œ": "OE",
+        "œ": "oe",
+        "Ŧ": "T",
+        "ŧ": "t",
+        "ſ": "s",
+        "Ƒ": "F",
+        "ƒ": "f",
+        "Ǆ": "DZ",
+        "ǅ": "Dz",
+        "ǆ": "dz",
+        "Ǉ": "LJ",
+        "ǈ": "Lj",
+        "ǉ": "lj",
+        "Ǌ": "NJ",
+        "ǋ": "Nj",
+        "ǌ": "nj",
+        "Ǳ": "DZ",
+        "ǲ": "Dz",
+        "ǳ": "dz",
+        "Ǽ": "AE",
+        "ǽ": "ae",
+        "Ǿ": "O",
+        "ǿ": "o",
+    }
 
     # Pattern that matches generational suffixes at the end of a string.
     # Matches case-insensitive suffixes after a whitespace character.
@@ -104,10 +156,14 @@ class AttributeUtilities:
             raise AttributeError("Value cannot be None")
 
         trimmed_value = value.strip()
+        transliterated_value = "".join(
+            AttributeUtilities.LATIN_EXTENDED_TRANSLITERATION_MAP.get(character, character)
+            for character in trimmed_value
+        )
 
         # Normalize to NFD (decomposed form) and filter out combining characters
-        normalized = unicodedata.normalize("NFD", trimmed_value)
-        return "".join(c for c in normalized if unicodedata.category(c) != "Mn")
+        normalized = unicodedata.normalize("NFD", transliterated_value)
+        return "".join(character for character in normalized if not unicodedata.category(character).startswith("M"))
 
     @staticmethod
     def remove_whitespace(value: str) -> str:

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
@@ -42,6 +42,24 @@ class TestFirstNameAttribute:
         assert self.first_name_attribute.normalize(name3) == "Francois"
         assert self.first_name_attribute.normalize(name4) == "Renee"
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("Łukasz", "Lukasz"),
+            ("Søren", "Soren"),
+            ("Ægir", "AEgir"),
+        ],
+    )
+    def test_normalize_should_transliterate_latin_extended_names(self, value, expected):
+        """Test normalization of first names that rely on Latin Extended transliteration."""
+        assert self.first_name_attribute.normalize(value) == expected
+
+    @pytest.mark.parametrize("value", ["Łukasz", "Søren", "Ægir"])
+    def test_validate_should_accept_latin_extended_names(self, value):
+        """Test validation acceptance for first names that rely on Latin Extended transliteration."""
+        assert self.first_name_attribute.validate(value) is True
+        assert self.first_name_attribute.validate(self.first_name_attribute.normalize(value)) is True
+
     def test_validate_should_return_true_for_any_non_empty_string(self):
         """Test validation for non-empty strings."""
         assert self.first_name_attribute.validate("John") is True

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/last_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/last_name_attribute_test.py
@@ -42,6 +42,24 @@ class TestLastNameAttribute:
         assert self.last_name_attribute.normalize(name3) == "Hernandez"
         assert self.last_name_attribute.normalize(name4) == "Mader"
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("Øst", "Ost"),
+            ("Đỗ", "Do"),
+            ("Œberg", "OEberg"),
+        ],
+    )
+    def test_normalize_should_transliterate_latin_extended_last_names(self, value, expected):
+        """Test normalization of last names that rely on Latin Extended transliteration."""
+        assert self.last_name_attribute.normalize(value) == expected
+
+    @pytest.mark.parametrize("value", ["Øst", "Đỗ", "Œberg"])
+    def test_validate_should_accept_latin_extended_last_names(self, value):
+        """Test validation acceptance for last names that rely on Latin Extended transliteration."""
+        assert self.last_name_attribute.validate(value) is True
+        assert self.last_name_attribute.validate(self.last_name_attribute.normalize(value)) is True
+
     def test_validate_should_return_true_for_valid_last_names_part1(self):
         """Test validation for valid last names (part 1)."""
         # Names with 3+ characters

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/utilities/attribute_utilities_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/utilities/attribute_utilities_test.py
@@ -10,6 +10,76 @@ from openlinktoken.attributes.utilities.attribute_utilities import AttributeUtil
 class TestAttributeUtilities:
     """Test cases for AttributeUtilities."""
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("Æ", "AE"),
+            ("æ", "ae"),
+            ("Ð", "D"),
+            ("ð", "d"),
+            ("Ø", "O"),
+            ("ø", "o"),
+            ("Þ", "TH"),
+            ("þ", "th"),
+            ("ß", "ss"),
+            ("ẞ", "SS"),
+            ("Đ", "D"),
+            ("đ", "d"),
+            ("Ħ", "H"),
+            ("ħ", "h"),
+            ("ı", "i"),
+            ("Ĳ", "IJ"),
+            ("ĳ", "ij"),
+            ("Ŀ", "L"),
+            ("ŀ", "l"),
+            ("Ł", "L"),
+            ("ł", "l"),
+            ("ŉ", "n"),
+            ("Ŋ", "NG"),
+            ("ŋ", "ng"),
+            ("Œ", "OE"),
+            ("œ", "oe"),
+            ("Ŧ", "T"),
+            ("ŧ", "t"),
+            ("ſ", "s"),
+            ("Ƒ", "F"),
+            ("ƒ", "f"),
+            ("Ǆ", "DZ"),
+            ("ǅ", "Dz"),
+            ("ǆ", "dz"),
+            ("Ǉ", "LJ"),
+            ("ǈ", "Lj"),
+            ("ǉ", "lj"),
+            ("Ǌ", "NJ"),
+            ("ǋ", "Nj"),
+            ("ǌ", "nj"),
+            ("Ǳ", "DZ"),
+            ("ǲ", "Dz"),
+            ("ǳ", "dz"),
+            ("Ǽ", "AE"),
+            ("ǽ", "ae"),
+            ("Ǿ", "O"),
+            ("ǿ", "o"),
+        ],
+    )
+    def test_normalize_diacritics_transliterates_latin_extended_characters(self, value, expected):
+        """normalize_diacritics should transliterate Latin Extended characters before NFD."""
+        assert AttributeUtilities.normalize_diacritics(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("Łukasz", "Lukasz"),
+            ("Søren Kierkegård", "Soren Kierkegard"),
+            ("Ægir Þór", "AEgir THor"),
+            ("Đỗ", "Do"),
+            ("Dvo\u0159\u00e1k\u20dd", "Dvorak"),
+        ],
+    )
+    def test_normalize_diacritics_handles_real_name_examples(self, value, expected):
+        """normalize_diacritics should preserve ASCII equivalents in representative names."""
+        assert AttributeUtilities.normalize_diacritics(value) == expected
+
     def test_cannot_instantiate(self):
         """AttributeUtilities is a utility class and should not be instantiatable."""
         with pytest.raises(RuntimeError):

--- a/pages/concepts/matching-model.md
+++ b/pages/concepts/matching-model.md
@@ -22,7 +22,8 @@ The matching model generates cryptographically secure tokens from personal ident
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Normalization                                │
 │  - Remove titles/suffixes                                       │
-│  - Strip diacritics                                             │
+│  - Remove diacritics and transliterate supported Latin Extended │
+│    letters to ASCII                                             │
 │  - Standardize formats                                          │
 └───────────────────────┬─────────────────────────────────────────┘
                         │
@@ -220,6 +221,7 @@ Open Link Token normalizes each field before token generation. For full rules, s
 
 - **María → MARIA**: Diacritic removed, uppercased
 - **García Jr. → GARCIA**: Suffix removed, diacritic removed, uppercased
+- **Łukasz / Søren / Øst / Œberg** style inputs normalize to ASCII forms such as `LUKASZ`, `SOREN`, `OST`, and `OEBERG`
 - **tom → TOM**: Uppercased
 - **03/22/1988 → 1988-03-22**: Date reformatted to ISO 8601
 - **30301-4455 → 30301**: ZIP+4 truncated to 5 digits
@@ -293,7 +295,7 @@ When comparing hash-only (or decrypted) token values across the two systems:
 
 ### Key Takeaways
 
-1. **Normalization is critical.** Two records with superficially different inputs (accents, suffixes, date formats) can match perfectly after normalization.
+1. **Normalization is critical.** Two records with superficially different inputs (accents, supported Latin Extended letters, suffixes, date formats) can match perfectly after normalization.
 2. **Missing attributes reduce matching opportunities.** CLN-202 couldn't generate T4 because SSN was missing.
 3. **Name variations may prevent matches.** "Tom" vs "Thomas" is a common real-world issue; T5's 3-character prefix helps only if the first 3 letters are identical.
 4. **Multiple rules provide fallback.** Even if T4 can't be generated (SSN missing), other rules may still match if other attributes align.

--- a/pages/concepts/normalization-and-validation.md
+++ b/pages/concepts/normalization-and-validation.md
@@ -32,7 +32,7 @@ Input → Normalize → Validate → Token Generation
 
 1. Trim leading/trailing whitespace
 2. Convert to uppercase
-3. Remove diacritics (é → E, ñ → N)
+3. Remove diacritics and transliterate supported Latin Extended letters to ASCII (é → E, Ł → L, Æ → AE)
 4. Remove titles: Dr, Mr, Mrs, Ms, Miss, Prof
 5. Remove suffixes: Jr, Sr, II, III, IV, PhD, MD
 6. Remove non-alphabetic characters (spaces, apostrophes, hyphens, periods)
@@ -43,8 +43,13 @@ Input → Normalize → Validate → Token Generation
 | -------------- | ---------- |
 | `"  John  "`   | `"JOHN"`   |
 | `"María"`      | `"MARIA"`  |
+| `"Łukasz"`     | `"LUKASZ"` |
+| `"Søren"`      | `"SOREN"`  |
+| `"Ægir"`       | `"AEGIR"`  |
+| `"Øst"`        | `"OST"`    |
 | `"Dr. Smith"`  | `"SMITH"`  |
 | `"O'Brien"`    | `"OBRIEN"` |
+| `"Œberg"`      | `"OEBERG"` |
 | `"García Jr."` | `"GARCIA"` |
 
 **Validation:**

--- a/pages/matching-concepts/index.md
+++ b/pages/matching-concepts/index.md
@@ -155,16 +155,18 @@ Decrypted tokens show the HMAC-SHA256 hash (base64 encoded) before AES encryptio
 
 All tokens use normalized attributes. See [Security](../security.md) for detailed rules.
 
+For names, normalization removes diacritics and transliterates supported Latin Extended letters to ASCII before later token-building steps.
+
 ### Quick Reference
 
-| Attribute  | Normalization                                           | Example                                               |
-| ---------- | ------------------------------------------------------- | ----------------------------------------------------- |
-| FirstName  | Uppercase, remove titles/suffixes, normalize diacritics | "José María" → "JOSE MARIA"                           |
-| LastName   | Uppercase, remove suffixes, normalize diacritics        | "O'Brien" → "OBRIEN"                                  |
-| Sex        | Standardized to "Male" or "Female"                      | "M", "m", "Male" → "MALE"                             |
-| BirthDate  | YYYY-MM-DD format                                       | "01/15/1980", "1980-01-15" → "1980-01-15"             |
-| PostalCode | Uppercase, dash removed for US; space for Canadian      | "98004", "98004-1234" → "98004", "K1A 1A1" → "K1A1A1" |
-| SSN        | 9-digit numeric                                         | "123-45-6789" → digits-only string                    |
+| Attribute  | Normalization                                                                                                 | Example                                               |
+| ---------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| FirstName  | Uppercase, remove titles/suffixes, remove diacritics, transliterate supported Latin Extended letters to ASCII | "Ægir" → "AEGIR"                                      |
+| LastName   | Uppercase, remove suffixes, remove diacritics, transliterate supported Latin Extended letters to ASCII        | "Œberg" → "OEBERG"                                    |
+| Sex        | Standardized to "Male" or "Female"                                                                            | "M", "m", "Male" → "MALE"                             |
+| BirthDate  | YYYY-MM-DD format                                                                                             | "01/15/1980", "1980-01-15" → "1980-01-15"             |
+| PostalCode | Uppercase, dash removed for US; space for Canadian                                                            | "98004", "98004-1234" → "98004", "K1A 1A1" → "K1A1A1" |
+| SSN        | 9-digit numeric                                                                                               | "123-45-6789" → digits-only string                    |
 
 ## Collision Resistance
 

--- a/pages/overview/index.md
+++ b/pages/overview/index.md
@@ -33,7 +33,7 @@ Matching is performed on deterministic hash-only values (or decrypted token payl
 ## How It Works
 
 1. **Input**: Person records with attributes (name, birthdate, SSN, postal code, sex)
-2. **Validation & Normalization**: Attributes are validated and normalized (uppercase, diacritic removal, title stripping)
+2. **Validation & Normalization**: Attributes are validated and normalized (uppercase, diacritic removal, supported Latin Extended transliteration, title stripping)
 3. **Token Generation**: Multiple token rules (T1–T5) combine different attributes
 4. **Transformation**: Deterministic HMAC-SHA256 hashes are produced; encrypted mode wraps them as `olt.V1` JWE match tokens
 5. **Output**: Encrypted `olt.V1` tokens (default) or hash-only values, plus metadata
@@ -56,7 +56,7 @@ Open Link Token uses **5 distinct token rules (T1–T5)** that define which attr
 
 Before tokens are generated, attributes are validated against practical, PII-focused rules:
 
-- **FirstName/LastName**: No placeholders, proper length, diacritics normalized
+- **FirstName/LastName**: No placeholders, proper length, diacritics removed, supported Latin Extended letters transliterated to ASCII
 - **BirthDate**: 1910–today, valid format (YYYY-MM-DD)
 - **SSN**: Valid US social security number (area, group, serial checks)
 - **PostalCode**: Valid US ZIP or Canadian postal code

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -68,14 +68,14 @@ Open Link Token is designed for **streaming-style** processing: it reads records
 
 All of the following must be provided per record:
 
-| Attribute      | Type   | Constraints                                  | Examples                                      | Normalization                                  |
-| -------------- | ------ | -------------------------------------------- | --------------------------------------------- | ---------------------------------------------- |
-| **FirstName**  | String | Non-empty after normalization                | "John", "José", "JoAnn"                       | Remove titles, suffixes, diacritics; uppercase |
-| **LastName**   | String | Non-empty after normalization                | "Smith", "O'Brien", "García"                  | Remove suffixes, diacritics; uppercase         |
-| **BirthDate**  | Date   | 1910-01-01 to today                          | "1980-01-15", "01/15/1980", "15.01.1980"      | ISO 8601 YYYY-MM-DD                            |
-| **Sex**        | String | "Male" or "Female" (case-insensitive)        | "M", "F", "male", "FEMALE"                    | Uppercase; normalize M→MALE, F→FEMALE          |
-| **PostalCode** | String | Valid US ZIP or Canadian postal code         | "98004", "K1A 1A1", "98004-1234"              | Remove dashes; pad ZIP to 5 digits             |
-| **SSN**        | String | 9 numeric digits (US Social Security Number) | "123-45-6789" (digits-only inputs normalized) | Remove dashes                                  |
+| Attribute      | Type   | Constraints                                  | Examples                                      | Normalization                                                                                                    |
+| -------------- | ------ | -------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **FirstName**  | String | Non-empty after normalization                | "John", "José", "JoAnn"                       | Remove titles/suffixes; remove diacritics and transliterate supported Latin Extended letters to ASCII; uppercase |
+| **LastName**   | String | Non-empty after normalization                | "Smith", "O'Brien", "García"                  | Remove suffixes; remove diacritics and transliterate supported Latin Extended letters to ASCII; uppercase        |
+| **BirthDate**  | Date   | 1910-01-01 to today                          | "1980-01-15", "01/15/1980", "15.01.1980"      | ISO 8601 YYYY-MM-DD                                                                                              |
+| **Sex**        | String | "Male" or "Female" (case-insensitive)        | "M", "F", "male", "FEMALE"                    | Uppercase; normalize M→MALE, F→FEMALE                                                                            |
+| **PostalCode** | String | Valid US ZIP or Canadian postal code         | "98004", "K1A 1A1", "98004-1234"              | Remove dashes; pad ZIP to 5 digits                                                                               |
+| **SSN**        | String | 9 numeric digits (US Social Security Number) | "123-45-6789" (digits-only inputs normalized) | Remove dashes                                                                                                    |
 
 ### Optional Attributes
 
@@ -85,7 +85,7 @@ All of the following must be provided per record:
 
 Attributes are validated **after normalization**. See [Concepts: Normalization and Validation](concepts/normalization-and-validation.md) for detailed rules:
 
-- **FirstName/LastName**: At least one alphabetic character after diacritic removal
+- **FirstName/LastName**: At least one alphabetic character after diacritic removal and supported Latin Extended transliteration
 - **BirthDate**: Valid date within allowed range
 - **Sex**: Exactly "MALE" or "FEMALE" after normalization
 - **PostalCode**: Valid US ZIP-5 or Canadian postal code format
@@ -107,7 +107,7 @@ If any attribute fails validation, the record is marked invalid in metadata, and
 
 Each attribute is normalized according to its type:
 
-- **Names** (FirstName, LastName): Remove titles/suffixes, diacritics, extra whitespace; uppercase
+- **Names** (FirstName, LastName): Remove titles/suffixes, remove diacritics and transliterate supported Latin Extended letters to ASCII, then uppercase
 - **BirthDate**: Parse input format (multiple formats supported) → ISO 8601 YYYY-MM-DD
 - **Sex**: Parse variants (M/male/Male → MALE; F/female/Female → FEMALE)
 - **PostalCode**: Remove dashes, zero-pad ZIP codes to 5 digits, uppercase Canadian postal codes


### PR DESCRIPTION
## Summary

- add Latin Extended transliteration for first- and last-name normalization in Java and Python
- add regression coverage plus cross-language parity documentation for the new normalization behavior
- include the existing branch changes to APM setup and `.gitignore` cleanup

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [x] Java
- [x] Python
- [ ] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- added a transliteration pre-step for supported Latin Extended characters before ASCII-only filtering in both implementations
- added full utility-map tests and first/last-name normalize+validate regression tests, and updated public + durable docs to describe the behavior
- updated the branch's existing devcontainer/APM setup script and `.gitignore` cleanup as part of the current branch diff
