### PR TITLE
feat: expose FileExtension enum (CSV/Parquet/ZIP) to extensions

### DIFF
--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/__init__.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/__init__.py
@@ -2,6 +2,7 @@
 I/O subpackage for the Open Link Token CLI project.
 """
 
+from openlinktoken_cli.io.file_extension import FileExtension
 from openlinktoken_cli.io.metadata_writer import MetadataWriter
 from openlinktoken_cli.io.person_attributes_reader import PersonAttributesReader
 from openlinktoken_cli.io.person_attributes_writer import PersonAttributesWriter

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/file_extension.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/file_extension.py
@@ -1,0 +1,13 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+from enum import Enum
+
+
+class FileExtension(str, Enum):
+    """Canonical file extensions supported by the Open Link Token CLI."""
+
+    CSV = ".csv"
+    PARQUET = ".parquet"
+    ZIP = ".zip"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/file_extension_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/file_extension_test.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+from openlinktoken_cli.io import FileExtension
+from openlinktoken_cli.io.file_extension import FileExtension as FileExtensionDirect
+
+
+class TestFileExtension:
+    def test_csv_value(self):
+        assert FileExtension.CSV == ".csv"
+
+    def test_parquet_value(self):
+        assert FileExtension.PARQUET == ".parquet"
+
+    def test_zip_value(self):
+        assert FileExtension.ZIP == ".zip"
+
+    def test_is_str(self):
+        for member in FileExtension:
+            assert isinstance(member, str)
+
+    def test_all_members_present(self):
+        members = {e.name for e in FileExtension}
+        assert members == {"CSV", "PARQUET", "ZIP"}
+
+    def test_importable_from_io_package(self):
+        assert FileExtension is FileExtensionDirect
+
+    def test_string_comparison(self):
+        assert FileExtension.CSV == ".csv"
+        assert ".parquet" == FileExtension.PARQUET
+
+    def test_use_in_set(self):
+        extensions = {FileExtension.CSV, FileExtension.PARQUET, FileExtension.ZIP}
+        assert ".csv" in extensions


### PR DESCRIPTION
## Summary

- Adds `FileExtension(str, Enum)` to `openlinktoken_cli.io` with `CSV`, `PARQUET`, and `ZIP` members.
- Exports it from the public `openlinktoken_cli.io` package so extensions can import a canonical set of supported file extensions instead of duplicating their own.

## Related issues

- Fixes #332

## What changed

- New `file_extension.py` — defines `FileExtension(str, Enum)` with `CSV = ".csv"`, `PARQUET = ".parquet"`, `ZIP = ".zip"`.
- `openlinktoken_cli/io/__init__.py` — exports `FileExtension` so consumers can do `from openlinktoken_cli.io import FileExtension`.
- New `file_extension_test.py` with 8 tests covering values, `str` subclass behaviour, membership, and package-level importability.