### PR TITLE
feat(cli): expose FileExtension enum from openlinktoken_cli.io

### DIFF
--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/__init__.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/__init__.py
@@ -2,8 +2,18 @@
 I/O subpackage for the Open Link Token CLI project.
 """
 
+from openlinktoken_cli.io.file_extension import FileExtension
 from openlinktoken_cli.io.metadata_writer import MetadataWriter
 from openlinktoken_cli.io.person_attributes_reader import PersonAttributesReader
 from openlinktoken_cli.io.person_attributes_writer import PersonAttributesWriter
 from openlinktoken_cli.io.token_reader import TokenReader
 from openlinktoken_cli.io.token_writer import TokenWriter
+
+__all__ = [
+    "FileExtension",
+    "MetadataWriter",
+    "PersonAttributesReader",
+    "PersonAttributesWriter",
+    "TokenReader",
+    "TokenWriter",
+]

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/file_extension.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/file_extension.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+
+from enum import Enum
+
+
+class FileExtension(str, Enum):
+    """Canonical file extensions supported by the Open Link Token CLI."""
+
+    CSV = ".csv"
+    PARQUET = ".parquet"
+    ZIP = ".zip"

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/file_type_detector.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/file_type_detector.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from openlinktoken_cli.io.file_extension import FileExtension
+
 
 class FileTypeDetector:
     """Detects file types based on file extensions."""
@@ -13,9 +15,9 @@ class FileTypeDetector:
     def detect_input_type(path: str) -> str:
         """Detect input file type from extension. Supports: csv, parquet."""
         suffix = Path(path).suffix.lower()
-        if suffix == ".csv":
+        if suffix == FileExtension.CSV:
             return FileTypeDetector.TYPE_CSV
-        if suffix == ".parquet":
+        if suffix == FileExtension.PARQUET:
             return FileTypeDetector.TYPE_PARQUET
         return ""
 
@@ -23,8 +25,8 @@ class FileTypeDetector:
     def detect_output_type(path: str) -> str:
         """Detect output file type from extension. Supports: csv, parquet."""
         suffix = Path(path).suffix.lower()
-        if suffix == ".csv":
+        if suffix == FileExtension.CSV:
             return FileTypeDetector.TYPE_CSV
-        if suffix == ".parquet":
+        if suffix == FileExtension.PARQUET:
             return FileTypeDetector.TYPE_PARQUET
         return ""

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/file_extension_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/file_extension_test.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+
+from openlinktoken_cli.io import FileExtension
+from openlinktoken_cli.io.file_extension import FileExtension as FileExtensionDirect
+
+
+def test_file_extension_values():
+    assert FileExtension.CSV == ".csv"
+    assert FileExtension.PARQUET == ".parquet"
+    assert FileExtension.ZIP == ".zip"
+
+
+def test_file_extension_is_str():
+    assert isinstance(FileExtension.CSV, str)
+    assert isinstance(FileExtension.PARQUET, str)
+    assert isinstance(FileExtension.ZIP, str)
+
+
+def test_file_extension_importable_from_io_package():
+    assert FileExtension is FileExtensionDirect
+
+
+def test_file_extension_all_members():
+    members = {e.value for e in FileExtension}
+    assert members == {".csv", ".parquet", ".zip"}


### PR DESCRIPTION
## Summary

- Adds a `FileExtension(str, Enum)` with `CSV`, `PARQUET`, and `ZIP` values to `openlinktoken_cli/io/file_extension.py` and exports it from the `openlinktoken_cli.io` public package.
- Gives extensions a canonical source of truth for supported file formats instead of defining their own local constants.

## Related issues

- Closes #332

## What changed

- New `FileExtension(str, Enum)` in `openlinktoken_cli/io/file_extension.py` — `CSV = ".csv"`, `PARQUET = ".parquet"`, `ZIP = ".zip"`.
- `FileExtension` exported from `openlinktoken_cli/io/__init__.py`; extensions import via `from openlinktoken_cli.io import FileExtension`.
- `FileTypeDetector` updated to use `FileExtension` values for its internal suffix comparisons instead of hardcoded string literals. Return types are unchanged (`str`) — no breaking changes.
- Tests added at `src/test/openlinktoken_cli/io/file_extension_test.py`.