### PR TITLE
fix: show CLI banner only for help flows

### DIFF
--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/open_link_token_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/open_link_token_command.py
@@ -137,12 +137,14 @@ class OpenLinkTokenCommand:
         """Main entry point for the command-line application."""
         configure_default_logging()
         parser = OpenLinkTokenCommand.create_parser()
+        raw_args = list(sys.argv[1:] if args is None else args)
 
-        # Show banner for interactive runs.
-        OpenLinkTokenCommand.show_banner()
+        # Show banner only for help-oriented entry points and bare invocation.
+        if OpenLinkTokenCommand._should_show_banner(raw_args):
+            OpenLinkTokenCommand.show_banner()
 
         try:
-            parsed_args = parser.parse_args(args)
+            parsed_args = parser.parse_args(raw_args)
         except SystemExit as error:
             return error.code if isinstance(error.code, int) else 1
 
@@ -198,6 +200,11 @@ class OpenLinkTokenCommand:
             if arg in ("--help", "help"):
                 return True
         return False
+
+    @staticmethod
+    def _should_show_banner(args):
+        """Return whether the current argv should display the CLI banner."""
+        return not args or OpenLinkTokenCommand._is_help_request(args)
 
     @staticmethod
     def _should_start_version_check(parsed_args: argparse.Namespace) -> bool:

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -681,6 +681,41 @@ class TestOpenLinkTokenCommand:
         assert "Privacy-Preserving Record Linkage v" in captured.out
         assert "usage: olt" in captured.out
 
+    def test_bare_invocation_shows_banner_for_interactive_runs(self, monkeypatch, capsys):
+        """Interactive top-level invocation should include the banner before help output."""
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        with patch("openlinktoken_cli.commands.open_link_token_command.start_version_check") as mock_version_check:
+            exit_code = OpenLinkTokenCommand.execute([])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0, "Bare invocation should exit successfully"
+        assert "Privacy-Preserving Record Linkage v" in captured.out
+        assert "usage: olt" in captured.out
+        mock_version_check.return_value.wait_and_notify.assert_called_once()
+
+    def test_help_subcommand_shows_banner_for_interactive_runs(self, monkeypatch, capsys):
+        """Interactive help subcommand output should include the Open Link Token banner."""
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        exit_code = OpenLinkTokenCommand.execute(["help"])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0, "Help subcommand should exit successfully"
+        assert "Privacy-Preserving Record Linkage v" in captured.out
+        assert "usage: olt" in captured.out
+
+    def test_version_does_not_show_banner_for_interactive_runs(self, monkeypatch, capsys):
+        """Interactive non-help output should not include the Open Link Token banner."""
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+
+        exit_code = OpenLinkTokenCommand.execute(["--version"])
+
+        captured = capsys.readouterr()
+        assert exit_code == 0, "Version output should exit successfully"
+        assert "Open Link Token" in captured.out
+        assert "Privacy-Preserving Record Linkage v" not in captured.out
+
     # ===== Hash Record IDs Tests =====
 
     def test_tokenize_command_hash_record_ids_output_contains_hashed_ids(self, temp_dir):


### PR DESCRIPTION
## Summary

- restrict the Python CLI banner to explicit help flows and bare `olt`
- keep ordinary non-help output, including `--version`, free of the banner
- add regression coverage for bare invocation, `help`, and non-help version output

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [ ] PySpark
- [ ] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- gate banner rendering in `OpenLinkTokenCommand` behind a small argv-aware helper
- preserve existing interactive and `NO_COLOR` behavior while changing when the banner appears
- add focused entry-point tests covering the approved banner contract
