### PR TITLE
feat(package): include exchange config in zip output

### DIFF
--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import contextlib
 import logging
 import sys
 import tempfile
@@ -132,34 +133,34 @@ class EncryptCommand:
                                 "Ensure the exchange config was loaded from a file (exchange.path must not be None)."
                             )
                         logger.info("ZIP output: encrypted tokens and exchange config will be bundled")
-                        zip_path = Path(args.output_path)
-                        with tempfile.TemporaryDirectory() as temp_dir:
-                            temp_token_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
-                            summary = EncryptCommand._encrypt_tokens(
-                                args.input_path,
-                                temp_token_path,
-                                input_type,
-                                input_type,
-                                encryption_key,
-                                ring_id,
-                                progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
-                            )
-                            zip_path.parent.mkdir(parents=True, exist_ok=True)
-                            with zipfile.ZipFile(
-                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
-                            ) as archive:
-                                archive.write(temp_token_path, arcname=Path(temp_token_path).name)
-                                archive.write(exchange.path, arcname=Path(exchange.path).name)
-                    else:
+
+                    with contextlib.ExitStack() as stack:
+                        if output_type == FileTypeDetector.TYPE_ZIP:
+                            temp_dir = stack.enter_context(tempfile.TemporaryDirectory())
+                            zip_path = Path(args.output_path)
+                            token_output_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
+                            token_output_type = input_type
+                        else:
+                            token_output_path = args.output_path
+                            token_output_type = output_type
+
                         summary = EncryptCommand._encrypt_tokens(
                             args.input_path,
-                            args.output_path,
+                            token_output_path,
                             input_type,
-                            output_type,
+                            token_output_type,
                             encryption_key,
                             ring_id,
                             progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
                         )
+
+                        if output_type == FileTypeDetector.TYPE_ZIP:
+                            zip_path.parent.mkdir(parents=True, exist_ok=True)
+                            with zipfile.ZipFile(
+                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
+                            ) as archive:
+                                archive.write(token_output_path, arcname=Path(token_output_path).name)
+                                archive.write(exchange.path, arcname=Path(exchange.path).name)
                     logger.info("Token encryption completed successfully")
                 except Exception as error:
                     logger.error("Error during token encryption: %s", error)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -5,7 +5,6 @@ import logging
 import sys
 import tempfile
 import uuid
-import zipfile
 from pathlib import Path
 
 from openlinktoken.tokens.token import Token
@@ -21,6 +20,7 @@ from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_
 from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+from openlinktoken_cli.util.zip_utils import bundle_into_zip
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +157,7 @@ class EncryptCommand:
                         )
 
                         if is_zip:
-                            EncryptCommand._bundle_into_zip(args.output_path, token_output_path, exchange.path)
+                            bundle_into_zip(args.output_path, token_output_path, exchange.path)
                     logger.info("Token encryption completed successfully")
                 except Exception as error:
                     logger.error("Error during token encryption: %s", error)
@@ -169,15 +169,6 @@ class EncryptCommand:
             print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
-
-    @staticmethod
-    def _bundle_into_zip(zip_output_path: str, token_path: str, exchange_config_path: str) -> None:
-        """Bundle encrypted token file and exchange config into a zip archive."""
-        zip_path = Path(zip_output_path)
-        zip_path.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-            archive.write(token_path, arcname=Path(token_path).name)
-            archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
 
     @staticmethod
     def _encrypt_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -126,7 +126,9 @@ class EncryptCommand:
                     logger.info(f"Exchange config: {exchange.path}")
 
                     reporter.update_status("Encrypting tokens")
-                    if output_type == FileTypeDetector.TYPE_ZIP:
+                    is_zip = output_type == FileTypeDetector.TYPE_ZIP
+
+                    if is_zip:
                         if not exchange.path:
                             raise ValueError(
                                 "ZIP output requires an exchange config file path. "
@@ -135,7 +137,7 @@ class EncryptCommand:
                         logger.info("ZIP output: encrypted tokens and exchange config will be bundled")
 
                     with contextlib.ExitStack() as stack:
-                        if output_type == FileTypeDetector.TYPE_ZIP:
+                        if is_zip:
                             temp_dir = stack.enter_context(tempfile.TemporaryDirectory())
                             zip_path = Path(args.output_path)
                             token_output_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
@@ -154,13 +156,8 @@ class EncryptCommand:
                             progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
                         )
 
-                        if output_type == FileTypeDetector.TYPE_ZIP:
-                            zip_path.parent.mkdir(parents=True, exist_ok=True)
-                            with zipfile.ZipFile(
-                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
-                            ) as archive:
-                                archive.write(token_output_path, arcname=Path(token_output_path).name)
-                                archive.write(exchange.path, arcname=Path(exchange.path).name)
+                        if is_zip:
+                            EncryptCommand._bundle_into_zip(args.output_path, token_output_path, exchange.path)
                     logger.info("Token encryption completed successfully")
                 except Exception as error:
                     logger.error("Error during token encryption: %s", error)
@@ -172,6 +169,15 @@ class EncryptCommand:
             print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
+
+    @staticmethod
+    def _bundle_into_zip(zip_output_path: str, token_path: str, exchange_config_path: str) -> None:
+        """Bundle encrypted token file and exchange config into a zip archive."""
+        zip_path = Path(zip_output_path)
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.write(token_path, arcname=Path(token_path).name)
+            archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
 
     @staticmethod
     def _encrypt_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -2,7 +2,10 @@
 
 import logging
 import sys
+import tempfile
 import uuid
+import zipfile
+from pathlib import Path
 
 from openlinktoken.tokens.token import Token
 from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
@@ -122,15 +125,41 @@ class EncryptCommand:
                     logger.info(f"Exchange config: {exchange.path}")
 
                     reporter.update_status("Encrypting tokens")
-                    summary = EncryptCommand._encrypt_tokens(
-                        args.input_path,
-                        args.output_path,
-                        input_type,
-                        output_type,
-                        encryption_key,
-                        ring_id,
-                        progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
-                    )
+                    if output_type == FileTypeDetector.TYPE_ZIP:
+                        if not exchange.path:
+                            raise ValueError(
+                                "ZIP output requires an exchange config file path. "
+                                "Ensure the exchange config was loaded from a file (exchange.path must not be None)."
+                            )
+                        logger.info("ZIP output: encrypted tokens and exchange config will be bundled")
+                        zip_path = Path(args.output_path)
+                        with tempfile.TemporaryDirectory() as temp_dir:
+                            temp_token_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
+                            summary = EncryptCommand._encrypt_tokens(
+                                args.input_path,
+                                temp_token_path,
+                                input_type,
+                                input_type,
+                                encryption_key,
+                                ring_id,
+                                progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
+                            )
+                            zip_path.parent.mkdir(parents=True, exist_ok=True)
+                            with zipfile.ZipFile(
+                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
+                            ) as archive:
+                                archive.write(temp_token_path, arcname=Path(temp_token_path).name)
+                                archive.write(exchange.path, arcname=Path(exchange.path).name)
+                    else:
+                        summary = EncryptCommand._encrypt_tokens(
+                            args.input_path,
+                            args.output_path,
+                            input_type,
+                            output_type,
+                            encryption_key,
+                            ring_id,
+                            progress_callback=reporter.make_progress_callback("Encrypting tokens", "tokens"),
+                        )
                     logger.info("Token encryption completed successfully")
                 except Exception as error:
                     logger.error("Error during token encryption: %s", error)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -5,7 +5,6 @@ import logging
 import sys
 import tempfile
 import uuid
-import zipfile
 from pathlib import Path
 from typing import List
 
@@ -26,6 +25,7 @@ from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_
 from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+from openlinktoken_cli.util.zip_utils import bundle_into_zip
 
 logger = logging.getLogger(__name__)
 
@@ -182,9 +182,7 @@ class PackageCommand:
                         )
 
                         if is_zip:
-                            PackageCommand._bundle_into_zip(
-                                args.output_path, token_output_path, metadata_path, exchange.path
-                            )
+                            bundle_into_zip(args.output_path, token_output_path, metadata_path, exchange.path)
                             metadata_path = None
                     logger.info("Token generation and encryption completed successfully")
                 except Exception as error:
@@ -205,16 +203,6 @@ class PackageCommand:
             print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
-
-    @staticmethod
-    def _bundle_into_zip(zip_output_path: str, token_path: str, metadata_path: str, exchange_config_path: str) -> None:
-        """Bundle token file, metadata, and exchange config into a zip archive."""
-        zip_path = Path(zip_output_path)
-        zip_path.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-            archive.write(token_path, arcname=Path(token_path).name)
-            archive.write(metadata_path, arcname=Path(metadata_path).name)
-            archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
 
     @staticmethod
     def _process_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -149,18 +149,34 @@ class PackageCommand:
 
                     reporter.update_status("Packaging records")
                     if output_type == FileTypeDetector.TYPE_ZIP:
+                        if not exchange.path:
+                            raise ValueError(
+                                "ZIP output requires an exchange config file path. "
+                                "Ensure the exchange config was loaded from a file (exchange.path must not be None)."
+                            )
                         logger.info("ZIP output: tokens, metadata, and exchange config will be bundled")
-                        summary, metadata_path = PackageCommand._process_tokens_to_zip(
-                            args.input_path,
-                            args.output_path,
-                            input_type,
-                            exchange.path,
-                            exchange.hashing_secret,
-                            encryption_key,
-                            ring_id,
-                            hash_record_ids,
-                            progress_callback=reporter.make_progress_callback("Packaging records", "records"),
-                        )
+                        zip_path = Path(args.output_path)
+                        with tempfile.TemporaryDirectory() as temp_dir:
+                            temp_token_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
+                            summary, temp_metadata_path = PackageCommand._process_tokens(
+                                args.input_path,
+                                temp_token_path,
+                                input_type,
+                                input_type,
+                                exchange.hashing_secret,
+                                encryption_key,
+                                ring_id,
+                                hash_record_ids,
+                                progress_callback=reporter.make_progress_callback("Packaging records", "records"),
+                            )
+                            zip_path.parent.mkdir(parents=True, exist_ok=True)
+                            with zipfile.ZipFile(
+                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
+                            ) as archive:
+                                archive.write(temp_token_path, arcname=Path(temp_token_path).name)
+                                archive.write(temp_metadata_path, arcname=Path(temp_metadata_path).name)
+                                archive.write(exchange.path, arcname=Path(exchange.path).name)
+                        metadata_path = None
                     else:
                         summary, metadata_path = PackageCommand._process_tokens(
                             args.input_path,
@@ -192,51 +208,6 @@ class PackageCommand:
             print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
-
-    @staticmethod
-    def _process_tokens_to_zip(
-        input_path: str,
-        zip_output_path: str,
-        input_type: str,
-        exchange_config_path: str | None,
-        hashing_secret: str | bytes,
-        encryption_key: bytes,
-        ring_id: str,
-        hash_record_ids: bool = False,
-        progress_callback=None,
-    ) -> tuple[PersonAttributesProcessingSummary, None]:
-        """Process tokens and bundle the result, metadata, and exchange config into a zip archive."""
-        if exchange_config_path is None:
-            raise ValueError(
-                "ZIP output requires an exchange config file path. "
-                "Ensure the exchange config was loaded from a file (exchange.path must not be None)."
-            )
-        zip_path = Path(zip_output_path)
-        output_stem = zip_path.stem
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_token_path = Path(temp_dir) / f"{output_stem}.{input_type}"
-
-            summary, temp_metadata_path = PackageCommand._process_tokens(
-                input_path,
-                str(temp_token_path),
-                input_type,
-                input_type,
-                hashing_secret,
-                encryption_key,
-                ring_id,
-                hash_record_ids,
-                progress_callback=progress_callback,
-            )
-
-            zip_path.parent.mkdir(parents=True, exist_ok=True)
-
-            with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-                archive.write(temp_token_path, arcname=temp_token_path.name)
-                archive.write(temp_metadata_path, arcname=Path(temp_metadata_path).name)
-                archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
-
-        return summary, None
 
     @staticmethod
     def _process_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -149,7 +149,9 @@ class PackageCommand:
                     logger.info(f"Exchange config: {exchange.path}")
 
                     reporter.update_status("Packaging records")
-                    if output_type == FileTypeDetector.TYPE_ZIP:
+                    is_zip = output_type == FileTypeDetector.TYPE_ZIP
+
+                    if is_zip:
                         if not exchange.path:
                             raise ValueError(
                                 "ZIP output requires an exchange config file path. "
@@ -158,7 +160,7 @@ class PackageCommand:
                         logger.info("ZIP output: tokens, metadata, and exchange config will be bundled")
 
                     with contextlib.ExitStack() as stack:
-                        if output_type == FileTypeDetector.TYPE_ZIP:
+                        if is_zip:
                             temp_dir = stack.enter_context(tempfile.TemporaryDirectory())
                             zip_path = Path(args.output_path)
                             token_output_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
@@ -179,14 +181,10 @@ class PackageCommand:
                             progress_callback=reporter.make_progress_callback("Packaging records", "records"),
                         )
 
-                        if output_type == FileTypeDetector.TYPE_ZIP:
-                            zip_path.parent.mkdir(parents=True, exist_ok=True)
-                            with zipfile.ZipFile(
-                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
-                            ) as archive:
-                                archive.write(token_output_path, arcname=Path(token_output_path).name)
-                                archive.write(metadata_path, arcname=Path(metadata_path).name)
-                                archive.write(exchange.path, arcname=Path(exchange.path).name)
+                        if is_zip:
+                            PackageCommand._bundle_into_zip(
+                                args.output_path, token_output_path, metadata_path, exchange.path
+                            )
                             metadata_path = None
                     logger.info("Token generation and encryption completed successfully")
                 except Exception as error:
@@ -196,7 +194,7 @@ class PackageCommand:
                 "Package complete",
                 PackageCommand._build_summary_lines(
                     args.output_path,
-                    None if output_type == FileTypeDetector.TYPE_ZIP else metadata_path,
+                    None if is_zip else metadata_path,
                     summary,
                     hash_record_ids,
                 ),
@@ -207,6 +205,16 @@ class PackageCommand:
             print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
+
+    @staticmethod
+    def _bundle_into_zip(zip_output_path: str, token_path: str, metadata_path: str, exchange_config_path: str) -> None:
+        """Bundle token file, metadata, and exchange config into a zip archive."""
+        zip_path = Path(zip_output_path)
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+            archive.write(token_path, arcname=Path(token_path).name)
+            archive.write(metadata_path, arcname=Path(metadata_path).name)
+            archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
 
     @staticmethod
     def _process_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -2,7 +2,10 @@
 
 import logging
 import sys
+import tempfile
 import uuid
+import zipfile
+from pathlib import Path
 from typing import List
 
 from openlinktoken.metadata import Metadata
@@ -145,24 +148,43 @@ class PackageCommand:
                     logger.info(f"Exchange config: {exchange.path}")
 
                     reporter.update_status("Packaging records")
-                    summary, metadata_path = PackageCommand._process_tokens(
-                        args.input_path,
-                        args.output_path,
-                        input_type,
-                        output_type,
-                        exchange.hashing_secret,
-                        encryption_key,
-                        ring_id,
-                        hash_record_ids,
-                        progress_callback=reporter.make_progress_callback("Packaging records", "records"),
-                    )
+                    if output_type == FileTypeDetector.TYPE_ZIP:
+                        logger.info("ZIP output: tokens, metadata, and exchange config will be bundled")
+                        summary, metadata_path = PackageCommand._process_tokens_to_zip(
+                            args.input_path,
+                            args.output_path,
+                            input_type,
+                            exchange.path,
+                            exchange.hashing_secret,
+                            encryption_key,
+                            ring_id,
+                            hash_record_ids,
+                            progress_callback=reporter.make_progress_callback("Packaging records", "records"),
+                        )
+                    else:
+                        summary, metadata_path = PackageCommand._process_tokens(
+                            args.input_path,
+                            args.output_path,
+                            input_type,
+                            output_type,
+                            exchange.hashing_secret,
+                            encryption_key,
+                            ring_id,
+                            hash_record_ids,
+                            progress_callback=reporter.make_progress_callback("Packaging records", "records"),
+                        )
                     logger.info("Token generation and encryption completed successfully")
                 except Exception as error:
                     logger.error("Error during token processing: %s", error)
                     raise
             reporter.finish_success(
                 "Package complete",
-                PackageCommand._build_summary_lines(args.output_path, metadata_path, summary, hash_record_ids),
+                PackageCommand._build_summary_lines(
+                    args.output_path,
+                    None if output_type == FileTypeDetector.TYPE_ZIP else metadata_path,
+                    summary,
+                    hash_record_ids,
+                ),
             )
             return 0
         except Exception as error:
@@ -170,6 +192,47 @@ class PackageCommand:
             print(f"Error: {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
+
+    @staticmethod
+    def _process_tokens_to_zip(
+        input_path: str,
+        zip_output_path: str,
+        input_type: str,
+        exchange_config_path: str | None,
+        hashing_secret: str | bytes,
+        encryption_key: bytes,
+        ring_id: str,
+        hash_record_ids: bool = False,
+        progress_callback=None,
+    ) -> tuple[PersonAttributesProcessingSummary, str]:
+        """Process tokens and bundle the result, metadata, and exchange config into a zip archive."""
+        zip_path = Path(zip_output_path)
+        output_stem = zip_path.stem
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_token_path = Path(temp_dir) / f"{output_stem}.{input_type}"
+
+            summary, temp_metadata_path = PackageCommand._process_tokens(
+                input_path,
+                str(temp_token_path),
+                input_type,
+                input_type,
+                hashing_secret,
+                encryption_key,
+                ring_id,
+                hash_record_ids,
+                progress_callback=progress_callback,
+            )
+
+            zip_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+                archive.write(temp_token_path, arcname=temp_token_path.name)
+                archive.write(temp_metadata_path, arcname=Path(temp_metadata_path).name)
+                if exchange_config_path:
+                    archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
+
+        return summary, zip_output_path
 
     @staticmethod
     def _process_tokens(
@@ -227,16 +290,21 @@ class PackageCommand:
     @staticmethod
     def _build_summary_lines(
         output_path: str,
-        metadata_path: str,
+        metadata_path: str | None,
         summary: PersonAttributesProcessingSummary,
         hash_record_ids: bool,
     ) -> list[str]:
         lines = [
             f"Output: {output_path}",
-            f"Metadata: {metadata_path}",
-            f"Rows processed: {summary.total_rows:,}",
-            f"Rows with invalid attributes: {summary.total_rows_with_invalid_attributes:,}",
         ]
+        if metadata_path:
+            lines.append(f"Metadata: {metadata_path}")
+        lines.extend(
+            [
+                f"Rows processed: {summary.total_rows:,}",
+                f"Rows with invalid attributes: {summary.total_rows_with_invalid_attributes:,}",
+            ]
+        )
         lines.extend(
             CliRunReporter.summarize_count_lines("Top invalid attributes", summary.invalid_attributes_by_type, limit=3)
         )

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -204,8 +204,13 @@ class PackageCommand:
         ring_id: str,
         hash_record_ids: bool = False,
         progress_callback=None,
-    ) -> tuple[PersonAttributesProcessingSummary, str]:
+    ) -> tuple[PersonAttributesProcessingSummary, None]:
         """Process tokens and bundle the result, metadata, and exchange config into a zip archive."""
+        if exchange_config_path is None:
+            raise ValueError(
+                "ZIP output requires an exchange config file path. "
+                "Ensure the exchange config was loaded from a file (exchange.path must not be None)."
+            )
         zip_path = Path(zip_output_path)
         output_stem = zip_path.stem
 
@@ -229,10 +234,9 @@ class PackageCommand:
             with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
                 archive.write(temp_token_path, arcname=temp_token_path.name)
                 archive.write(temp_metadata_path, arcname=Path(temp_metadata_path).name)
-                if exchange_config_path:
-                    archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
+                archive.write(exchange_config_path, arcname=Path(exchange_config_path).name)
 
-        return summary, zip_output_path
+        return summary, None
 
     @staticmethod
     def _process_tokens(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import contextlib
 import logging
 import sys
 import tempfile
@@ -155,40 +156,38 @@ class PackageCommand:
                                 "Ensure the exchange config was loaded from a file (exchange.path must not be None)."
                             )
                         logger.info("ZIP output: tokens, metadata, and exchange config will be bundled")
-                        zip_path = Path(args.output_path)
-                        with tempfile.TemporaryDirectory() as temp_dir:
-                            temp_token_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
-                            summary, temp_metadata_path = PackageCommand._process_tokens(
-                                args.input_path,
-                                temp_token_path,
-                                input_type,
-                                input_type,
-                                exchange.hashing_secret,
-                                encryption_key,
-                                ring_id,
-                                hash_record_ids,
-                                progress_callback=reporter.make_progress_callback("Packaging records", "records"),
-                            )
-                            zip_path.parent.mkdir(parents=True, exist_ok=True)
-                            with zipfile.ZipFile(
-                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
-                            ) as archive:
-                                archive.write(temp_token_path, arcname=Path(temp_token_path).name)
-                                archive.write(temp_metadata_path, arcname=Path(temp_metadata_path).name)
-                                archive.write(exchange.path, arcname=Path(exchange.path).name)
-                        metadata_path = None
-                    else:
+
+                    with contextlib.ExitStack() as stack:
+                        if output_type == FileTypeDetector.TYPE_ZIP:
+                            temp_dir = stack.enter_context(tempfile.TemporaryDirectory())
+                            zip_path = Path(args.output_path)
+                            token_output_path = str(Path(temp_dir) / f"{zip_path.stem}.{input_type}")
+                            token_output_type = input_type
+                        else:
+                            token_output_path = args.output_path
+                            token_output_type = output_type
+
                         summary, metadata_path = PackageCommand._process_tokens(
                             args.input_path,
-                            args.output_path,
+                            token_output_path,
                             input_type,
-                            output_type,
+                            token_output_type,
                             exchange.hashing_secret,
                             encryption_key,
                             ring_id,
                             hash_record_ids,
                             progress_callback=reporter.make_progress_callback("Packaging records", "records"),
                         )
+
+                        if output_type == FileTypeDetector.TYPE_ZIP:
+                            zip_path.parent.mkdir(parents=True, exist_ok=True)
+                            with zipfile.ZipFile(
+                                args.output_path, mode="w", compression=zipfile.ZIP_DEFLATED
+                            ) as archive:
+                                archive.write(token_output_path, arcname=Path(token_output_path).name)
+                                archive.write(metadata_path, arcname=Path(metadata_path).name)
+                                archive.write(exchange.path, arcname=Path(exchange.path).name)
+                            metadata_path = None
                     logger.info("Token generation and encryption completed successfully")
                 except Exception as error:
                     logger.error("Error during token processing: %s", error)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/file_type_detector.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/file_type_detector.py
@@ -10,6 +10,7 @@ class FileTypeDetector:
 
     TYPE_CSV = "csv"
     TYPE_PARQUET = "parquet"
+    TYPE_ZIP = "zip"
 
     @staticmethod
     def detect_input_type(path: str) -> str:
@@ -23,10 +24,12 @@ class FileTypeDetector:
 
     @staticmethod
     def detect_output_type(path: str) -> str:
-        """Detect output file type from extension. Supports: csv, parquet."""
+        """Detect output file type from extension. Supports: csv, parquet, zip."""
         suffix = Path(path).suffix.lower()
         if suffix == FileExtension.CSV:
             return FileTypeDetector.TYPE_CSV
         if suffix == FileExtension.PARQUET:
             return FileTypeDetector.TYPE_PARQUET
+        if suffix == FileExtension.ZIP:
+            return FileTypeDetector.TYPE_ZIP
         return ""

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/zip_utils.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/zip_utils.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+
+import zipfile
+from pathlib import Path
+
+
+def bundle_into_zip(zip_output_path: str, *file_paths: str) -> None:
+    """Bundle files into a zip archive, using each file's basename as the entry name."""
+    zip_path = Path(zip_output_path)
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_output_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for file_path in file_paths:
+            archive.write(file_path, arcname=Path(file_path).name)

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -175,6 +175,57 @@ class TestOpenLinkTokenCommand:
         assert output_csv.exists(), "Output CSV should be created"
         assert output_csv.stat().st_size > 0, "Output CSV should not be empty"
 
+    def test_encrypt_command_csv_to_zip(self, temp_dir):
+        """Test encrypt command with ZIP output bundles encrypted tokens and exchange config."""
+        input_csv = temp_dir / "input.csv"
+        hashed_csv = temp_dir / "hashed.csv"
+        output_zip = temp_dir / "output.zip"
+        exchange_config, private_key = self._create_exchange_config(temp_dir, "encrypt-zip")
+
+        # First tokenize (hash-only) to produce hashed tokens for encrypt to consume
+        OpenLinkTokenCommand.execute(
+            [
+                "tokenize",
+                "-i",
+                str(input_csv),
+                "-o",
+                str(hashed_csv),
+                "--exchange-config",
+                str(exchange_config),
+                "--private-key",
+                str(private_key),
+            ]
+        )
+
+        args = [
+            "encrypt",
+            "-i",
+            str(hashed_csv),
+            "-o",
+            str(output_zip),
+            "--exchange-config",
+            str(exchange_config),
+            "--private-key",
+            str(private_key),
+        ]
+
+        exit_code = OpenLinkTokenCommand.execute(args)
+
+        assert exit_code == 0, "Command should execute successfully"
+        assert output_zip.exists(), "Output ZIP should be created"
+        assert output_zip.stat().st_size > 0, "Output ZIP should not be empty"
+
+        with zipfile.ZipFile(output_zip) as archive:
+            names = archive.namelist()
+
+        assert "output.csv" in names, "ZIP should contain the encrypted tokens CSV"
+        assert "encrypt-zip.exchange.json" in names, "ZIP should contain the exchange config JSON"
+        assert len(names) == 2, f"ZIP should contain exactly 2 files, got: {names}"
+
+        with zipfile.ZipFile(output_zip) as archive:
+            assert len(archive.read("output.csv")) > 0, "Tokens CSV inside ZIP should not be empty"
+            assert len(archive.read("encrypt-zip.exchange.json")) > 0, "Exchange config inside ZIP should not be empty"
+
     def test_decrypt_command(self, temp_dir):
         """Test decrypt command."""
         input_csv = temp_dir / "input.csv"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -5,6 +5,7 @@ Tests the end-to-end workflows for token generation and decryption using new sub
 """
 
 import os
+import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -112,8 +113,6 @@ class TestOpenLinkTokenCommand:
 
     def test_package_command_csv_to_zip(self, temp_dir):
         """Test package command with ZIP output bundles tokens, metadata, and exchange config."""
-        import zipfile
-
         input_csv = temp_dir / "input.csv"
         output_zip = temp_dir / "output.zip"
         exchange_config, private_key = self._create_exchange_config(temp_dir, "package-zip")

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -110,6 +110,48 @@ class TestOpenLinkTokenCommand:
         assert output_parquet.exists(), "Output Parquet should be created"
         assert output_parquet.stat().st_size > 0, "Output Parquet should not be empty"
 
+    def test_package_command_csv_to_zip(self, temp_dir):
+        """Test package command with ZIP output bundles tokens, metadata, and exchange config."""
+        import zipfile
+
+        input_csv = temp_dir / "input.csv"
+        output_zip = temp_dir / "output.zip"
+        exchange_config, private_key = self._create_exchange_config(temp_dir, "package-zip")
+
+        args = [
+            "package",
+            "-i",
+            str(input_csv),
+            "-o",
+            str(output_zip),
+            "--exchange-config",
+            str(exchange_config),
+            "--private-key",
+            str(private_key),
+        ]
+
+        exit_code = OpenLinkTokenCommand.execute(args)
+
+        assert exit_code == 0, "Command should execute successfully"
+        assert output_zip.exists(), "Output ZIP should be created"
+        assert output_zip.stat().st_size > 0, "Output ZIP should not be empty"
+
+        with zipfile.ZipFile(output_zip) as archive:
+            names = archive.namelist()
+
+        assert "output.csv" in names, "ZIP should contain the tokens CSV"
+        assert "output.metadata.json" in names, "ZIP should contain the metadata JSON"
+        assert "package-zip.exchange.json" in names, "ZIP should contain the exchange config JSON"
+        assert len(names) == 3, f"ZIP should contain exactly 3 files, got: {names}"
+
+        with zipfile.ZipFile(output_zip) as archive:
+            assert len(archive.read("output.csv")) > 0, "Tokens CSV inside ZIP should not be empty"
+            assert len(archive.read("output.metadata.json")) > 0, "Metadata JSON inside ZIP should not be empty"
+            assert len(archive.read("package-zip.exchange.json")) > 0, "Exchange config inside ZIP should not be empty"
+
+        # Metadata must NOT appear next to the zip — it is bundled inside
+        assert not (temp_dir / "output.metadata.json").exists(), "Metadata should not appear next to the zip"
+
     def test_tokenize_command(self, temp_dir):
         """Test tokenize command (hash-only, no encryption)."""
         input_csv = temp_dir / "input.csv"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/util/zip_utils_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/util/zip_utils_test.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+
+import zipfile
+
+import pytest
+
+from openlinktoken_cli.util.zip_utils import bundle_into_zip
+
+
+class TestBundleIntoZip:
+    """Unit tests for bundle_into_zip."""
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path):
+        return tmp_path
+
+    def test_creates_zip_with_all_files(self, temp_dir):
+        """All provided files appear in the archive."""
+        file_a = temp_dir / "tokens.csv"
+        file_b = temp_dir / "tokens.metadata.json"
+        file_c = temp_dir / "exchange.json"
+        file_a.write_text("a")
+        file_b.write_text("b")
+        file_c.write_text("c")
+
+        output_zip = temp_dir / "output.zip"
+        bundle_into_zip(str(output_zip), str(file_a), str(file_b), str(file_c))
+
+        with zipfile.ZipFile(output_zip) as archive:
+            assert sorted(archive.namelist()) == sorted(["tokens.csv", "tokens.metadata.json", "exchange.json"])
+
+    def test_archive_entries_use_basename(self, temp_dir):
+        """Entry names are basenames only — no directory path components."""
+        sub = temp_dir / "subdir"
+        sub.mkdir()
+        file_a = sub / "deep_file.csv"
+        file_a.write_text("data")
+
+        output_zip = temp_dir / "output.zip"
+        bundle_into_zip(str(output_zip), str(file_a))
+
+        with zipfile.ZipFile(output_zip) as archive:
+            assert archive.namelist() == ["deep_file.csv"]
+
+    def test_file_contents_preserved(self, temp_dir):
+        """Contents of each file are preserved inside the archive."""
+        file_a = temp_dir / "data.csv"
+        file_a.write_text("row1,row2")
+
+        output_zip = temp_dir / "output.zip"
+        bundle_into_zip(str(output_zip), str(file_a))
+
+        with zipfile.ZipFile(output_zip) as archive:
+            assert archive.read("data.csv") == b"row1,row2"
+
+    def test_creates_parent_directories(self, temp_dir):
+        """Parent directories of the zip path are created if they do not exist."""
+        file_a = temp_dir / "tokens.csv"
+        file_a.write_text("x")
+
+        output_zip = temp_dir / "nested" / "deep" / "output.zip"
+        bundle_into_zip(str(output_zip), str(file_a))
+
+        assert output_zip.exists()
+
+    def test_uses_deflate_compression(self, temp_dir):
+        """Archive uses ZIP_DEFLATED compression."""
+        file_a = temp_dir / "tokens.csv"
+        file_a.write_text("a" * 1000)
+
+        output_zip = temp_dir / "output.zip"
+        bundle_into_zip(str(output_zip), str(file_a))
+
+        with zipfile.ZipFile(output_zip) as archive:
+            info = archive.getinfo("tokens.csv")
+            assert info.compress_type == zipfile.ZIP_DEFLATED

--- a/pages/config/configuration.md
+++ b/pages/config/configuration.md
@@ -124,10 +124,16 @@ olt package \
 
 ### Output Files Generated
 
-Each run produces two files:
+For CSV or Parquet output, each run produces two files:
 
 1. **Tokens file**: `<output_path>` (CSV or Parquet)
 2. **Metadata file**: `<output_path>.metadata.json` (always JSON)
+
+When the output path ends in `.zip`, the `package` command bundles all three files into a single archive:
+
+1. `<stem>.csv` (or `.parquet`) — encrypted tokens
+2. `<stem>.metadata.json` — processing metadata
+3. `<exchange-config-filename>.exchange.json` — exchange config
 
 ---
 

--- a/pages/config/configuration.md
+++ b/pages/config/configuration.md
@@ -135,6 +135,11 @@ When the output path ends in `.zip`, the `package` command bundles all three fil
 2. `<stem>.metadata.json` — processing metadata
 3. `<exchange-config-filename>.exchange.json` — exchange config
 
+The `encrypt` command also supports `.zip` output, bundling two files (no metadata):
+
+1. `<stem>.csv` (or `.parquet`) — encrypted tokens
+2. `<exchange-config-filename>.exchange.json` — exchange config
+
 ---
 
 ## Processing Modes

--- a/pages/operations/running-batch-jobs.md
+++ b/pages/operations/running-batch-jobs.md
@@ -15,6 +15,8 @@ Open Link Token processes input files (CSV or Parquet) and produces two outputs:
 1. **Tokens file** (CSV or Parquet): Contains `RecordId`, `RuleId`, `Token` columns
 2. **Metadata file** (JSON): Processing statistics, secret hashes, and validation counts
 
+When the output path ends in `.zip`, the `package` command bundles the tokens file, metadata JSON, and exchange config JSON together into a single zip archive for upload.
+
 ---
 
 ## CLI Batch Processing
@@ -54,6 +56,25 @@ olt package \
   -o ../../../resources/output.csv \
   --exchange-config ../../../resources/batch.exchange.json
 ```
+
+### ZIP Output
+
+Pass a `.zip` path to `-o` to bundle the tokens file, metadata JSON, and exchange config JSON into a single archive:
+
+```bash
+olt package \
+  -i ../../../resources/sample.csv \
+  -o ../../../resources/output.zip \
+  --exchange-config ../../../resources/batch.exchange.json
+```
+
+The resulting archive contains three files:
+
+| File                   | Description                               |
+| ---------------------- | ----------------------------------------- |
+| `output.csv`           | Encrypted tokens (same format as input)   |
+| `output.metadata.json` | Processing metadata                       |
+| `batch.exchange.json`  | Exchange config used for this package run |
 
 ---
 

--- a/pages/operations/running-batch-jobs.md
+++ b/pages/operations/running-batch-jobs.md
@@ -15,7 +15,7 @@ Open Link Token processes input files (CSV or Parquet) and produces two outputs:
 1. **Tokens file** (CSV or Parquet): Contains `RecordId`, `RuleId`, `Token` columns
 2. **Metadata file** (JSON): Processing statistics, secret hashes, and validation counts
 
-When the output path ends in `.zip`, the `package` command bundles the tokens file, metadata JSON, and exchange config JSON together into a single zip archive for upload.
+When the output path ends in `.zip`, the `package` and `encrypt` commands bundle the output tokens file and exchange config JSON (plus metadata JSON for `package`) into a single zip archive for upload.
 
 ---
 
@@ -59,7 +59,9 @@ olt package \
 
 ### ZIP Output
 
-Pass a `.zip` path to `-o` to bundle the tokens file, metadata JSON, and exchange config JSON into a single archive:
+Pass a `.zip` path to `-o` to bundle the output tokens file, metadata JSON (for `package`), and exchange config into a single archive.
+
+**`package` — tokens, metadata, and exchange config:**
 
 ```bash
 olt package \
@@ -75,6 +77,22 @@ The resulting archive contains three files:
 | `output.csv`           | Encrypted tokens (same format as input)   |
 | `output.metadata.json` | Processing metadata                       |
 | `batch.exchange.json`  | Exchange config used for this package run |
+
+**`encrypt` — tokens and exchange config:**
+
+```bash
+olt encrypt \
+  -i ../../../resources/hashed.csv \
+  -o ../../../resources/output.zip \
+  --exchange-config ../../../resources/batch.exchange.json
+```
+
+The resulting archive contains two files:
+
+| File                  | Description                               |
+| --------------------- | ----------------------------------------- |
+| `output.csv`          | Encrypted tokens (same format as input)   |
+| `batch.exchange.json` | Exchange config used for this encrypt run |
 
 ---
 

--- a/pages/operations/sharing-tokenized-data.md
+++ b/pages/operations/sharing-tokenized-data.md
@@ -291,7 +291,7 @@ Check the generated `.metadata.json` for processing statistics:
 
 ### Step 4: Prepare Transfer Package
 
-Include in the transfer:
+Use `olt package -o output.zip` to automatically bundle the tokens, metadata, and exchange config into a single archive. Alternatively, include the files separately:
 
 | File                         | Purpose                                                          | Contains Secrets?         |
 | ---------------------------- | ---------------------------------------------------------------- | ------------------------- |

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -67,14 +67,14 @@ The automatic version check can also be disabled permanently by setting the envi
 
 ### `package` (Default Encrypted Mode)
 
-| Argument            | Short | Required | Description                                                                                     |
-| ------------------- | ----- | -------- | ----------------------------------------------------------------------------------------------- |
-| `--input`           | `-i`  | Yes      | Path to input file (CSV or Parquet)                                                             |
-| `--output`          | `-o`  | Yes      | Path to output file                                                                             |
-| `--exchange-config` |       | No       | Exchange config JSON path. Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted. |
-| `--private-key`     |       | No\*     | Private key PEM used to decrypt the exchange config and derive the transport encryption key     |
-| `--private-key-env` |       | No\*     | Environment variable containing the private key PEM                                             |
-| `--hash-record-ids` |       | No       | SHA-256 hash each input `RecordId` before writing to output (one-way, no traceability)          |
+| Argument            | Short | Required | Description                                                                                                                                              |
+| ------------------- | ----- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--input`           | `-i`  | Yes      | Path to input file (CSV or Parquet)                                                                                                                      |
+| `--output`          | `-o`  | Yes      | Path to output file. Supported extensions: `.csv`, `.parquet`, `.zip`. A `.zip` path bundles the tokens, metadata, and exchange config into one archive. |
+| `--exchange-config` |       | No       | Exchange config JSON path. Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted.                                                          |
+| `--private-key`     |       | No\*     | Private key PEM used to decrypt the exchange config and derive the transport encryption key                                                              |
+| `--private-key-env` |       | No\*     | Environment variable containing the private key PEM                                                                                                      |
+| `--hash-record-ids` |       | No       | SHA-256 hash each input `RecordId` before writing to output (one-way, no traceability)                                                                   |
 
 ### `tokenize` (Hashed Tokens Only)
 

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -90,13 +90,13 @@ The automatic version check can also be disabled permanently by setting the envi
 
 ### `encrypt` (Encrypt Input Tokens)
 
-| Argument            | Short | Required | Description                                                                                     |
-| ------------------- | ----- | -------- | ----------------------------------------------------------------------------------------------- |
-| `--input`           | `-i`  | Yes      | Path to input file (CSV or Parquet)                                                             |
-| `--output`          | `-o`  | Yes      | Path to output file                                                                             |
-| `--exchange-config` |       | No       | Exchange config JSON path. Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted. |
-| `--private-key`     |       | No\*     | Private key PEM used to decrypt the exchange config and derive the transport encryption key     |
-| `--private-key-env` |       | No\*     | Environment variable containing the private key PEM                                             |
+| Argument            | Short | Required | Description                                                                                                                                             |
+| ------------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--input`           | `-i`  | Yes      | Path to input file (CSV or Parquet)                                                                                                                     |
+| `--output`          | `-o`  | Yes      | Path to output file. Supported extensions: `.csv`, `.parquet`, `.zip`. A `.zip` path bundles the encrypted tokens and exchange config into one archive. |
+| `--exchange-config` |       | No       | Exchange config JSON path. Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted.                                                         |
+| `--private-key`     |       | No\*     | Private key PEM used to decrypt the exchange config and derive the transport encryption key                                                             |
+| `--private-key-env` |       | No\*     | Environment variable containing the private key PEM                                                                                                     |
 
 ### `decrypt` (Decrypt Encrypted Tokens)
 

--- a/tools/interoperability/multi_language_interoperability_test.py
+++ b/tools/interoperability/multi_language_interoperability_test.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 from typing import Any, Dict
 
@@ -385,6 +386,112 @@ class TestTokenCompatibility:
             print("✅ Metadata consistency verified!")
             print("-" * 30)
 
+    def test_package_command_zip_output(self):
+        """Verify that the package command bundles tokens, metadata, and exchange config into a zip."""
+        print("\nTesting package command zip output")
+        print("-" * 30)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            output_zip = temp_path / "output.zip"
+
+            exchange_config, private_key = self.python_cli._bootstrap_exchange_config(temp_path)
+
+            self.python_cli.run(
+                "package",
+                "-i",
+                str(self.python_cli.sample_csv),
+                "-o",
+                str(output_zip),
+                "--exchange-config",
+                str(exchange_config),
+                "--private-key",
+                str(private_key),
+                home_dir=temp_path,
+            )
+
+            assert output_zip.exists(), "Package zip output file was not created"
+            assert output_zip.stat().st_size > 0, "Package zip output file is empty"
+
+            with zipfile.ZipFile(output_zip) as archive:
+                names = archive.namelist()
+
+            assert "output.csv" in names, f"ZIP missing tokens CSV; got: {names}"
+            assert "output.metadata.json" in names, f"ZIP missing metadata JSON; got: {names}"
+            exchange_config_name = exchange_config.name
+            assert exchange_config_name in names, f"ZIP missing exchange config '{exchange_config_name}'; got: {names}"
+            assert len(names) == 3, f"ZIP should contain exactly 3 files, got: {names}"
+
+            with zipfile.ZipFile(output_zip) as archive:
+                assert len(archive.read("output.csv")) > 0, "Tokens CSV inside ZIP is empty"
+                assert len(archive.read("output.metadata.json")) > 0, "Metadata JSON inside ZIP is empty"
+                assert len(archive.read(exchange_config_name)) > 0, "Exchange config inside ZIP is empty"
+
+                meta = json.loads(archive.read("output.metadata.json"))
+                assert meta.get("TotalRows") == EXPECTED_SAMPLE_METADATA["TotalRows"], meta
+
+            print("✅ package zip output verified!")
+            print("-" * 30)
+
+    def test_encrypt_command_zip_output(self):
+        """Verify that the encrypt command bundles encrypted tokens and exchange config into a zip."""
+        print("\nTesting encrypt command zip output")
+        print("-" * 30)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            tokenized_csv = temp_path / "tokenized.csv"
+            output_zip = temp_path / "encrypted.zip"
+
+            exchange_config, private_key = self.python_cli._bootstrap_exchange_config(temp_path)
+
+            self.python_cli.run(
+                "tokenize",
+                "-i",
+                str(self.python_cli.sample_csv),
+                "-o",
+                str(tokenized_csv),
+                "--exchange-config",
+                str(exchange_config),
+                "--private-key",
+                str(private_key),
+                home_dir=temp_path,
+            )
+
+            assert tokenized_csv.exists(), "Tokenize step did not produce output"
+
+            self.python_cli.run(
+                "encrypt",
+                "-i",
+                str(tokenized_csv),
+                "-o",
+                str(output_zip),
+                "--exchange-config",
+                str(exchange_config),
+                "--private-key",
+                str(private_key),
+                home_dir=temp_path,
+            )
+
+            assert output_zip.exists(), "Encrypt zip output file was not created"
+            assert output_zip.stat().st_size > 0, "Encrypt zip output file is empty"
+
+            with zipfile.ZipFile(output_zip) as archive:
+                names = archive.namelist()
+
+            assert "encrypted.csv" in names, f"ZIP missing encrypted tokens CSV; got: {names}"
+            exchange_config_name = exchange_config.name
+            assert exchange_config_name in names, f"ZIP missing exchange config '{exchange_config_name}'; got: {names}"
+            assert "encrypted.metadata.json" not in names, f"Encrypt ZIP should not contain metadata; got: {names}"
+            assert len(names) == 2, f"ZIP should contain exactly 2 files, got: {names}"
+
+            with zipfile.ZipFile(output_zip) as archive:
+                assert len(archive.read("encrypted.csv")) > 0, "Encrypted tokens CSV inside ZIP is empty"
+                assert len(archive.read(exchange_config_name)) > 0, "Exchange config inside ZIP is empty"
+
+            print("✅ encrypt zip output verified!")
+            print("-" * 30)
+
 
 if __name__ == "__main__":
     test = TestTokenCompatibility()
@@ -395,6 +502,8 @@ if __name__ == "__main__":
         test.test_python_cli_module_entrypoint_tokenize_flow()
         test.test_java_library_harness_matches_python_cli_tokenize_output()
         test.test_metadata_consistency()
+        test.test_package_command_zip_output()
+        test.test_encrypt_command_zip_output()
         print("\n✅ ALL TESTS PASSED!")
     except Exception as error:
         print(f"\n❌ TEST FAILED: {str(error)}")


### PR DESCRIPTION
## Summary

When the output path ends in .zip, the package and encrypt commands now bundle the output tokens file, exchange config JSON, and (for package) metadata JSON into a single zip archive. This satisfies that the server can independently verify exchange parameters (key fingerprints, curve, rotation config) without relying solely on the metadata supplied by the client.

## What changed

- Add TYPE_ZIP constant and .zip detection to FileTypeDetector
- Add zip output branch to PackageCommand.execute() — processes tokens to a temp dir via _process_tokens(), then bundles tokens, metadata, and exchange config into the zip
- Add zip output branch to EncryptCommand.execute() — same pattern, bundles encrypted tokens and exchange config (no metadata for encrypt-only flow)
- Make metadata_path optional in _build_summary_lines() since it is bundled inside the zip rather than written alongside it
- Add test_package_command_csv_to_zip() verifying zip contains exactly tokens, metadata, and exchange config
- Add test_encrypt_command_csv_to_zip() verifying zip contains exactly tokens and exchange config
- Update running-batch-jobs.md, cli.md, configuration.md, and sharing-tokenized-data.md reference docs