### PR TITLE
feat(setup): migrate to docker compose, use trixie base, and add rtk installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ARG JAVA_VERSION=21
-FROM mcr.microsoft.com/devcontainers/java:1-${JAVA_VERSION}-bookworm
+FROM mcr.microsoft.com/devcontainers/java:3-${JAVA_VERSION}-trixie
 
 # Fix Yarn repository GPG key issue - remove the Yarn repo to prevent feature installation failures
 # The Yarn InRelease file is signed with key 62D54FD4003F6525 which is no longer in their pubkey.gpg
@@ -11,7 +11,7 @@ COPY .devcontainer/scripts/detect_zscaler.sh /tmp/
 # Copy host-provided certificate if it exists (will be skipped if file doesn't exist)
 COPY .devcontainer/scripts/zscaler_root.pem* /tmp/host_zscaler_cert.pem
 
-RUN apt-get update && apt-get install -y ca-certificates openssl python3 libpython3.11 curl && \
+RUN apt-get update && apt-get install -y ca-certificates openssl curl git-lfs && \
     # Make the script executable and run it
     chmod +x /tmp/detect_zscaler.sh && \
     /tmp/detect_zscaler.sh && \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -46,6 +46,32 @@ If your organization uses Zscaler for SSL inspection, you'll need to configure t
 
 For more details, see [Zscaler Certificate Management](./scripts/README.md).
 
+## Development Tools
+
+The dev container includes several tools to optimize your development workflow:
+
+### rtk - Rust Token Killer
+
+For environments where you use GitHub Copilot or other LLM-driven tools, `rtk` is available to help reduce token usage by optimizing code before sending it to the model.
+
+**What it does:**
+
+- Minifies and strips comments from code
+- Normalizes whitespace
+- Helps keep LLM interactions efficient by reducing token count
+
+**How to use:**
+
+```bash
+# Process a file with rtk
+rtk <file.py> result_minified.py
+
+# Get help
+rtk --help
+```
+
+This tool is automatically installed during the container setup process and is available on your PATH.
+
 ### Keeping it relevant
 
 If you end up needing additional tools, extensions or settings, please add them to the `.devcontainer/devcontainer.json` file. This will ensure that everyone has the same environment with everything needed.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -35,6 +35,11 @@
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
       "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
     },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    },
     "ghcr.io/jsburckhardt/devcontainer-features/opencode:1": {
       "version": "1.1.1",
       "resolved": "ghcr.io/jsburckhardt/devcontainer-features/opencode@sha256:047f9144ad6540ee416cc2ea170f41bfae887c6c2cd883e14d2ab44a1ce20fc8",

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,44 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {
+      "version": "1.1.3",
+      "resolved": "ghcr.io/devcontainers/features/copilot-cli@sha256:e10d091ae7ef9b8d2ed5f601d75f5a090bc04acbac1a26d4cd3c0d5edde4ea10",
+      "integrity": "sha256:e10d091ae7ef9b8d2ed5f601d75f5a090bc04acbac1a26d4cd3c0d5edde4ea10"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "version": "1.2.5",
+      "resolved": "ghcr.io/devcontainers/features/git-lfs@sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72",
+      "integrity": "sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/java@sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a",
+      "integrity": "sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/jsburckhardt/devcontainer-features/opencode:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/jsburckhardt/devcontainer-features/opencode@sha256:047f9144ad6540ee416cc2ea170f41bfae887c6c2cd883e14d2ab44a1ce20fc8",
+      "integrity": "sha256:047f9144ad6540ee416cc2ea170f41bfae887c6c2cd883e14d2ab44a1ce20fc8"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,9 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
   "name": "Open Link Token",
-  "dockerComposeFile": ["../docker-compose.yml"],
+  "dockerComposeFile": ["docker-compose.yml"],
   "service": "app",
+  "workspaceFolder": "/workspaces/OpenLinkToken",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
       "configureZshAsDefaultShell": true
@@ -17,11 +18,17 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20.12.0"
     },
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false
+    },
     "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/copilot-cli:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/jsburckhardt/devcontainer-features/opencode:1": {}
+    "ghcr.io/jsburckhardt/devcontainer-features/opencode:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11",
+      "installPipenv": "true"
+    }
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,19 +2,14 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
   "name": "Open Link Token",
-  "build": {
-    "context": "..",
-    "dockerfile": "Dockerfile",
-    "args": {
-      "JAVA_VERSION": "21"
-    }
-  },
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "app",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
       "configureZshAsDefaultShell": true
     },
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "21.0.10",
+      "version": "21.0.11",
       "installMaven": "true",
       "mavenVersion": "3.8.8",
       "installGradle": "false"
@@ -25,7 +20,8 @@
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/copilot-cli:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/jsburckhardt/devcontainer-features/opencode:1": {}
   },
   "customizations": {
     "vscode": {
@@ -54,14 +50,8 @@
       }
     }
   },
-  "mounts": [
-    "type=volume,source=openlinktoken-local,target=/home/vscode/.local",
-    "type=volume,source=openlinktoken-cache,target=/home/vscode/.cache",
-    "type=volume,source=openlinktoken-copilot,target=/home/vscode/.copilot",
-    "type=volume,source=openlinktoken-vscode-server,target=/home/vscode/.vscode-server",
-    "type=volume,source=openlinktoken-vscode-insiders,target=/home/vscode/.vscode-server-insiders"
-  ],
   "containerEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
     "PYSPARK_SUBMIT_ARGS": "--driver-memory 8g --executor-memory 8g --conf spark.driver.maxResultSize=4g --conf spark.memory.fraction=0.7 pyspark-shell",
     "UV_PROJECT_ENVIRONMENT": "/home/vscode/.local/share/openlinktoken/.venv"
   },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,18 +1,20 @@
-version: "3.8"
-
 services:
   app:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     volumes:
+      - ..:/workspaces/OpenLinkToken
       - openlinktoken-local:/home/vscode/.local
-      - opentoken-cache:/home/vscode/.cache
+      - openlinktoken-cache:/home/vscode/.cache
       - openlinktoken-copilot:/home/vscode/.copilot
       - openlinktoken-vscode-server:/home/vscode/.vscode-server
       - openlinktoken-vscode-insiders:/home/vscode/.vscode-server-insiders
       - openlinktoken-opencode:/home/vscode/.opencode
       - openlinktoken-config:/home/vscode/.config
+    user: vscode:vscode
+    # Keeps the container running so devcontainer tooling can attach
+    command: sleep infinity
 
 volumes:
   openlinktoken-local:

--- a/.devcontainer/scripts/unified-setup.sh
+++ b/.devcontainer/scripts/unified-setup.sh
@@ -8,9 +8,27 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 VENV_DIR="${UV_PROJECT_ENVIRONMENT:-/home/vscode/.local/share/openlinktoken/.venv}"
 WORKSPACE_VENV_DIR="$REPO_ROOT/.venv"
 STATE_DIR="${VENV_DIR}/.setup-state"
-PHASE="${1:-full}"  # Options: full, post-create, post-start, post-attach
+
+# Default phase and force flag
+PHASE="full"
+FORCE=false
+
+# Parse arguments to support --force or -f, alongside the phase argument
+for arg in "$@"; do
+  if [[ "$arg" == "--force" ]] || [[ "$arg" == "-f" ]]; then
+    FORCE=true
+  else
+    PHASE="$arg"
+  fi
+done
 
 mkdir -p "$STATE_DIR"
+
+# If force is requested, clear the setup state to allow re-running steps
+if [ "$FORCE" = true ]; then
+  echo "→ Force flag detected. Clearing setup state..."
+  rm -rf "$STATE_DIR" && mkdir -p "$STATE_DIR"
+fi
 
 # Marker functions for tracking completed steps
 mark_complete() {

--- a/.devcontainer/scripts/unified-setup.sh
+++ b/.devcontainer/scripts/unified-setup.sh
@@ -140,6 +140,39 @@ step_install_prek() {
 # APM setup
 # ============================================================================
 
+step_install_rtk() {
+  skip_if_complete "rtk-installed" "rtk installation" && return 0
+
+  if command -v rtk >/dev/null 2>&1; then
+    echo "⊘ Skipping rtk installation (already installed)"
+    mark_complete "rtk-installed"
+    return 0
+  fi
+
+  echo "→ Installing rtk (Rust Token Killer) for token optimization"
+  curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+
+  mark_complete "rtk-installed"
+}
+
+step_install_bun() {
+  skip_if_complete "bun-installed" "bun installation" && return 0
+
+  echo "→ Installing bun"
+  curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.local/share/bun/bin:$PATH"
+  mark_complete "bun-installed"
+}
+
+step_install_opencode_auto_resume() {
+  skip_if_complete "opencode-auto-resume-installed" "opencode-auto-resume installation" && return 0
+
+  echo "→ Installing opencode-auto-resume"
+  npm install -g opencode-auto-resume
+  mark_complete "opencode-auto-resume-installed"
+}
+
 step_install_apm_cli() {
   echo "→ Installing apm CLI"
   uv pip install apm-cli
@@ -212,6 +245,9 @@ run_full_setup() {
   step_install_prek
   step_install_apm_cli
   step_setup_apm
+  step_install_rtk
+  step_install_bun
+  step_install_opencode_auto_resume
 }
 
 run_refresh_setup() {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,3 +30,33 @@ When performing a code review, focus only on findings that are medium severity o
 - Load only the smallest relevant instruction set for the files you are editing.
 - Keep this file summary-only; move detailed guidance to scoped instruction modules instead of duplicating it here.
 - For Open Link Token component layout, registration patterns, and parity-sensitive changes, use `.github/instructions/openlinktoken-architecture.instructions.md`.
+
+<!-- rtk-instructions v2 -->
+
+# RTK — Token-Optimized CLI
+
+**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
+
+## Rule
+
+Always prefix shell commands with `rtk`:
+
+```bash
+# Instead of:              Use:
+git status                 rtk git status
+git log -10                rtk git log -10
+cargo test                 rtk cargo test
+docker ps                  rtk docker ps
+kubectl get pods           rtk kubectl pods
+```
+
+## Meta commands (use directly)
+
+```bash
+rtk gain              # Token savings dashboard
+rtk gain --history    # Per-command savings history
+rtk discover          # Find missed rtk opportunities
+rtk proxy <cmd>       # Run raw (no filtering) but track usage
+```
+
+<!-- /rtk-instructions -->

--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "rtk hook copilot",
+        "cwd": ".",
+        "timeout": 5
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "rtk hook copilot",
+        "powershell": "rtk hook copilot",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,8 @@ apm_modules/
 
 # Added by apm install
 .agents/
+
+node_modules/
+package.json
+package-lock.json
+docs/superpowers/

--- a/apm.yml
+++ b/apm.yml
@@ -19,6 +19,6 @@ dependencies:
     - obra/superpowers/skills/writing-plans
     - obra/superpowers/skills/writing-skills
     - github/awesome-copilot/skills/documentation-writer
-    - github/awesome-copilot/skills/gh-cli
+    - github/awesome-copilot/skills/gh-cli#7f59e018008c52c385e7c4799430692cfe1118c2
   mcp: []
 scripts: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - openlinktoken-local:/home/vscode/.local
+      - opentoken-cache:/home/vscode/.cache
+      - openlinktoken-copilot:/home/vscode/.copilot
+      - openlinktoken-vscode-server:/home/vscode/.vscode-server
+      - openlinktoken-vscode-insiders:/home/vscode/.vscode-server-insiders
+      - openlinktoken-opencode:/home/vscode/.opencode
+      - openlinktoken-config:/home/vscode/.config
+
+volumes:
+  openlinktoken-local:
+  openlinktoken-cache:
+  openlinktoken-copilot:
+  openlinktoken-vscode-server:
+  openlinktoken-vscode-insiders:
+  openlinktoken-opencode:
+  openlinktoken-config:


### PR DESCRIPTION
## Summary
Enhanced development environment by integrating `rtk` (Rust Token Killer) into the dev container and streamlining setup processes. This PR migrates the dev container configuration to use Docker Compose, adds support for several new tools (Python with Pipenv, opencode), and updates the base image.

## Related issues

- None

## Affected surfaces

- [x] Java
- [x] Python
- [ ] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [x] CI / workflows / agent instructions

## What changed

- **Dev Container**: Switched to Docker Compose for a more robust environment and updated the base image to Debian Trixie (Java 21) and included git-lfs.
- **Setup Script**: Added `--force` support to `.devcontainer/scripts/unified-setup.sh` to allow re-running installation steps and automated installation of `rtk`, `bun`, and `opencode-auto-resume`.
- **Tooling Integration**: Integrated Python (Pipenv) and the `opencode` extension directly into dev container features.
- **AI Workflow**: Added `rtk` usage instructions to Copilot instructions and introduced a new git hook (`.github/hooks/rtk-rewrite.json`) to optimize command outputs for LLMs.
- **Cleanup**: Updated `.gitignore` and documentation files.