### PR TITLE
fix: split pandas constraints by Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
         exclude:
           # PySpark 3.4.x and 3.5.x do not support Python 3.13+ (pyspark itself has no 3.13/3.14 wheels).
           # Spark 3.4 uses pyarrow<23 + pandas<2.2 (runtime enforced by pyspark 3.4.x)
-          # Spark 3.5 uses pyarrow<20 + pandas 2.2.3 (runtime enforced by pyspark 3.5.x)
+          # Spark 3.5 uses pyarrow<20. Python 3.10 resolves pandas 2.2.3; Python 3.11+ resolves pandas 3.0.3.
           - python-version: "3.13"
             spark-version: "3.4"
           - python-version: "3.13"

--- a/lib/python/openlinktoken-cli/requirements.txt
+++ b/lib/python/openlinktoken-cli/requirements.txt
@@ -2,7 +2,9 @@
 openlinktoken==2.0.0-alpha
 
 # Data processing for I/O formats
-pandas==2.2.3
+# pandas 3.x drops Python 3.10 support, so keep a Python-version split.
+pandas==2.2.3; python_version < "3.11"
+pandas==3.0.3; python_version >= "3.11"
 pyarrow==24.0.0
 csv2parquet==0.0.9
 

--- a/lib/python/openlinktoken-pyspark/pyproject.toml
+++ b/lib/python/openlinktoken-pyspark/pyproject.toml
@@ -41,6 +41,14 @@ conflicts = [
     { extra = "spark40" },
     { extra = "spark41" },
   ],
+  [
+    { package = "openlinktoken-cli" },
+    { extra = "spark34" },
+  ],
+  [
+    { package = "openlinktoken-cli" },
+    { extra = "spark35" },
+  ],
 ]
 
 [tool.pytest.ini_options]

--- a/lib/python/openlinktoken-pyspark/setup.py
+++ b/lib/python/openlinktoken-pyspark/setup.py
@@ -44,25 +44,29 @@ setup(
         "spark41": [
             "pyspark==4.1.0",
             "pyarrow==24.0.0",
-            "pandas==2.2.3",
+            "pandas==2.2.3; python_version < '3.11'",
+            "pandas==3.0.3; python_version >= '3.11'",
         ],
         # Spark 4.0.x - Recommended for Java 21
         "spark40": [
             "pyspark==4.0.1",
             "pyarrow==24.0.0",
-            "pandas==2.2.3",
+            "pandas==2.2.3; python_version < '3.11'",
+            "pandas==3.0.3; python_version >= '3.11'",
         ],
         # Spark 3.5.x - For Java 8-17 (NOT compatible with Java 21)
         "spark35": [
             "pyspark==3.5.5",
             "pyarrow==19.0.0",
-            "pandas==2.2.3",
+            "pandas==2.2.3; python_version < '3.11'",
+            "pandas==3.0.3; python_version >= '3.11'",
         ],
         # Spark 3.4.x - Legacy support
         "spark34": [
             "pyspark==3.4.4",
             "pyarrow==15.0.0",
-            "pandas==2.1.4",
+            "pandas==2.1.4; python_version < '3.11'",
+            "pandas==3.0.3; python_version >= '3.11'",
         ],
         # Development dependencies
         "dev": [


### PR DESCRIPTION
## Summary

- Add Python-version-aware pandas constraints so dependency resolution stays compatible across supported runtimes.
- Resolve Python compatibility friction for CLI and PySpark extras while keeping Spark/pyarrow constraints explicit.

## Related issues

- Related to #

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [x] PySpark
- [ ] Docs / GitHub Pages
- [x] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Updated `lib/python/openlinktoken-cli/requirements.txt` to use conditional pandas pins:
  - `pandas==2.2.3` for Python < 3.11
  - `pandas==3.0.3` for Python >= 3.11
- Updated `lib/python/openlinktoken-pyspark/setup.py` extras (`spark34`, `spark35`, `spark40`, `spark41`) with the same Python-version-aware pandas constraints.
- Added `tool.uv.conflicts` entries in `lib/python/openlinktoken-pyspark/pyproject.toml` to prevent incompatible installs that combine `openlinktoken-cli` with `spark34`/`spark35` extras.
- Clarified CI workflow comments in `.github/workflows/ci.yml` to reflect pandas resolution behavior across Python versions.

### Verification

- `prek run --files .github/workflows/ci.yml lib/python/openlinktoken-cli/requirements.txt lib/python/openlinktoken-pyspark/pyproject.toml lib/python/openlinktoken-pyspark/setup.py` passed successfully.
