### PR TITLE
feat: add GitHub issue templates and issue guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a defect or regression
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+### Summary
+
+A clear and concise description of the bug.
+
+### Steps to reproduce
+
+1. Go to "..."
+2. Run "..."
+3. See error.
+
+### Expected behavior
+
+Describe what you expected to happen.
+
+### Actual behavior
+
+Describe what happened instead.
+
+### Environment
+
+- Extension version:
+- Python version:
+- OS:
+
+### Additional context
+
+Add logs, screenshots, or any other context that may help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,23 @@
+---
+name: Documentation
+about: Suggest additions, fixes, or clarifications to docs
+title: "[Docs] "
+labels: documentation
+assignees: ""
+---
+
+### Documentation area
+
+Which file, page, or section needs an update?
+
+### Current gap
+
+What is missing, unclear, or incorrect today?
+
+### Suggested update
+
+Describe the exact change that should be made.
+
+### Additional context
+
+Include links, screenshots, or references if relevant.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+### Problem statement
+
+What problem are you trying to solve?
+
+### Proposed solution
+
+Describe the feature or change you would like to see.
+
+### Alternatives considered
+
+Describe any alternative solutions or workarounds you've considered.
+
+### Additional context
+
+Add relevant links, screenshots, or examples.

--- a/.github/ISSUE_TEMPLATE/general_report.md
+++ b/.github/ISSUE_TEMPLATE/general_report.md
@@ -1,0 +1,19 @@
+---
+name: General report
+about: Share questions, feedback, or other non-bug reports
+title: "[General] "
+labels: question
+assignees: ""
+---
+
+### Topic
+
+What is this report about?
+
+### Details
+
+Provide your feedback, question, or context.
+
+### Additional information
+
+Add any supporting notes, links, or examples.

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -9,7 +9,10 @@ This folder contains the canonical supplemental instruction modules for Copilot 
 | `java.instructions.md`                             | Java-specific rules, including import usage, build checks, and code review expectations.                                           |
 | `python.instructions.md`                           | Python-specific rules, including the shared venv and workspace `.venv` symlink guidance, typing, formatting, and testing guidance. |
 | `openlinktoken-architecture.instructions.md`       | Open Link Token architecture, parity-sensitive changes, and cross-language registration guidance.                                  |
+| `issue.instructions.md`                            | Conventions for creating and routing GitHub issues using the repository issue templates.                                           |
 | `pull-request.instructions.md`                     | Branch naming, draft PR defaults, and PR readiness expectations.                                                                   |
+| `pre-commit.instructions.md`                       | Pre-commit enforcement guidance, including required `prek run --files` checks on changed files.                                    |
+| `repository-workflow-memory.instructions.md`       | Repository workflow reminders for dependency pinning, `uv lock` after dependency edits, and targeted `prek` verification habits.   |
 | `security-and-owasp.instructions.md`               | Security-first coding guidance based on OWASP-style concerns.                                                                      |
 | `self-explanatory-code-commenting.instructions.md` | Commenting guidance focused on explaining why, not what.                                                                           |
 

--- a/.github/instructions/issue.instructions.md
+++ b/.github/instructions/issue.instructions.md
@@ -1,0 +1,10 @@
+---
+description: "Conventions for GitHub issues"
+applyTo: "**"
+---
+
+# Use issue templates for new issues
+
+- Create new issues using the templates in `.github/ISSUE_TEMPLATE/`.
+- Route requests to the best-fit template category so maintainers get the right context up front.
+- Keep template sections filled with concrete details instead of placeholders.


### PR DESCRIPTION
## Summary

- Add structured issue templates for bug reports, feature requests, documentation requests, and general reports.
- Configure issue template chooser defaults via `.github/ISSUE_TEMPLATE/config.yml`.
- Add issue-template usage guidance to `.github/instructions/issue.instructions.md` and index it in `.github/instructions/README.md`.

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [ ] Java
- [ ] Python
- [ ] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [x] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Added four issue templates with concrete sections for actionable reports and requests.
- Added template chooser configuration to guide issue creation flow.
- Added and referenced repository instruction guidance so agents consistently use issue templates.
