### PR TITLE
fix(cli): bump cryptography and urllib3 pins

### DIFF
--- a/lib/python/openlinktoken-cli/requirements.txt
+++ b/lib/python/openlinktoken-cli/requirements.txt
@@ -8,8 +8,9 @@ pandas==3.0.3; python_version >= "3.11"
 pyarrow==24.0.0
 csv2parquet==0.0.9
 
-# Cryptography - mandate secure version to address CVE-2023-0286
-cryptography==46.0.7
+# Cryptography - mandate secure version to address CVE-2026-44432
+cryptography==48.0.1
+urllib3==2.7.0
 
 # JOSE/JWE for match token format
 jwcrypto==1.5.7

--- a/lib/python/openlinktoken/requirements.txt
+++ b/lib/python/openlinktoken/requirements.txt
@@ -1,5 +1,5 @@
-# Cryptography - mandate secure version to address CVE-2023-0286
-cryptography==46.0.7
+# Cryptography - mandate secure version to address CVE-2026-44432
+cryptography==48.0.1
 
 # JOSE/JWE for match token format
 jwcrypto==1.5.7

--- a/lib/python/openlinktoken/setup.py
+++ b/lib/python/openlinktoken/setup.py
@@ -13,7 +13,7 @@ try:
     with open(readme_path, encoding="utf-8") as f:
         long_description = f.read()
 except FileNotFoundError:
-     # Fallback to a short description if README is unavailable
+    # Fallback to a short description if README is unavailable
     long_description = "Open Link Token Python implementation for record linkage."
 
 # Read requirements from requirements.txt
@@ -38,7 +38,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "dev": [
-            "cryptography==46.0.7",
+            "cryptography==48.0.1",
             "pycryptodome==3.23.0",
         ],
         "test": ["pytest==9.0.3"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ openlinktoken = { workspace = true }
 
 [dependency-groups]
 dev = [
-   "cryptography==46.0.7",
+   "cryptography==48.0.1",
    "jwcrypto==1.5.7",
    "csv2parquet==0.0.9",
    "pytest==9.0.3",


### PR DESCRIPTION
## Summary

- Update `lib/python/openlinktoken-cli/requirements.txt` to pin `cryptography==48.0.1` and add `urllib3==2.7.0`.
- Keep CLI dependency constraints explicit for security and reproducibility.

## Related issues

- Fixes #N/A
- Related to #N/A

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [ ] PySpark
- [ ] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Bumped the cryptography dependency pin from `46.0.7` to `48.0.1`.
- Added an explicit urllib3 dependency pin at `2.7.0`.