### PR TITLE
fix: require setuptools for PySpark 3.x on Python 3.12+

### DIFF
--- a/lib/python/openlinktoken-pyspark/setup.py
+++ b/lib/python/openlinktoken-pyspark/setup.py
@@ -60,6 +60,7 @@ setup(
             "pyarrow==19.0.0",
             "pandas==2.2.3; python_version < '3.11'",
             "pandas==3.0.3; python_version >= '3.11'",
+            "setuptools==82.0.1; python_version >= '3.12'",
         ],
         # Spark 3.4.x - Legacy support
         "spark34": [
@@ -67,6 +68,7 @@ setup(
             "pyarrow==15.0.0",
             "pandas==2.1.4; python_version < '3.11'",
             "pandas==3.0.3; python_version >= '3.11'",
+            "setuptools==82.0.1; python_version >= '3.12'",
         ],
         # Development dependencies
         "dev": [


### PR DESCRIPTION
## Summary

- Adds an explicit `setuptools==82.0.1` dependency for the PySpark `spark35` and `spark34` extras when running on Python 3.12+.
- Prevents PySpark 3.x from failing at runtime with `ModuleNotFoundError: No module named distutils` in CI and user environments.

## Related issues

- Fixes #N/A
- Related to #N/A

## Affected surfaces

- [ ] Java
- [x] Python
- [ ] CLI
- [x] PySpark
- [ ] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Updated `lib/python/openlinktoken-pyspark/setup.py` extras for `spark35` and `spark34` to include `setuptools==82.0.1; python_version >= "3.12"`.
- Kept the fix package-scoped so Spark 3.x installs become self-contained instead of relying on transitive dev dependency behavior.
