### PR TITLE
fix: correct Maven Central + PyPI publishing auth and workflow bugs (…

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -25,12 +25,28 @@ inputs:
     description: "Python version to install"
     required: false
     default: "3.10"
+  central-username:
+    description: "Central Publisher Portal user token username (for Maven Central deploys). Leave unset to skip."
+    required: false
+    default: ""
+  central-password:
+    description: "Central Publisher Portal user token password (for Maven Central deploys). Leave unset to skip."
+    required: false
+    default: ""
+  gpg-private-key:
+    description: "Base64-encoded, armored GPG private key used to sign Maven Central release artifacts. Leave unset to skip."
+    required: false
+    default: ""
+  gpg-passphrase:
+    description: "Passphrase for the GPG private key above. Leave unset to skip."
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
     - name: Set up JDK
       if: inputs.enable-java == 'true'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: ${{ inputs.java-distribution }}
@@ -38,9 +54,37 @@ runs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+    # actions/setup-java only writes a single <server> entry (for "github" above) and
+    # closes the <settings> root element. Appending a second <servers> block after
+    # </settings> would produce invalid XML, so instead we insert the "central" server
+    # (Central Publisher Portal user token, used by central-publishing-maven-plugin) and
+    # a gpg.passphrase server entry before the existing </servers> closing tag.
+    - name: Add Central Portal and GPG credentials to settings.xml
+      if: inputs.enable-java == 'true' && inputs.central-username != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        SETTINGS_FILE="$GITHUB_WORKSPACE/settings.xml"
+        sed -i "s#</servers>#<server><id>central</id><username>\${env.CENTRAL_PORTAL_USERNAME}</username><password>\${env.CENTRAL_PORTAL_PASSWORD}</password></server><server><id>gpg.passphrase</id><passphrase>\${env.GPG_PASSPHRASE}</passphrase></server></servers>#" "$SETTINGS_FILE"
+        echo "Added central and gpg.passphrase server entries to settings.xml"
+      env:
+        CENTRAL_PORTAL_USERNAME: ${{ inputs.central-username }}
+        CENTRAL_PORTAL_PASSWORD: ${{ inputs.central-password }}
+        GPG_PASSPHRASE: ${{ inputs.gpg-passphrase }}
+
+    - name: Import GPG signing key
+      if: inputs.enable-java == 'true' && inputs.gpg-private-key != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
+        echo "Imported GPG signing key"
+      env:
+        GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}
+
     - name: Set up Python
       if: inputs.enable-python == 'true'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
       - name: Check if release exists
         id: check_release
         if: steps.check_tag.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = 'v${{ steps.get_version.outputs.version }}';
@@ -82,7 +82,7 @@ jobs:
       - name: Create GitHub Release
         id: create_release
         if: steps.check_tag.outputs.exists == 'false' && steps.check_release.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const version = '${{ steps.get_version.outputs.version }}';

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Add comment to PR
         if: steps.check_version.outputs.needs_update == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -157,7 +157,7 @@ jobs:
 
       - name: Version already up-to-date comment
         if: steps.check_version.outputs.needs_update == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/build-olt-cli.yml
+++ b/.github/workflows/build-olt-cli.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -98,7 +98,7 @@ jobs:
             --output-dir release-assets
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: olt-cli-${{ env.VERSION }}-${{ matrix.os }}
           path: release-assets/*
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload release assets
         if: env.RELEASE_FOUND == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       actions: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain (Java)
         uses: ./.github/actions/setup-toolchain
@@ -52,14 +52,14 @@ jobs:
         run: cd lib/java && mvn jacoco:report
 
       - name: Upload JaCoCo artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: java-code-coverage
           path: |
             lib/java/openlinktoken/target/site/jacoco/*
 
       - name: Add Java code coverage to PR
-        uses: madrapps/jacoco-report@v1.7.1
+        uses: madrapps/jacoco-report@v1.8.0
         with:
           paths: |
             lib/java/openlinktoken/target/site/jacoco/jacoco.xml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain (Python)
         uses: ./.github/actions/setup-toolchain
@@ -111,7 +111,7 @@ jobs:
           PYTHONPATH=lib/python/openlinktoken/src/main pytest lib/python/openlinktoken/src/test --junitxml=lib/python/openlinktoken/test-results-${{ matrix.python-version }}.xml --cov=lib/python/openlinktoken/src/main --cov-report=xml:lib/python/openlinktoken/coverage.xml --cov-report=html:lib/python/openlinktoken/htmlcov
 
       - name: Upload Python coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-code-coverage-${{ matrix.python-version }}
           path: |
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload Python JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-junit-core-${{ matrix.python-version }}
           path: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: Add Python code coverage to PR
         if: matrix.python-version == '3.10'
-        uses: orgoro/coverage@v3.2
+        uses: orgoro/coverage@v3.3.1
         with:
           coverageFile: lib/python/openlinktoken/coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain (Python)
         uses: ./.github/actions/setup-toolchain
@@ -180,7 +180,7 @@ jobs:
           PYTHONPATH=lib/python/openlinktoken/src/main:lib/python/openlinktoken-cli/src/main pytest lib/python/openlinktoken-cli/src/test --junitxml=lib/python/openlinktoken-cli/test-results-${{ matrix.python-version }}.xml --cov=lib/python/openlinktoken-cli/src/main --cov-report=xml:lib/python/openlinktoken-cli/coverage.xml --cov-report=html:lib/python/openlinktoken-cli/htmlcov
 
       - name: Upload Python CLI coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-cli-code-coverage-${{ matrix.python-version }}
           path: |
@@ -189,7 +189,7 @@ jobs:
 
       - name: Upload Python CLI JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-junit-cli-${{ matrix.python-version }}
           path: |
@@ -260,7 +260,7 @@ jobs:
           - python-version: "3.14"
             spark-version: "3.5"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain (Python + Java for PySpark)
         uses: ./.github/actions/setup-toolchain
@@ -303,7 +303,7 @@ jobs:
 
       - name: Upload PySpark coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pyspark-code-coverage-${{ matrix.python-version }}-spark${{ matrix.spark-version }}
           path: |
@@ -312,7 +312,7 @@ jobs:
 
       - name: Upload PySpark JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-junit-pyspark-${{ matrix.python-version }}-spark${{ matrix.spark-version }}
           path: |
@@ -330,7 +330,7 @@ jobs:
 
       - name: Add PySpark code coverage to PR
         if: matrix.python-version == '3.10' && matrix.spark-version == '4.0'
-        uses: orgoro/coverage@v3.2
+        uses: orgoro/coverage@v3.3.1
         with:
           coverageFile: lib/python/openlinktoken-pyspark/coverage-${{ matrix.python-version }}-spark${{ matrix.spark-version }}.xml
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -350,7 +350,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download Python JUnit artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: python-junit-*
           path: test-results
@@ -459,7 +459,7 @@ jobs:
       - name: Upsert sticky Python test comment
         if: always() && steps.build-summary.outcome == 'success' && steps.build-summary.outputs.body != ''
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const commentMarker = '<!-- python-tests-sticky-comment -->';
@@ -525,7 +525,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup toolchain (Java + Python)
         uses: ./.github/actions/setup-toolchain
@@ -551,7 +551,7 @@ jobs:
 
       - name: Upload interoperability artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: interoperability-test-results
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set up Java 21 for Maven build
       - name: Setup toolchain (Java)

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up toolchain
         uses: ./.github/actions/setup-toolchain

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Install the cosign tool for signing images (only needed for releases)
       # https://github.com/sigstore/cosign-installer
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload Docker image details to release
         if: env.RELEASE_FOUND == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const version = '${{ env.VERSION }}';

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -45,12 +45,17 @@ jobs:
       RELEASE_ID: ${{ needs.release-info.outputs['release-id'] }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain (Java)
         uses: ./.github/actions/setup-toolchain
         with:
+          enable-java: true
           enable-python: false
+          central-username: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          central-password: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Build with Maven
         run: cd lib/java && mvn -B package --file pom.xml
@@ -76,9 +81,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Publish to Maven Central
+        run: |
+          cd lib/java/openlinktoken
+          mvn deploy \
+            -s "$GITHUB_WORKSPACE/settings.xml" \
+            -Pcentral-release \
+            -Dmaven.test.skip=true \
+            -B --file pom.xml
+        env:
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
       - name: Upload Maven artifacts to release
         if: env.RELEASE_FOUND == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -105,7 +123,7 @@ jobs:
                 releaseId = release.data.id;
                 console.log(`[DEBUG] Found release on second query with ID ${releaseId}`);
               } catch (error) {
-                console.log(`✗ No release found for tag ${tag}`);
+                console.log(`No release found for tag ${tag}`);
                 console.log(`[DEBUG] Error: ${error.message}`);
                 return;
               }
@@ -117,7 +135,7 @@ jobs:
               console.log(`[DEBUG] Processing artifact directory: ${artifactDir}`);
 
               if (!fs.existsSync(artifactDir)) {
-                console.log(`✗ No artifacts directory found at ${artifactDir}`);
+                console.log(`No artifacts directory found at ${artifactDir}`);
                 continue;
               }
 
@@ -141,10 +159,10 @@ jobs:
                     name: file,
                     data: fs.readFileSync(filePath)
                   });
-                  console.log(`✓ Successfully uploaded ${file}`);
+                  console.log(`Successfully uploaded ${file}`);
                   console.log(`[DEBUG] Asset ID: ${response.data.id}`);
                 } catch (error) {
-                  console.log(`✗ Error uploading ${file}: ${error.message}`);
+                  console.log(`Error uploading ${file}: ${error.message}`);
                   if (error.status) {
                     console.log(`[DEBUG] HTTP Status: ${error.status}`);
                   }

--- a/.github/workflows/multi-language-sync.yml
+++ b/.github/workflows/multi-language-sync.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Fetch full history for proper PR base comparison
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -88,7 +88,7 @@ jobs:
           exit 0
 
       - name: Create PR comment with progress tracking
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const syncReport = ${{ toJSON(steps.sync-check.outputs.SYNC_REPORT) }};

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,14 +29,11 @@ jobs:
       # Use manual input version if provided (add v prefix for tag format)
       release-tag: ${{ github.event.inputs.version && format('v{0}', github.event.inputs.version) || '' }}
 
-  build:
+  build_and_test:
     needs: release-info
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
-
+      contents: read
     env:
       VERSION: ${{ needs.release-info.outputs['version'] }}
       TAG: ${{ needs.release-info.outputs['tag'] }}
@@ -44,7 +41,7 @@ jobs:
       RELEASE_ID: ${{ needs.release-info.outputs['release-id'] }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain (Python only)
         uses: ./.github/actions/setup-toolchain
@@ -53,18 +50,25 @@ jobs:
           enable-python: true
           python-version: "3.10"
 
-      - name: Build openlinktoken distribution (wheel + sdist)
-        working-directory: lib/python/openlinktoken
-        run: uv build
+      - name: Install dependencies and run tests
+        run: |
+          # Install core package in editable mode for testing
+          uv pip install --break-system-packages --system -e lib/python/openlinktoken/
+          # Install requirements for everything including testing tools
+          uv pip install --break-system-packages --system -r lib/python/openlinktoken/requirements.txt \
+            pytest pytest-cov ruff
 
-      - name: Build openlinktoken-pyspark distribution (wheel + sdist)
-        working-directory: lib/python/openlinktoken-pyspark
-        run: uv build
+          # Run tests for core package
+          cd lib/python/openlinktoken
+          PYTHONPATH=src/main pytest src/test --junitxml=../test-results.xml --cov=src/main --cov-report=xml:coverage.xml
 
-      # PyPI publish steps removed per request (can be re-enabled later).
+      - name: Build distributions
+        run: |
+          (cd lib/python/openlinktoken && uv build -o dist/)
+          (cd lib/python/openlinktoken-pyspark && uv build -o dist/)
 
-      - name: Upload built distributions as workflow artifacts (for debugging)
-        uses: actions/upload-artifact@v4
+      - name: Upload Python artifacts
+        uses: actions/upload-artifact@v7
         with:
           name: python-packages-${{ env.TAG }}
           path: |
@@ -73,76 +77,27 @@ jobs:
             lib/python/openlinktoken-pyspark/dist/*.whl
             lib/python/openlinktoken-pyspark/dist/*.tar.gz
 
-      - name: Attach distributions to release
-        if: env.RELEASE_FOUND == 'true'
-        uses: actions/github-script@v7
+  publish_to_pypi:
+    needs: [release-info, build_and_test]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for PyPI Trusted Publishing (OIDC) — no API token needed
+      contents: read
+    steps:
+      - name: Download Python artifacts
+        uses: actions/download-artifact@v8
         with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
+          name: python-packages-${{ needs.release-info.outputs['tag'] }}
+          path: dist_temp
 
-            const tag = '${{ env.TAG }}';
-            const dirs = [
-              'lib/python/openlinktoken/dist',
-              'lib/python/openlinktoken-pyspark/dist'
-            ];
+      - name: Prepare Python distributions
+        run: |
+          mkdir -p dist
+          find dist_temp -type f \( -name '*.whl' -o -name '*.tar.gz' \) -exec cp {} dist/ \;
 
-            console.log(`[DEBUG] Starting Python artifact upload process`);
-            console.log(`[DEBUG] Tag: ${tag}`);
-
-            let releaseId = '${{ env.RELEASE_ID }}';
-            console.log(`[DEBUG] Initial releaseId: ${releaseId}`);
-
-            if (!releaseId) {
-              console.log(`[DEBUG] releaseId empty; querying release by tag ${tag}`);
-              try {
-                const release = await github.rest.repos.getReleaseByTag({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  tag: tag
-                });
-                releaseId = release.data.id;
-                console.log(`[DEBUG] Found release with ID ${releaseId}`);
-              } catch (error) {
-                console.log(`✗ No release found for tag ${tag}`);
-                console.log(`[DEBUG] Error: ${error.message}`);
-                return;
-              }
-            }
-
-            const files = [];
-            for (const d of dirs) {
-              if (!fs.existsSync(d)) {
-                console.log(`[DEBUG] Directory missing: ${d}`);
-                continue;
-              }
-              const found = fs.readdirSync(d).filter(f => (f.endsWith('.whl') || f.endsWith('.tar.gz')));
-              console.log(`[DEBUG] ${d} -> ${found.length} distributables`);
-              for (const f of found) files.push(path.join(d, f));
-            }
-
-            if (files.length === 0) {
-              console.log('✗ No Python artifacts found to upload');
-              return;
-            }
-
-            console.log(`[DEBUG] Uploading ${files.length} artifacts to release ID ${releaseId}`);
-            for (const filePath of files) {
-              try {
-                const name = path.basename(filePath);
-                const size = fs.statSync(filePath).size;
-                console.log(`[DEBUG] Uploading ${name} (${size} bytes)`);
-                const resp = await github.rest.repos.uploadReleaseAsset({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  release_id: releaseId,
-                  name,
-                  data: fs.readFileSync(filePath)
-                });
-                console.log(`✓ Uploaded ${name} (asset id ${resp.data.id})`);
-              } catch (error) {
-                console.log(`✗ Failed to upload ${filePath}: ${error.message}`);
-                if (error.status) console.log(`[DEBUG] HTTP Status: ${error.status}`);
-              }
-            }
-            console.log('[DEBUG] Python artifact upload complete');
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true

--- a/.github/workflows/release-context.yml
+++ b/.github/workflows/release-context.yml
@@ -41,7 +41,7 @@ jobs:
       release-id: ${{ steps.release-summary.outputs.release_id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/retarget-pr-to-develop.yml
+++ b/.github/workflows/retarget-pr-to-develop.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Retarget PR to develop
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/validate-pr-target.yml
+++ b/.github/workflows/validate-pr-target.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Validate PR is from release branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/docs/branch-workflow-and-release-process.md
+++ b/docs/branch-workflow-and-release-process.md
@@ -266,8 +266,13 @@ A: Repository admins can override branch protection, but it's strongly discourag
 
 ## Related Documentation
 
+- [Publishing Guide](./publishing-guide.md) - Automated Maven Central, PyPI, and Docker publishing workflows
 - [Branch Protection and Release Workflows](./branch-protection-and-release-workflows.md) - Admin setup instructions for branch protection
 - [Development Guide](./dev-guide-development.md) - Development environment setup and language-specific build instructions
-- Workflow files:
+- Publishing workflow files:
+  - `.github/workflows/python-publish.yml`
+  - `.github/workflows/maven-publish.yml`
+  - `.github/workflows/docker-publish.yml`
+- Release workflow files:
   - `.github/workflows/auto-version-bump.yml`
   - `.github/workflows/auto-release.yml`

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -1,0 +1,291 @@
+# Publishing OpenLinkToken to Maven Central and PyPI
+
+This guide documents the configuration required to publish OpenLinkToken artifacts to Maven Central (via the Sonatype Central Publisher Portal) and PyPI. It covers prerequisite accounts, repository secrets, Maven settings, and the automated GitHub Actions workflows that perform the actual publishing.
+
+---
+
+## Table of Contents
+
+1. [Publishing Overview](#publishing-overview)
+2. [Maven Central (Sonatype Central Publisher Portal)](#maven-central-sonatype-central-publisher-portal)
+3. [PyPI — Python Package Index](#pypi--python-package-index)
+4. [Publishing Triggers](#publishing-triggers)
+5. [Manual Publishing](#manual-publishing)
+6. [Troubleshooting](#troubleshooting)
+
+---
+
+## Publishing Overview
+
+OpenLinkToken artifacts are published to two primary registries via GitHub Actions:
+
+| Artifact                                     | Registry                                                   | Workflow                                                        |
+| -------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------- |
+| `openlinktoken` Java JAR + POM               | Maven Central (Central Publisher Portal) + GitHub Packages | [`maven-publish.yml`](../.github/workflows/maven-publish.yml)   |
+| `openlinktoken` Python wheel + sdist         | PyPI                                                       | [`python-publish.yml`](../.github/workflows/python-publish.yml) |
+| `openlinktoken-pyspark` Python wheel + sdist | PyPI                                                       | [`python-publish.yml`](../.github/workflows/python-publish.yml) |
+
+Both registries use **short-lived, workload-identity-based authentication** rather than long-lived static API tokens wherever the platform supports it:
+
+- **PyPI** uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) — GitHub Actions authenticates via OpenID Connect (OIDC); there is no PyPI API token stored as a secret.
+- **Maven Central** (via the Central Publisher Portal) still requires a Portal **user token** (username/password pair) plus a **GPG signing key**, since the Portal does not yet support OIDC. These are stored as repository secrets.
+
+### Prerequisites Checklist
+
+| Item                                                  | Required For                                                     | How to Configure                                                                                                                                                                                                                                                                       |
+| ----------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PyPI Trusted Publisher entry                          | PyPI publishing (`openlinktoken`, `openlinktoken-pyspark`)       | Configure on [pypi.org](https://pypi.org) per-project — **no GitHub secret needed**. See [PyPI section](#pypi--python-package-index) below.                                                                                                                                            |
+| `CENTRAL_PORTAL_USERNAME` / `CENTRAL_PORTAL_PASSWORD` | Maven Central publishing                                         | Generate a [Central Portal user token](https://central.sonatype.com/account) and add both values as [repository secrets](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enforcing-secure-settings/managing-secrets-for-your-dependency-stack) |
+| `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE`                  | Maven Central publishing (artifact signing, required by Central) | Generate a GPG key pair and add the base64-encoded armored private key and its passphrase as repository secrets. See [Maven Central section](#maven-central-sonatype-central-publisher-portal) below.                                                                                  |
+
+---
+
+## Maven Central (Sonatype Central Publisher Portal)
+
+### 1. Create a Central Publisher Portal Account and Namespace
+
+1. Register at [central.sonatype.com](https://central.sonatype.com/) (if you do not already have an account — existing OSSRH/JIRA accounts can sign in with the same credentials).
+2. Go to **Namespaces** and verify ownership of the `org.openlinktoken` namespace (via a DNS TXT record or GitHub repository verification, per the Portal's instructions).
+3. Once verified, you can publish any artifact under the `org.openlinktoken` group ID.
+
+### 2. Generate a Portal User Token
+
+1. Go to [central.sonatype.com/account](https://central.sonatype.com/account).
+2. Click **Generate User Token**.
+3. **Copy the username and password immediately** — the password is only shown once.
+
+> Legacy OSSRH JIRA credentials (`issues.sonatype.org`) **do not work** against the Portal — publishing with them returns `401 Unauthorized`. You must generate a new Portal user token.
+
+### 3. Generate a GPG Signing Key
+
+Maven Central requires every release artifact (JAR, POM, sources jar, javadoc jar) to be signed with GPG.
+
+```bash
+# Generate a new key (use a real name/email; a passphrase is strongly recommended)
+gpg --full-generate-key
+
+# List keys to get the key ID
+gpg --list-secret-keys --keyid-format LONG
+
+# Publish the public key so Central can verify signatures
+gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
+
+# Export the private key for use in CI (base64-encode so it survives as a GitHub secret)
+gpg --export-secret-keys --armor <KEY_ID> | base64 -w0 > gpg-private-key.b64
+```
+
+### 4. Add Repository Secrets
+
+Navigate to **Settings → Secrets and variables → Actions** in your GitHub repository. Add:
+
+| Secret Name               | Value                                              |
+| ------------------------- | -------------------------------------------------- |
+| `CENTRAL_PORTAL_USERNAME` | The Portal user token **username** from step 2     |
+| `CENTRAL_PORTAL_PASSWORD` | The Portal user token **password** from step 2     |
+| `GPG_PRIVATE_KEY`         | Contents of `gpg-private-key.b64` from step 3      |
+| `GPG_PASSPHRASE`          | The passphrase you set when generating the GPG key |
+
+### 5. How Authentication Is Wired Up in CI
+
+[`setup-toolchain/action.yml`](../.github/actions/setup-toolchain/action.yml) accepts `central-username`, `central-password`, `gpg-private-key`, and `gpg-passphrase` inputs. When Maven publishing needs them, `maven-publish.yml` passes the secrets in as inputs:
+
+```yaml
+- name: Setup toolchain (Java)
+  uses: ./.github/actions/setup-toolchain
+  with:
+    enable-java: true
+    enable-python: false
+    central-username: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+    central-password: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+    gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+    gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+```
+
+The composite action then:
+
+1. Lets `actions/setup-java@v4` generate `settings.xml` with the `github` server entry (for GitHub Packages).
+2. Inserts a `central` server entry (Portal user token) and a `gpg.passphrase` server entry into that same `settings.xml`, referencing environment variables that are supplied at `mvn deploy` time (never written to disk in plaintext).
+3. Imports the GPG private key into the runner's keyring with `gpg --batch --import`.
+
+The publish step in `maven-publish.yml` then runs:
+
+```yaml
+- name: Publish to Maven Central
+  run: |
+    cd lib/java
+    mvn deploy -s "$GITHUB_WORKSPACE/settings.xml" -Pcentral-release -Dmaven.test.skip=true -B --file pom.xml
+  env:
+    CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+    CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
+    GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+```
+
+The `-Pcentral-release` profile (defined in [`lib/java/pom.xml`](../lib/java/pom.xml)) activates the `central-publishing-maven-plugin`, attaches sources/javadoc jars, and signs all artifacts with `maven-gpg-plugin` — all scoped to this profile so a normal `mvn package`/`mvn deploy` (e.g. the separate "Publish to GitHub Packages Apache Maven" step) never requires a GPG key or Portal credentials.
+
+### 6. POM Configuration
+
+```xml
+<distributionManagement>
+    <repository>
+        <id>github</id>
+        <name>GitHub Packages</name>
+        <url>https://maven.pkg.github.com/TruvetaPublic/OpenLinkToken</url>
+    </repository>
+    <snapshotRepository>
+        <id>central</id>
+        <name>Central Portal Snapshot Repository</name>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
+</distributionManagement>
+```
+
+Note that Maven Central **releases** are not deployed via `distributionManagement` at all — the `central-publishing-maven-plugin` bundles and uploads artifacts directly to the Portal API when the `central-release` profile is active.
+
+---
+
+## PyPI — Python Package Index
+
+OpenLinkToken publishes to PyPI using **Trusted Publishing (OIDC)** — there is no PyPI API token stored anywhere in this repository. GitHub Actions presents a short-lived OIDC identity token scoped to this repository and workflow, and PyPI exchanges it for a temporary upload credential.
+
+### 1. Register a Trusted Publisher on PyPI
+
+This must be configured **once per PyPI project** (`openlinktoken` and `openlinktoken-pyspark` each need their own entry):
+
+1. Sign in at [pypi.org](https://pypi.org/) and go to the project's **Settings → Publishing** page (for a brand-new project that hasn't been published yet, use [pypi.org/manage/account/publishing](https://pypi.org/manage/account/publishing/) to pre-register a "pending" trusted publisher instead).
+2. Click **Add a new publisher** and choose **GitHub**.
+3. Fill in:
+
+   | Field             | Value                                                |
+   | ----------------- | ---------------------------------------------------- |
+   | PyPI Project Name | `openlinktoken` (repeat for `openlinktoken-pyspark`) |
+   | Owner             | `TruvetaPublic`                                      |
+   | Repository name   | `OpenLinkToken`                                      |
+   | Workflow name     | `python-publish.yml`                                 |
+   | Environment name  | `pypi`                                               |
+
+4. Save. No secret or token is generated or copied — PyPI now trusts OIDC tokens minted by this repository's `python-publish.yml` workflow when it runs under the `pypi` GitHub Environment.
+
+### 2. How Authentication Is Wired Up in CI
+
+The `publish_to_pypi` job in [`python-publish.yml`](../.github/workflows/python-publish.yml) declares:
+
+```yaml
+publish_to_pypi:
+  needs: [release-info, build_and_test]
+  runs-on: ubuntu-latest
+  environment: pypi
+  permissions:
+    id-token: write # required for PyPI Trusted Publishing (OIDC) — no API token needed
+    contents: read
+  steps:
+    - name: Download Python artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-packages-${{ needs.release-info.outputs['tag'] }}
+        path: dist_temp
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist_temp
+```
+
+`permissions: id-token: write` is what allows the job to request an OIDC token from GitHub's OIDC provider; `pypa/gh-action-pypi-publish` handles exchanging that token with PyPI automatically. There is no `password`, `user`, or token input to configure — adding one would be a sign something has regressed back to token-based auth.
+
+### 3. Verify on PyPI
+
+After publishing, verify the packages appear on PyPI:
+
+- <https://pypi.org/project/openlinktoken/>
+- <https://pypi.org/project/openlinktoken-pyspark/>
+
+---
+
+## Publishing Triggers
+
+Both `maven-publish.yml` and `python-publish.yml` are triggered by any of the following events:
+
+| Trigger                                 | Description                                                                        | Example                                                                                                                             |
+| --------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `release.created` / `release.published` | A GitHub Release is created or published                                           | After `auto-release.yml` creates tag `v2.0.0` and its release                                                                       |
+| `workflow_run` (completed)              | The "Create Release on Merge" workflow (`auto-release.yml`) completes successfully | Merging a `release/2.0.0` → `main` PR triggers `auto-release.yml`, which in turn fires `maven-publish.yml` and `python-publish.yml` |
+| `workflow_dispatch` (manual)            | A workflow manually triggered via the GitHub UI with a `version` input             | Clicking **Run workflow** in Actions tab                                                                                            |
+
+### Trigger Chain
+
+```
+release/2.x.x BRANCH PR MERGED -> main
+          |
+          v
+auto-release.yml (Create Release on Merge)
+          v
+    Creates GitHub Release tag v2.x.x
+          v
+maven-publish.yml + python-publish.yml (AUTOMATICALLY TRIGGERED)
+          v
+    Build -> Deploy -> Attach to Release
+```
+
+There is intentionally only **one** workflow per ecosystem watching for releases (`maven-publish.yml`, `python-publish.yml`). A tag-push-triggered `release.yml` workflow previously existed alongside `python-publish.yml` and would have double-published the same version to PyPI for every release; it has been removed in favor of this single trigger chain.
+
+---
+
+## Manual Publishing
+
+To publish a specific version manually:
+
+1. Navigate to **Actions → Maven Package** (or **Python Package**) in the GitHub UI.
+2. Click **Run workflow**.
+3. Select the `main` branch.
+4. Enter the version string (e.g., `2.0.0`).
+5. Click **Run workflow**.
+
+The workflow will:
+
+1. Check out the `main` branch.
+2. Read the version from the `release-context.yml` shared workflow.
+3. Build the package (`mvn package` for Maven; `uv build` for Python).
+4. Deploy to Maven Central + GitHub Packages, or to PyPI.
+5. Attach artifacts to the named release (Maven) or the workflow run (Python).
+
+---
+
+## Troubleshooting
+
+### Maven deploy fails with "401 Unauthorized"
+
+- Confirm `CENTRAL_PORTAL_USERNAME` / `CENTRAL_PORTAL_PASSWORD` are a **Central Portal user token** (from [central.sonatype.com/account](https://central.sonatype.com/account)), not a legacy OSSRH JIRA username/password — the old credentials are rejected by the Portal.
+- Verify `settings.xml` contains a `<server><id>central</id>...</server>` block (added by `setup-toolchain/action.yml`).
+
+### Maven deploy fails with "no signature" / "artifact not signed"
+
+- Confirm `GPG_PRIVATE_KEY` (base64-encoded, armored) and `GPG_PASSPHRASE` are set — the Central Publisher Portal rejects unsigned releases.
+- Confirm the `-Pcentral-release` profile is active on the deploy command; GPG signing only runs inside that profile.
+
+### Maven deploy fails with "Namespace not verified"
+
+- Verify the `org.openlinktoken` namespace ownership at [central.sonatype.com/publishing/namespaces](https://central.sonatype.com/publishing/namespaces).
+
+### PyPI upload fails with "invalid-publisher" or "no matching trusted publisher"
+
+- Re-check the Trusted Publisher entry on pypi.org: Owner (`TruvetaPublic`), Repository (`OpenLinkToken`), Workflow filename (`python-publish.yml`), and Environment name (`pypi`) must match exactly, including the environment the `publish_to_pypi` job declares.
+- Confirm the job has `permissions: id-token: write` — without it, no OIDC token is requested and the publish step fails before it even reaches PyPI.
+
+### PyPI upload returns `403 Forbidden`
+
+- This is expected if a Trusted Publisher has not been registered for the project yet, or was registered with mismatched repository/workflow/environment values — see above.
+- OpenLinkToken does not use a `PYPI_TOKEN` secret; if you see references to one, treat it as stale/incorrect documentation.
+
+### Artifacts not appearing in Maven Central after `mvn deploy -Pcentral-release`
+
+With `autoPublish: true` configured on `central-publishing-maven-plugin`, a successful `mvn deploy` publishes automatically once validation passes. If it doesn't appear:
+
+1. Navigate to [central.sonatype.com/publishing/deployments](https://central.sonatype.com/publishing/deployments).
+2. Check the deployment's validation status — failed validation (e.g., missing sources/javadoc jar, missing signature, invalid POM metadata) blocks publishing.
+3. The artifact typically appears on Maven Central within 10–30 minutes after a successful publish.
+
+### Artifacts not appearing in GitHub Packages
+
+- Check that the workflow ran successfully (`Actions → Maven Package`).
+- Verify the `GITHUB_TOKEN` permission includes `packages: write`.
+- Browse to <https://github.com/TruvetaPublic/OpenLinkToken/packages> to verify.

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/Attribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/Attribute.java
@@ -12,7 +12,7 @@ package org.openlinktoken.attributes;
  * An attribute has a name and a list of aliases. The name is the canonical name
  * of the attribute, while the aliases are alternative names that can be used to
  * refer to the attribute.
- * <p>
+ * </p>
  *
  * <p>
  * An attribute also has a normalization function that converts the attribute

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/BaseAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/BaseAttribute.java
@@ -20,7 +20,6 @@ import org.openlinktoken.attributes.validation.SerializableAttributeValidator;
  * <ul>
  * <li>Not null or empty</li>
  * </ul>
- * </p>
  */
 public abstract class BaseAttribute implements SerializableAttribute {
 

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/CanadianPostalCodeAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/CanadianPostalCodeAttribute.java
@@ -157,9 +157,9 @@ public class CanadianPostalCodeAttribute extends BaseAttribute {
      *
      * For Canadian postal codes:
      * - Codes shorter than minLength are rejected (return original)
-     * - 3-character format (e.g., "J1X") is padded with " 000" to create full format (e.g., "J1X 000") if minLength <= 3
-     * - 4-character format (e.g., "J1X 1") is padded with "A0" to create full format (e.g., "J1X 1A0") if minLength <= 4
-     * - 5-character format (e.g., "J1X 1A") is padded with "0" to create full format (e.g., "J1X 1A0") if minLength <= 5
+     * - 3-character format (e.g., "J1X") is padded with " 000" to create full format (e.g., "J1X 000") if minLength &lt;= 3
+     * - 4-character format (e.g., "J1X 1") is padded with "A0" to create full format (e.g., "J1X 1A0") if minLength &lt;= 4
+     * - 5-character format (e.g., "J1X 1A") is padded with "0" to create full format (e.g., "J1X 1A0") if minLength &lt;= 5
      * - 6-character format returns uppercase format with space (e.g., "k1a0a6" becomes "K1A 0A6")
      * If the input value is null or doesn't match Canadian postal pattern, the
      * original trimmed value is returned.

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/USPostalCodeAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/USPostalCodeAttribute.java
@@ -107,8 +107,8 @@ public class USPostalCodeAttribute extends BaseAttribute {
      *
      * For US ZIP codes:
      * - Codes shorter than minLength are rejected (return original)
-     * - 3-digit ZIP code (ZIP-3) is padded with "00" to create 5-digit format (e.g., "951" becomes "95100") if minLength <= 3
-     * - 4-digit ZIP code (ZIP-4) is padded with "0" to create 5-digit format (e.g., "1234" becomes "12340") if minLength <= 4
+     * - 3-digit ZIP code (ZIP-3) is padded with "00" to create 5-digit format (e.g., "951" becomes "95100") if minLength &lt;= 3
+     * - 4-digit ZIP code (ZIP-4) is padded with "0" to create 5-digit format (e.g., "1234" becomes "12340") if minLength &lt;= 4
      * - 5-digit or longer ZIP codes return the first 5 digits (e.g., "12345-6789" becomes "12345")
      * If the input value is null or doesn't match US ZIP pattern, the original
      * trimmed value is returned.

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -13,6 +13,26 @@
     <description>Open Link Token Parent POM - Privacy-preserving record linkage library</description>
     <url>https://truvetapublic.github.io/OpenLinkToken/</url>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <id>openlinktoken</id>
+            <name>Open Link Token Team</name>
+            <email>contact@openlinktoken.org</email>
+            <url>https://truvetapublic.github.io/OpenLinkToken/</url>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/TruvetaPublic/OpenLinkToken</url>
+        <connection>scm:git:git://github.com/TruvetaPublic/OpenLinkToken.git</connection>
+        <developerConnection>scm:git:git@github.com:TruvetaPublic/OpenLinkToken.git</developerConnection>
+    </scm>
     <modules>
         <module>openlinktoken</module>
     </modules>
@@ -23,12 +43,17 @@
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/TruvetaPublic/OpenLinkToken</url>
         </repository>
+        <snapshotRepository>
+            <id>central</id>
+            <name>Central Portal Snapshot Repository</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.deploy.skip>false</maven.deploy.skip>
         <maven.compiler.release>17</maven.compiler.release>
         <junit.jupiter.version>6.1.0</junit.jupiter.version>
         <surefire.plugin.version>3.5.6</surefire.plugin.version>
@@ -249,4 +274,78 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <!--
+            Activated explicitly (-Pcentral-release) only for the Maven Central deploy step in
+            maven-publish.yml. Kept out of the default build so that ordinary `mvn package`/`mvn
+            deploy` (GitHub Packages) runs never require a GPG key or Central Portal credentials.
+        -->
+        <profile>
+            <id>central-release</id>
+            <build>
+                <plugins>
+                    <!-- Publishes to Maven Central via the Central Publisher Portal -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                    <!-- Maven Central requires a sources jar for every release artifact -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Maven Central requires a javadoc jar for every release artifact -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Maven Central requires GPG-signed artifacts -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.7</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
…#396)

## Summary

- Fixes critical/high-severity bugs in the Maven Central and PyPI publishing setup.
- Migrates Maven Central publishing from decommissioned Sonatype OSSRH to the Central Publisher Portal with GPG signing.
- Fixes the release workflows so Java, Python, and PySpark artifacts build and publish reliably.

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [x] Java
- [x] Python
- [ ] CLI
- [x] PySpark
- [x] Docs / GitHub Pages
- [x] CI / workflows / agent instructions
- [x] Release process

## What changed

- `lib/java/pom.xml`: removed duplicate repository configuration and decommissioned OSSRH URLs; added the `central-release` profile with Central Publisher Portal, sources/javadocs, and GPG signing.
- `.github/actions/setup-toolchain/action.yml`: fixed invalid YAML/XML generation, safely injects Central/GPG credentials, accepts explicit composite-action inputs, and imports the GPG key.
- `.github/workflows/maven-publish.yml`: publishes the library module directly to Maven Central so `openlinktoken-parent` is not included in the Central bundle.
- `.github/workflows/python-publish.yml`: fixed job dependencies and publisher inputs; uses OIDC Trusted Publishing; builds with the correct `uv build --out-dir` option; isolates package-directory changes; flattens downloaded artifacts before publishing; and skips already-uploaded files on retries.
- Fixed JavaDoc doclint failures in attribute and postal-code documentation.
- Removed duplicate `.github/workflows/release.yml` publishing behavior.
- `docs/publishing-guide.md`: documents PyPI Trusted Publishing and Maven Central Portal/GPG setup, including required secrets.

## Follow-up required before publishing

- Verify the `org.openlinktoken` namespace in Sonatype Central Portal.
- Register PyPI Trusted Publishers for the exact projects `openlinktoken` and `openlinktoken-pyspark`, using the `pypi` environment and `.github/workflows/python-publish.yml`.
- Configure repository secrets: `CENTRAL_PORTAL_USERNAME`, `CENTRAL_PORTAL_PASSWORD`, `GPG_PRIVATE_KEY`, and `GPG_PASSPHRASE`.

---------

## Summary

- Briefly describe the user-visible or developer-visible change.
- Call out the main reason for the change or the problem it solves.

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [ ] Java
- [ ] Python
- [ ] CLI
- [ ] PySpark
- [ ] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Highlight the most important implementation changes.
- Note any intentional trade-offs or follow-up work.
