### PR TITLE
Release v2.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.1.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<prerelease>[0-9A-Za-z.-]+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{prerelease}
 	{major}.{minor}.{patch}
 commit = False

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -35,10 +35,6 @@ replace = "{new_version}"
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bumpversion:file:lib/python/openlinktoken-cli/requirements.txt]
-search = openlinktoken=={current_version}
-replace = openlinktoken=={new_version}
-
 [bumpversion:file:lib/python/openlinktoken-cli/pyproject.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -55,10 +55,6 @@ replace = __version__ = "{new_version}"
 search = {current_version}
 replace = {new_version}
 
-[bumpversion:file:lib/python/openlinktoken-cli/src/test/openlinktoken_cli/version_checker_test.py]
-search = {current_version}
-replace = {new_version}
-
 [bumpversion:file:lib/python/openlinktoken-pyspark/setup.py]
 search = {current_version}
 replace = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 2.1.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<prerelease>[0-9A-Za-z.-]+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{prerelease}
 	{major}.{minor}.{patch}
 commit = False
@@ -36,8 +36,8 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [bumpversion:file:lib/python/openlinktoken-cli/pyproject.toml]
-search = version = "{current_version}"
-replace = version = "{new_version}"
+search = "{current_version}"
+replace = "{new_version}"
 
 [bumpversion:file:lib/python/openlinktoken-cli/setup.py]
 search = "{current_version}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,10 @@ jobs:
           olt generate-key-pair --name recipient --force
           olt initiate-exchange --name smoke --public-key "$HOME/.openlinktoken/recipient.public.pem" --output target/smoke.exchange.json --hashingsecret "HashingKey"
           olt package -i ../../../resources/sample.csv -o target/output.csv --exchange-config target/smoke.exchange.json --private-key "$HOME/.openlinktoken/smoke.private.pem"
+          # Test custom tokenization config with standard data
+          olt package -i ../../../resources/sample.csv -o target/output-with-config.csv --exchange-config target/smoke.exchange.json --config ../../../resources/sample-custom-tokenization-config.yaml --private-key "$HOME/.openlinktoken/smoke.private.pem"
+          # Test custom tokenization config with nonstandard data
+          olt package -i ../../../resources/sample-nonstandard-input.csv -o target/output-nonstandard-with-config.csv --exchange-config target/smoke.exchange.json --config ../../../resources/sample-custom-tokenization-config-nonstandard.yaml --private-key "$HOME/.openlinktoken/smoke.private.pem"
 
       - name: Validate CLI output files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ coverage-*.xml
 htmlcov/
 htmlcov-*/
 test-results-*.xml
+test-output.xml
 tools/sync-report-*.json
 demos/pprl-superhero-example/outputs/
 demos/pprl-superhero-example/datasets/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Our approach to record linkage relies on building a set of matching tokens (or t
   - [Key Matching Ideas](#key-matching-ideas)
   - [Running Open Link Token](#running-open-link-token)
   - [Security Notes](#security-notes)
+  - [Custom Tokenization Configuration](#custom-tokenization-configuration)
   - [Contributing \& Community](#contributing--community)
   - [Documentation](#documentation)
 
@@ -132,8 +133,8 @@ See <a href="https://truvetapublic.github.io/OpenLinkToken/quickstarts/" target=
 
 ## Running Open Link Token
 
-- **CLI subcommands** (`olt` binary or Docker convenience scripts):
-  - `tokenize` - Internal hashed token generation (`--mode hash-only` is available for deterministic SHA-256 output)
+- **Subcommand Interface**: Modern command-based interface:
+  - `tokenize` - Internal hashed token generation (`--mode hash-only` is available for deterministic SHA-256 output; `--config` is available for custom field mapping and token rules)
   - `encrypt` - Encrypt existing hashed tokens
   - `decrypt` - Decrypt encrypted tokens
   - `package` - Tokenize + encrypt in one step (recommended)
@@ -149,6 +150,12 @@ See <a href="https://truvetapublic.github.io/OpenLinkToken/quickstarts/" target=
 - **`tokenize --mode hash-only`**: Deterministic SHA-256 output with no exchange config or secret. Useful for local exploration, but **not** for production or cross-organisation exchange
 - **Secret management**: Handle hashing/encryption secrets securely; avoid committing secrets; prefer env/secret stores
 - **Validation**: Reject placeholders and malformed attributes before tokenization
+
+## Custom Tokenization Configuration
+
+For `tokenize --config` usage, example input/config files, and the full configuration-file specification, see:
+
+- <a href="https://truvetapublic.github.io/OpenLinkToken/reference/tokenization-config.html" target="_blank" rel="noopener noreferrer">Tokenization Configuration Reference</a>
 
 ## Contributing & Community
 

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -248,7 +248,7 @@ If you also want the same ZIP and checksum bundle produced by the release workfl
 
 ```shell
 python -m openlinktoken_cli.util.release_assets \
-  --version 2.0.0 \
+  --version 2.1.0 \
   --runner-os Linux \
   --dist-dir dist \
   --output-dir release-assets

--- a/docs/tokenization-config-format.md
+++ b/docs/tokenization-config-format.md
@@ -18,7 +18,7 @@ olt tokenize \
 ## Example Input (Unusual Fields)
 
 ```csv
-member_id,given_nm,surname_txt,dob_iso,gender_code,zip_5,national_id
+member_id,given nm,surname_txt,dob_iso,gender_code,zip_5,national_id
 A-1001,Ana,Lopez,1988-03-12,F,98052,123-45-6789
 A-1002,Marcus,Nguyen,1979-11-05,M,10001,234-56-7890
 ```
@@ -26,27 +26,27 @@ A-1002,Marcus,Nguyen,1979-11-05,M,10001,234-56-7890
 ## Example Configuration File
 
 ```yaml
-attributes:
-  member_id:
-    field: RecordId
+column_mappings:
+  RecordId:
+    column_name: "member_id"
     type: RecordId
-  given_nm:
-    field: GivenName
+  GivenName:
+    column_name: "given nm"
     type: FirstName
-  surname_txt:
-    field: FamilyName
+  FamilyName:
+    column_name: "surname_txt"
     type: LastName
-  dob_iso:
-    field: DateOfBirth
+  DateOfBirth:
+    column_name: "dob_iso"
     type: BirthDate
-  gender_code:
-    field: SexAtBirth
+  SexAtBirth:
+    column_name: "gender_code"
     type: Sex
-  zip_5:
-    field: HomeZip
+  HomeZip:
+    column_name: "zip_5"
     type: PostalCode
-  national_id:
-    field: NationalId
+  NationalId:
+    column_name: "national_id"
     type: SocialSecurityNumber
 
 token_rules:
@@ -65,35 +65,35 @@ token_rules:
 
 Top-level keys:
 
-| Key           | Required | Type    | Description                                                                  |
-| ------------- | -------- | ------- | ---------------------------------------------------------------------------- |
-| `attributes`  | Yes      | Mapping | Maps input column names to logical field IDs and attribute types.            |
-| `token_rules` | Yes      | Mapping | Defines each token rule as an ordered list of `{field, expression}` entries. |
+| Key               | Required | Type    | Description                                                                  |
+| ----------------- | -------- | ------- | ---------------------------------------------------------------------------- |
+| `column_mappings` | Yes      | Mapping | Maps logical field IDs to source column names and attribute types.           |
+| `token_rules`     | Yes      | Mapping | Defines each token rule as an ordered list of `{field, expression}` entries. |
 
-`attributes` entry schema:
+`column_mappings` entry schema:
 
-| Field           | Required | Type    | Description                                                                                            |
-| --------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `<column_name>` | Yes      | Mapping | Input column name from the CSV or Parquet schema (for example `given_nm`).                             |
-| `field`         | Yes      | String  | Logical field identifier used by token rules (for example `FirstName`).                                |
-| `type`          | Yes      | String  | Open Link Token attribute type/alias. See [Attribute Types](#attribute-types) for all accepted values. |
+| Field         | Required | Type    | Description                                                                                      |
+| ------------- | -------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `<field_id>`  | Yes      | Mapping | Logical field identifier used by token rules (for example `GivenName`).                          |
+| `column_name` | Yes      | String  | Source column name in the CSV or Parquet file (for example `"given_nm"`).                        |
+| `type`        | Yes      | String  | Open Link Token attribute type. See [Attribute Types](#attribute-types) for all accepted values. |
 
 `token_rules` entry schema:
 
 | Field        | Required | Type   | Description                                                                                                |
 | ------------ | -------- | ------ | ---------------------------------------------------------------------------------------------------------- |
 | `<rule_id>`  | Yes      | List   | Token rule identifier (`T1`, `T2`, `T3`, `T4`, `T5`, or custom).                                           |
-| `field`      | Yes      | String | Must match one of the `attributes.*.field` values.                                                         |
+| `field`      | Yes      | String | Must match one of the `column_mappings` field IDs.                                                         |
 | `expression` | Yes      | String | Attribute-expression pipeline used by token generation. See [Expression syntax](#expression-syntax) below. |
 
 ## Validation Rules
 
 Validation enforced by the CLI:
 
-- `attributes` must be present and non-empty.
+- `column_mappings` must be present and non-empty.
 - `token_rules` must be present and non-empty.
 - Every token-rule entry must contain non-empty `field` and `expression`.
-- Every token-rule `field` must reference a declared `attributes.*.field` value.
+- Every token-rule `field` must reference a declared `column_mappings` field ID.
 - Every declared `type` must resolve to a known Open Link Token attribute class/alias.
 - Token-rule entry order is preserved and used as-is during token construction.
 

--- a/docs/tokenization-config-format.md
+++ b/docs/tokenization-config-format.md
@@ -1,0 +1,129 @@
+# Tokenization Configuration Format
+
+## Overview
+
+`tokenize --config` lets you map non-standard input column names to Open Link Token attribute types and define token rules explicitly.
+
+Use this when source data does not use built-in aliases (for example `given_nm` instead of `FirstName`) or when custom token rules are required.
+
+## Example Command
+
+```bash
+olt tokenize \
+  -i unusual-input.csv -o output.csv \
+  --exchange-config ./partner.exchange.json \
+  --config ./tokenization-config.yaml
+```
+
+## Example Input (Unusual Fields)
+
+```csv
+member_id,given_nm,surname_txt,dob_iso,gender_code,zip_5,national_id
+A-1001,Ana,Lopez,1988-03-12,F,98052,123-45-6789
+A-1002,Marcus,Nguyen,1979-11-05,M,10001,234-56-7890
+```
+
+## Example Configuration File
+
+```yaml
+attributes:
+  member_id:
+    field: RecordId
+    type: RecordId
+  given_nm:
+    field: GivenName
+    type: FirstName
+  surname_txt:
+    field: FamilyName
+    type: LastName
+  dob_iso:
+    field: DateOfBirth
+    type: BirthDate
+  gender_code:
+    field: SexAtBirth
+    type: Sex
+  zip_5:
+    field: HomeZip
+    type: PostalCode
+  national_id:
+    field: NationalId
+    type: SocialSecurityNumber
+
+token_rules:
+  T1:
+    - field: FamilyName
+      expression: T|U
+    - field: GivenName
+      expression: T|S(0,1)|U
+    - field: DateOfBirth
+      expression: T|D
+    - field: SexAtBirth
+      expression: T|S(0,1)|U
+```
+
+## File Specification
+
+Top-level keys:
+
+| Key           | Required | Type    | Description                                                                  |
+| ------------- | -------- | ------- | ---------------------------------------------------------------------------- |
+| `attributes`  | Yes      | Mapping | Maps input column names to logical field IDs and attribute types.            |
+| `token_rules` | Yes      | Mapping | Defines each token rule as an ordered list of `{field, expression}` entries. |
+
+`attributes` entry schema:
+
+| Field           | Required | Type    | Description                                                                                            |
+| --------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `<column_name>` | Yes      | Mapping | Input column name from the CSV or Parquet schema (for example `given_nm`).                             |
+| `field`         | Yes      | String  | Logical field identifier used by token rules (for example `FirstName`).                                |
+| `type`          | Yes      | String  | Open Link Token attribute type/alias. See [Attribute Types](#attribute-types) for all accepted values. |
+
+`token_rules` entry schema:
+
+| Field        | Required | Type   | Description                                                                                                |
+| ------------ | -------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| `<rule_id>`  | Yes      | List   | Token rule identifier (`T1`, `T2`, `T3`, `T4`, `T5`, or custom).                                           |
+| `field`      | Yes      | String | Must match one of the `attributes.*.field` values.                                                         |
+| `expression` | Yes      | String | Attribute-expression pipeline used by token generation. See [Expression syntax](#expression-syntax) below. |
+
+## Validation Rules
+
+Validation enforced by the CLI:
+
+- `attributes` must be present and non-empty.
+- `token_rules` must be present and non-empty.
+- Every token-rule entry must contain non-empty `field` and `expression`.
+- Every token-rule `field` must reference a declared `attributes.*.field` value.
+- Every declared `type` must resolve to a known Open Link Token attribute class/alias.
+- Token-rule entry order is preserved and used as-is during token construction.
+
+> **Note:** `expression` values are not validated at config-load time. An unknown operator (for example `Y` instead of `D`) will raise a `ValueError` per row during token generation, not at startup.
+
+## Expression Syntax
+
+See [Expression Syntax](../pages/concepts/token-rules.md#expression-syntax) in the Token Rules concept page.
+
+## Notes
+
+- `--config` works with `tokenize` for both CSV and Parquet input.
+- Built-in aliases continue to work when `--config` is omitted.
+
+## Attribute Types
+
+Accepted values for the field `type`. Each type applies its own normalization and validation rules — see [Normalization and Validation](../concepts/normalization-and-validation). |
+
+| `type` value           | Description                    |
+| ---------------------- | ------------------------------ |
+| `Age`                  | Age (numeric)                  |
+| `BirthDate`            | Date of birth                  |
+| `BirthYear`            | Year of birth                  |
+| `Date`                 | Generic date                   |
+| `Decimal`              | Decimal number                 |
+| `FirstName`            | Given / first name             |
+| `Integer`              | Integer number                 |
+| `LastName`             | Family / last name             |
+| `PostalCode`           | Postal or ZIP code             |
+| `Sex`                  | Biological sex                 |
+| `SocialSecurityNumber` | National identification number |
+| `String`               | Generic string                 |
+| `Year`                 | Generic year                   |

--- a/lib/java/openlinktoken/pom.xml
+++ b/lib/java/openlinktoken/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.openlinktoken</groupId>
         <artifactId>openlinktoken-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>openlinktoken</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <name>openlinktoken</name>
     <description>Open Link Token Core Library - Privacy-preserving record linkage using cryptographically secure token generation</description>

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/Metadata.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/Metadata.java
@@ -23,7 +23,7 @@ public class Metadata {
     public static final String METADATA_FILE_EXTENSION = ".metadata.json";
     public static final String SYSTEM_JAVA_VERSION = System.getProperty("java.version");
 
-    public static final String DEFAULT_VERSION = "2.0.0";
+    public static final String DEFAULT_VERSION = "2.1.0";
 
     // Output format values
     public static final String OUTPUT_FORMAT_JSON = "JSON";

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/AttributeExpression.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/AttributeExpression.java
@@ -12,7 +12,6 @@ import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.lang3.time.DateUtils;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -43,7 +42,6 @@ import lombok.Setter;
  * matches the regular expression.</li>
  * </ul>
  */
-@AllArgsConstructor
 @Getter
 @Setter
 public final class AttributeExpression implements Serializable {
@@ -53,7 +51,35 @@ public final class AttributeExpression implements Serializable {
             .compile("\\s*(?<expr>[^ (]+)(?:\\((?<args>[^\\)]+)\\))?");
 
     private Class<? extends Attribute> attributeClass;
+    private String fieldId;
     private String expressions;
+
+    /**
+     * Creates an attribute expression using an attribute class as the field identity.
+     *
+     * @param attributeClass the attribute class (used as both identity and behavior)
+     * @param expressions    the expression pipeline string
+     * @deprecated Use {@link #AttributeExpression(String, Class, String)} instead.
+     */
+    @Deprecated(since = "2.1.0", forRemoval = false)
+    public AttributeExpression(Class<? extends Attribute> attributeClass, String expressions) {
+        this.attributeClass = attributeClass;
+        this.expressions = expressions;
+        this.fieldId = null;
+    }
+
+    /**
+     * Creates an attribute expression using a field ID for identity and an attribute class for behavior.
+     *
+     * @param fieldId        unique field identifier from the FieldRegistry
+     * @param attributeClass the attribute class providing normalization and validation
+     * @param expressions    the expression pipeline string
+     */
+    public AttributeExpression(String fieldId, Class<? extends Attribute> attributeClass, String expressions) {
+        this.fieldId = fieldId;
+        this.attributeClass = attributeClass;
+        this.expressions = expressions;
+    }
 
     /**
      * Get the effective value for an attribute after application

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/AttributeField.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/AttributeField.java
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.attributes;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import lombok.Getter;
+
+/**
+ * Represents a named field slot in a person record.
+ *
+ * <p>
+ * An {@code AttributeField} separates two concerns that were previously conflated:
+ * <ul>
+ *   <li><b>Field identity</b> — "which value from the person record?" (the {@code fieldId})</li>
+ *   <li><b>Attribute behavior</b> — "how to normalize/validate?" (the {@code attributeClass})</li>
+ * </ul>
+ *
+ * <p>
+ * This allows multiple fields to share the same attribute type (e.g., two fields both using
+ * {@code StringAttribute} normalization) while remaining distinct keys in the person attributes map.
+ */
+@Getter
+public final class AttributeField implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String fieldId;
+    private final Class<? extends Attribute> attributeClass;
+
+    /**
+     * Creates an attribute field with the given identity and attribute type.
+     *
+     * @param fieldId        unique field identifier (e.g., "LastName", "MotherLastName")
+     * @param attributeClass the attribute class providing normalization and validation behavior
+     */
+    public AttributeField(String fieldId, Class<? extends Attribute> attributeClass) {
+        this.fieldId = Objects.requireNonNull(fieldId, "fieldId must not be null");
+        this.attributeClass = Objects.requireNonNull(attributeClass, "attributeClass must not be null");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AttributeField other)) {
+            return false;
+        }
+        return fieldId.equals(other.fieldId);
+    }
+
+    @Override
+    public int hashCode() {
+        return fieldId.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "AttributeField{fieldId='" + fieldId + "', attributeClass=" + attributeClass.getSimpleName() + "}";
+    }
+}

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/FieldRegistry.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/FieldRegistry.java
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.attributes;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Registry mapping field identifiers to their corresponding {@link Attribute} instances.
+ *
+ * <p>
+ * The {@code FieldRegistry} is the resolution layer that connects field identifiers
+ * (string keys used in person-attribute maps) to the attribute instances that provide
+ * normalization and validation behavior.
+ *
+ * <p>
+ * Built-in attributes are auto-registered using their canonical name as the field ID.
+ * Config-driven fields can register additional mappings (e.g., "MotherLastName" → StringAttribute).
+ */
+public final class FieldRegistry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, AttributeField> fields;
+    private final Map<String, Attribute> fieldToAttribute;
+
+    private FieldRegistry(Map<String, AttributeField> fields, Map<String, Attribute> fieldToAttribute) {
+        this.fields = Collections.unmodifiableMap(new HashMap<>(fields));
+        this.fieldToAttribute = Collections.unmodifiableMap(new HashMap<>(fieldToAttribute));
+    }
+
+    /**
+     * Creates a default registry populated with all built-in attributes.
+     *
+     * <p>
+     * Each attribute is registered using its canonical name (from {@link Attribute#getName()})
+     * as the field ID.
+     *
+     * @return a new registry with built-in attribute registrations
+     */
+    public static FieldRegistry createDefault() {
+        var builder = new Builder();
+        for (Attribute attribute : AttributeLoader.load()) {
+            builder.register(attribute.getName(), attribute.getClass(), attribute);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Resolves the attribute instance for a given field ID.
+     *
+     * @param fieldId the field identifier
+     * @return an Optional containing the attribute if registered, empty otherwise
+     */
+    public Optional<Attribute> getAttribute(String fieldId) {
+        return Optional.ofNullable(fieldToAttribute.get(fieldId));
+    }
+
+    /**
+     * Resolves the attribute field definition for a given field ID.
+     *
+     * @param fieldId the field identifier
+     * @return an Optional containing the AttributeField if registered, empty otherwise
+     */
+    public Optional<AttributeField> getField(String fieldId) {
+        return Optional.ofNullable(fields.get(fieldId));
+    }
+
+    /**
+     * Returns all registered field IDs.
+     *
+     * @return an unmodifiable set of field identifiers
+     */
+    public Set<String> getFieldIds() {
+        return fields.keySet();
+    }
+
+    /**
+     * Returns the number of registered fields.
+     *
+     * @return the registry size
+     */
+    public int size() {
+        return fields.size();
+    }
+
+    /**
+     * Builder for constructing a {@link FieldRegistry} with custom registrations.
+     */
+    public static final class Builder {
+
+        private final Map<String, AttributeField> fields = new HashMap<>();
+        private final Map<String, Attribute> fieldToAttribute = new HashMap<>();
+
+        public Builder() {
+        }
+
+        /**
+         * Creates a builder pre-populated with all built-in attribute registrations.
+         *
+         * @return a new builder with defaults loaded
+         */
+        public static Builder fromDefaults() {
+            var builder = new Builder();
+            for (Attribute attribute : AttributeLoader.load()) {
+                builder.register(attribute.getName(), attribute.getClass(), attribute);
+            }
+            return builder;
+        }
+
+        /**
+         * Registers a field ID with its attribute class and instance.
+         *
+         * @param fieldId        the unique field identifier
+         * @param attributeClass the attribute class providing behavior
+         * @param attribute      the attribute instance for normalization/validation
+         * @return this builder for chaining
+         */
+        public Builder register(String fieldId, Class<? extends Attribute> attributeClass, Attribute attribute) {
+            fields.put(fieldId, new AttributeField(fieldId, attributeClass));
+            fieldToAttribute.put(fieldId, attribute);
+            return this;
+        }
+
+        /**
+         * Builds an immutable {@link FieldRegistry} from the current registrations.
+         *
+         * @return the constructed registry
+         */
+        public FieldRegistry build() {
+            return new FieldRegistry(fields, fieldToAttribute);
+        }
+    }
+}

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/TokenGenerator.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/TokenGenerator.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.openlinktoken.attributes.Attribute;
 import org.openlinktoken.attributes.AttributeExpression;
 import org.openlinktoken.attributes.AttributeLoader;
+import org.openlinktoken.attributes.FieldRegistry;
 import org.openlinktoken.tokens.tokenizer.SHA256Tokenizer;
 import org.openlinktoken.tokens.tokenizer.Tokenizer;
 import org.openlinktoken.tokens.tokenizer.PassthroughTokenizer;
@@ -38,6 +39,7 @@ public class TokenGenerator implements Serializable {
     private BaseTokenDefinition tokenDefinition;
 
     private Map<Class<? extends Attribute>, Attribute> attributeInstanceMap;
+    private FieldRegistry fieldRegistry;
 
     /**
      * Initializes the token generator.
@@ -64,6 +66,22 @@ public class TokenGenerator implements Serializable {
         this.attributeInstanceMap = new HashMap<>();
         AttributeLoader.load().forEach(attribute -> attributeInstanceMap.put(attribute.getClass(), attribute));
         this.tokenizer = tokenizer;
+        this.fieldRegistry = FieldRegistry.createDefault();
+    }
+
+    /**
+     * Initializes the token generator with a custom field registry.
+     *
+     * @param tokenDefinition the token definition.
+     * @param tokenizer       the tokenizer implementation.
+     * @param fieldRegistry   custom field registry for field-ID-based lookups.
+     */
+    public TokenGenerator(BaseTokenDefinition tokenDefinition, Tokenizer tokenizer, FieldRegistry fieldRegistry) {
+        this.tokenDefinition = tokenDefinition;
+        this.attributeInstanceMap = new HashMap<>();
+        AttributeLoader.load().forEach(attribute -> attributeInstanceMap.put(attribute.getClass(), attribute));
+        this.tokenizer = tokenizer;
+        this.fieldRegistry = fieldRegistry;
     }
 
     /*
@@ -81,6 +99,7 @@ public class TokenGenerator implements Serializable {
      * @return the token signature using the token definition for the given token
      * identifier.
      */
+    @Deprecated(since = "2.1.0", forRemoval = false)
     protected String getTokenSignature(String tokenId, Map<Class<? extends Attribute>, String> personAttributes,
             TokenGeneratorResult result) {
         var definition = tokenDefinition.getTokenDefinition(tokenId);
@@ -125,7 +144,9 @@ public class TokenGenerator implements Serializable {
      * @param personAttributes the person attributes map.
      *
      * @return A map of token/rule identifier to the token signature.
+     * @deprecated Use {@link #getAllTokenSignaturesViaFieldId(Map)} instead.
      */
+    @Deprecated(since = "2.1.0", forRemoval = false)
     public Map<String, String> getAllTokenSignatures(Map<Class<? extends Attribute>, String> personAttributes) {
         var signatures = new HashMap<String, String>();
         for (String tokenId : tokenDefinition.getTokenIdentifiers()) {
@@ -154,6 +175,7 @@ public class TokenGenerator implements Serializable {
      *
      * @throws TokenGenerationException in case of failure to generate the token.
      */
+    @Deprecated(since = "2.1.0", forRemoval = false)
     protected String getToken(String tokenId, Map<Class<? extends Attribute>, String> personAttributes,
             TokenGeneratorResult result)
             throws TokenGenerationException {
@@ -175,11 +197,13 @@ public class TokenGenerator implements Serializable {
     /**
      * Get the tokens for all token/rule identifiers.
      *
-     * @param personAttributes the person attributes map.
+     * @param personAttributes the person attributes map, keyed by attribute class.
      *
      * @return A {@link TokenGeneratorResult} object containing the tokens and
      *         invalid attributes.
+     * @deprecated Use {@link #getAllTokensViaFieldId(Map)} with a field-ID-keyed map instead.
      */
+    @Deprecated(since = "2.1.0", forRemoval = false)
     public TokenGeneratorResult getAllTokens(Map<Class<? extends Attribute>, String> personAttributes) {
         TokenGeneratorResult result = new TokenGeneratorResult();
 
@@ -200,10 +224,12 @@ public class TokenGenerator implements Serializable {
     /**
      * Get invalid person attribute names.
      *
-     * @param personAttributes the person attributes map.
+     * @param personAttributes the person attributes map, keyed by attribute class.
      *
      * @return A set of invalid person attribute names.
+     * @deprecated Use field-ID-keyed person attributes with {@link #getAllTokensViaFieldId(Map)} instead.
      */
+    @Deprecated(since = "2.1.0", forRemoval = false)
     public Set<String> getInvalidPersonAttributes(Map<Class<? extends Attribute>, String> personAttributes) {
         var response = new HashSet<String>();
 
@@ -214,5 +240,135 @@ public class TokenGenerator implements Serializable {
         }
 
         return response;
+    }
+
+    // ===== Primary API =====
+
+    /**
+     * Get the token signature for a given token identifier.
+     *
+     * @param tokenId          the token identifier.
+     * @param personAttributes person attributes keyed by field ID (e.g., "LastName" → "Smith").
+     * @param result           the token generator result.
+     *
+     * @return the token signature, or null if required fields are missing or invalid.
+     */
+    protected String getTokenSignatureViaFieldId(String tokenId, Map<String, String> personAttributes,
+            TokenGeneratorResult result) {
+        var definition = tokenDefinition.getTokenDefinition(tokenId);
+        if (personAttributes == null) {
+            throw new IllegalArgumentException("Person attributes cannot be null.");
+        }
+
+        var values = new ArrayList<String>(definition.size());
+
+        for (AttributeExpression attributeExpression : definition) {
+            String resolvedFieldId = resolveFieldId(attributeExpression);
+            if (resolvedFieldId == null || !personAttributes.containsKey(resolvedFieldId)) {
+                return null;
+            }
+
+            var attribute = resolveAttribute(attributeExpression, resolvedFieldId);
+            if (attribute == null) {
+                return null;
+            }
+
+            String attributeValue = personAttributes.get(resolvedFieldId);
+            if (!attribute.validate(attributeValue)) {
+                result.getInvalidAttributes().add(attribute.getName());
+                return null;
+            }
+
+            attributeValue = attribute.normalize(attributeValue);
+
+            try {
+                attributeValue = attributeExpression.getEffectiveValue(attributeValue);
+                values.add(attributeValue);
+            } catch (IllegalArgumentException e) {
+                logger.error(e.getMessage());
+                return null;
+            }
+        }
+
+        return Stream.of(values.toArray(new String[0])).filter(s -> null != s && !s.isBlank())
+                .collect(Collectors.joining("|"));
+    }
+
+    /**
+     * Get the tokens for all token/rule identifiers.
+     *
+     * <p>
+     * This is the preferred API. It natively supports multiple fields sharing the same
+     * attribute type (e.g., "MotherLastName" and "FatherLastName" both backed by StringAttribute).
+     *
+     * @param personAttributes person attributes keyed by field ID (e.g., "LastName" → "Smith").
+     *
+     * @return A {@link TokenGeneratorResult} object containing the tokens and invalid attributes.
+     */
+    public TokenGeneratorResult getAllTokensViaFieldId(Map<String, String> personAttributes) {
+        TokenGeneratorResult result = new TokenGeneratorResult();
+
+        for (String tokenId : tokenDefinition.getTokenIdentifiers()) {
+            try {
+                var signature = getTokenSignatureViaFieldId(tokenId, personAttributes, result);
+                logger.debug("Token signature for token id {}: {}", tokenId, signature);
+                try {
+                    String token = tokenizer.tokenize(signature);
+                    if (Token.BLANK.equals(token)) {
+                        result.getBlankTokensByRule().add(tokenId);
+                    }
+                    if (token != null) {
+                        result.getTokens().put(tokenId, token);
+                    }
+                } catch (Exception e) {
+                    logger.error("Error generating token for token id: " + tokenId, e);
+                }
+            } catch (Exception e) {
+                logger.error("Error generating token for token id: " + tokenId, e);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Get the token signatures for all token/rule identifiers. Mostly useful for debugging.
+     *
+     * @param personAttributes person attributes keyed by field ID.
+     *
+     * @return A map of token/rule identifier to the token signature.
+     */
+    public Map<String, String> getAllTokenSignaturesViaFieldId(Map<String, String> personAttributes) {
+        var signatures = new HashMap<String, String>();
+        for (String tokenId : tokenDefinition.getTokenIdentifiers()) {
+            try {
+                var signature = getTokenSignatureViaFieldId(tokenId, personAttributes, new TokenGeneratorResult());
+                if (signature != null) {
+                    signatures.put(tokenId, signature);
+                }
+            } catch (Exception e) {
+                logger.error("Error generating token signature for token id: " + tokenId, e);
+            }
+        }
+        return signatures;
+    }
+
+    private String resolveFieldId(AttributeExpression expression) {
+        if (expression.getFieldId() != null) {
+            return expression.getFieldId();
+        }
+        // Legacy fallback: derive field ID from attribute class name
+        var attribute = attributeInstanceMap.get(expression.getAttributeClass());
+        return attribute != null ? attribute.getName() : null;
+    }
+
+    private Attribute resolveAttribute(AttributeExpression expression, String resolvedFieldId) {
+        // Try field registry first
+        var fromRegistry = fieldRegistry.getAttribute(resolvedFieldId);
+        if (fromRegistry.isPresent()) {
+            return fromRegistry.get();
+        }
+        // Fallback to class-based lookup
+        return attributeInstanceMap.get(expression.getAttributeClass());
     }
 }

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/FieldIds.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/FieldIds.java
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.tokens.definitions;
+
+import org.openlinktoken.attributes.AttributeExpression;
+
+/**
+ * Enumerates the field identifiers referenced by the built-in T1-T5 token definitions.
+ *
+ * <p>
+ * Centralizing these values avoids duplicating the same field-id strings across
+ * multiple token definition classes.
+ *
+ * @see AttributeExpression
+ */
+public enum FieldIds {
+    LAST_NAME("LastName"),
+    FIRST_NAME("FirstName"),
+    SEX("Sex"),
+    BIRTH_DATE("BirthDate"),
+    POSTAL_CODE("PostalCode"),
+    SOCIAL_SECURITY_NUMBER("SocialSecurityNumber");
+
+    private final String fieldId;
+
+    FieldIds(String fieldId) {
+        this.fieldId = fieldId;
+    }
+
+    /**
+     * Returns the field identifier string used to key person attributes.
+     *
+     * @return the field id
+     */
+    public String getFieldId() {
+        return fieldId;
+    }
+}

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T1Token.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T1Token.java
@@ -28,10 +28,11 @@ public class T1Token implements Token {
     private final ArrayList<AttributeExpression> definition = new ArrayList<>();
 
     public T1Token() {
-        definition.add(new AttributeExpression(LastNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(FirstNameAttribute.class, "T|S(0,1)|U"));
-        definition.add(new AttributeExpression(SexAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(BirthDateAttribute.class, "T|D"));
+        definition.add(new AttributeExpression(FieldIds.LAST_NAME.getFieldId(), LastNameAttribute.class, "T|U"));
+        definition.add(
+                new AttributeExpression(FieldIds.FIRST_NAME.getFieldId(), FirstNameAttribute.class, "T|S(0,1)|U"));
+        definition.add(new AttributeExpression(FieldIds.SEX.getFieldId(), SexAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.BIRTH_DATE.getFieldId(), BirthDateAttribute.class, "T|D"));
     }
 
     @Override

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T2Token.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T2Token.java
@@ -28,10 +28,11 @@ public class T2Token implements Token {
     private final ArrayList<AttributeExpression> definition = new ArrayList<>();
 
     public T2Token() {
-        definition.add(new AttributeExpression(LastNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(FirstNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(BirthDateAttribute.class, "T|D"));
-        definition.add(new AttributeExpression(PostalCodeAttribute.class, "T|S(0,3)|U"));
+        definition.add(new AttributeExpression(FieldIds.LAST_NAME.getFieldId(), LastNameAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.FIRST_NAME.getFieldId(), FirstNameAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.BIRTH_DATE.getFieldId(), BirthDateAttribute.class, "T|D"));
+        definition.add(
+                new AttributeExpression(FieldIds.POSTAL_CODE.getFieldId(), PostalCodeAttribute.class, "T|S(0,3)|U"));
     }
 
     @Override

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T3Token.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T3Token.java
@@ -28,10 +28,10 @@ public class T3Token implements Token {
     private final ArrayList<AttributeExpression> definition = new ArrayList<>();
 
     public T3Token() {
-        definition.add(new AttributeExpression(LastNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(FirstNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(SexAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(BirthDateAttribute.class, "T|D"));
+        definition.add(new AttributeExpression(FieldIds.LAST_NAME.getFieldId(), LastNameAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.FIRST_NAME.getFieldId(), FirstNameAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.SEX.getFieldId(), SexAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.BIRTH_DATE.getFieldId(), BirthDateAttribute.class, "T|D"));
     }
 
     @Override

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T4Token.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T4Token.java
@@ -27,9 +27,10 @@ public class T4Token implements Token {
     private final ArrayList<AttributeExpression> definition = new ArrayList<>();
 
     public T4Token() {
-        definition.add(new AttributeExpression(SocialSecurityNumberAttribute.class, "T|M(\\d+)"));
-        definition.add(new AttributeExpression(SexAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(BirthDateAttribute.class, "T|D"));
+        definition.add(new AttributeExpression(FieldIds.SOCIAL_SECURITY_NUMBER.getFieldId(),
+                SocialSecurityNumberAttribute.class, "T|M(\\d+)"));
+        definition.add(new AttributeExpression(FieldIds.SEX.getFieldId(), SexAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.BIRTH_DATE.getFieldId(), BirthDateAttribute.class, "T|D"));
     }
 
     @Override

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T5Token.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/tokens/definitions/T5Token.java
@@ -27,9 +27,10 @@ public class T5Token implements Token {
     private final ArrayList<AttributeExpression> definition = new ArrayList<>();
 
     public T5Token() {
-        definition.add(new AttributeExpression(LastNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(FirstNameAttribute.class, "T|S(0,3)|U"));
-        definition.add(new AttributeExpression(SexAttribute.class, "T|U"));
+        definition.add(new AttributeExpression(FieldIds.LAST_NAME.getFieldId(), LastNameAttribute.class, "T|U"));
+        definition.add(
+                new AttributeExpression(FieldIds.FIRST_NAME.getFieldId(), FirstNameAttribute.class, "T|S(0,3)|U"));
+        definition.add(new AttributeExpression(FieldIds.SEX.getFieldId(), SexAttribute.class, "T|U"));
     }
 
     @Override

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/AttributeFieldTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/AttributeFieldTest.java
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.attributes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import org.openlinktoken.attributes.general.StringAttribute;
+import org.openlinktoken.attributes.person.FirstNameAttribute;
+import org.openlinktoken.attributes.person.LastNameAttribute;
+
+class AttributeFieldTest {
+
+    @Test
+    void testConstructor() {
+        var field = new AttributeField("LastName", LastNameAttribute.class);
+        assertEquals("LastName", field.getFieldId());
+        assertEquals(LastNameAttribute.class, field.getAttributeClass());
+    }
+
+    @Test
+    void testConstructorRejectsNullFieldId() {
+        assertThrows(NullPointerException.class, () -> new AttributeField(null, StringAttribute.class));
+    }
+
+    @Test
+    void testConstructorRejectsNullAttributeClass() {
+        assertThrows(NullPointerException.class, () -> new AttributeField("Test", null));
+    }
+
+    @Test
+    void testEqualityByFieldId() {
+        var field1 = new AttributeField("Name", StringAttribute.class);
+        var field2 = new AttributeField("Name", FirstNameAttribute.class);
+        assertEquals(field1, field2);
+        assertEquals(field1.hashCode(), field2.hashCode());
+    }
+
+    @Test
+    void testInequalityByFieldId() {
+        var field1 = new AttributeField("FirstName", StringAttribute.class);
+        var field2 = new AttributeField("LastName", StringAttribute.class);
+        assertNotEquals(field1, field2);
+    }
+
+    @Test
+    void testToString() {
+        var field = new AttributeField("BirthDate", StringAttribute.class);
+        var str = field.toString();
+        assertEquals("AttributeField{fieldId='BirthDate', attributeClass=StringAttribute}", str);
+    }
+}

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/FieldRegistryTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/FieldRegistryTest.java
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.attributes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.openlinktoken.attributes.general.StringAttribute;
+import org.openlinktoken.attributes.person.LastNameAttribute;
+
+class FieldRegistryTest {
+
+    @Test
+    void testCreateDefaultLoadsBuiltInAttributes() {
+        var registry = FieldRegistry.createDefault();
+        assertTrue(registry.size() > 0);
+        assertTrue(registry.getFieldIds().contains("FirstName"));
+        assertTrue(registry.getFieldIds().contains("LastName"));
+        assertTrue(registry.getFieldIds().contains("String"));
+    }
+
+    @Test
+    void testGetAttributeReturnsRegisteredInstance() {
+        var registry = FieldRegistry.createDefault();
+        var attribute = registry.getAttribute("FirstName");
+        assertTrue(attribute.isPresent());
+        assertEquals("FirstName", attribute.get().getName());
+    }
+
+    @Test
+    void testGetAttributeReturnsEmptyForUnknownField() {
+        var registry = FieldRegistry.createDefault();
+        var attribute = registry.getAttribute("NonExistent");
+        assertFalse(attribute.isPresent());
+    }
+
+    @Test
+    void testGetFieldReturnsAttributeField() {
+        var registry = FieldRegistry.createDefault();
+        var field = registry.getField("LastName");
+        assertTrue(field.isPresent());
+        assertEquals("LastName", field.get().getFieldId());
+        assertEquals(LastNameAttribute.class, field.get().getAttributeClass());
+    }
+
+    @Test
+    void testBuilderRegistersCustomField() {
+        var attribute = new StringAttribute();
+        var registry = FieldRegistry.Builder.fromDefaults()
+                .register("MotherLastName", StringAttribute.class, attribute)
+                .register("FatherLastName", StringAttribute.class, attribute)
+                .build();
+
+        assertTrue(registry.getFieldIds().contains("MotherLastName"));
+        assertTrue(registry.getFieldIds().contains("FatherLastName"));
+
+        var motherAttr = registry.getAttribute("MotherLastName");
+        var fatherAttr = registry.getAttribute("FatherLastName");
+        assertTrue(motherAttr.isPresent());
+        assertTrue(fatherAttr.isPresent());
+        assertEquals(attribute, motherAttr.get());
+        assertEquals(attribute, fatherAttr.get());
+    }
+
+    @Test
+    void testBuilderFromDefaultsIncludesBuiltIns() {
+        var registry = FieldRegistry.Builder.fromDefaults().build();
+        assertTrue(registry.getFieldIds().contains("FirstName"));
+        assertTrue(registry.getFieldIds().contains("LastName"));
+    }
+
+    @Test
+    void testMultipleFieldsSameAttributeType() {
+        var stringAttr = new StringAttribute();
+        var registry = new FieldRegistry.Builder()
+                .register("Field1", StringAttribute.class, stringAttr)
+                .register("Field2", StringAttribute.class, stringAttr)
+                .register("Field3", StringAttribute.class, stringAttr)
+                .build();
+
+        assertEquals(3, registry.size());
+
+        var field1 = registry.getField("Field1");
+        var field2 = registry.getField("Field2");
+        var field3 = registry.getField("Field3");
+
+        assertTrue(field1.isPresent());
+        assertTrue(field2.isPresent());
+        assertTrue(field3.isPresent());
+
+        assertNotNull(registry.getAttribute("Field1").orElse(null));
+        assertNotNull(registry.getAttribute("Field2").orElse(null));
+        assertNotNull(registry.getAttribute("Field3").orElse(null));
+    }
+}

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/tokens/TokenGeneratorFieldIdTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/tokens/TokenGeneratorFieldIdTest.java
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: MIT */
+package org.openlinktoken.tokens;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.openlinktoken.attributes.AttributeExpression;
+import org.openlinktoken.attributes.FieldRegistry;
+import org.openlinktoken.attributes.general.StringAttribute;
+import org.openlinktoken.attributes.person.FirstNameAttribute;
+import org.openlinktoken.attributes.person.LastNameAttribute;
+import org.openlinktoken.attributes.person.SexAttribute;
+import org.openlinktoken.tokens.tokenizer.PassthroughTokenizer;
+
+class TokenGeneratorFieldIdTest {
+
+    private TokenGenerator tokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        var stringAttr = new StringAttribute();
+        var registry = FieldRegistry.Builder.fromDefaults()
+                .register("MotherLastName", StringAttribute.class, stringAttr)
+                .register("FatherLastName", StringAttribute.class, stringAttr)
+                .build();
+
+        BaseTokenDefinition tokenDefinition = new BaseTokenDefinition() {
+            private final Map<String, List<AttributeExpression>> defs = Map.of(
+                    "T_MULTI", List.of(
+                            new AttributeExpression("MotherLastName", StringAttribute.class, "T|U"),
+                            new AttributeExpression("FatherLastName", StringAttribute.class, "T|U"),
+                            new AttributeExpression("FirstName", FirstNameAttribute.class, "T|S(0,1)|U")),
+                    "T_LEGACY", List.of(
+                            new AttributeExpression(LastNameAttribute.class, "T|U"),
+                            new AttributeExpression(FirstNameAttribute.class, "T|S(0,1)|U"),
+                            new AttributeExpression(SexAttribute.class, "T|U")));
+
+            @Override
+            public String getVersion() {
+                return "test";
+            }
+
+            @Override
+            public Set<String> getTokenIdentifiers() {
+                return defs.keySet();
+            }
+
+            @Override
+            public List<AttributeExpression> getTokenDefinition(String tokenId) {
+                return defs.get(tokenId);
+            }
+        };
+
+        tokenGenerator = new TokenGenerator(tokenDefinition, new PassthroughTokenizer(List.of()), registry);
+    }
+
+    @Test
+    void testMultiFieldSameTypeGeneratesToken() {
+        Map<String, String> person = Map.of(
+                "MotherLastName", "Garcia",
+                "FatherLastName", "Lopez",
+                "FirstName", "Ana");
+
+        var result = tokenGenerator.getAllTokensViaFieldId(person);
+        assertTrue(result.getTokens().containsKey("T_MULTI"));
+        assertEquals("GARCIA|LOPEZ|A", result.getTokens().get("T_MULTI"));
+    }
+
+    @Test
+    void testMultiFieldMissingFieldSkipsToken() {
+        Map<String, String> person = Map.of(
+                "MotherLastName", "Garcia",
+                "FirstName", "Ana");
+
+        var result = tokenGenerator.getAllTokensViaFieldId(person);
+        // Missing field produces BLANK token
+        assertEquals(Token.BLANK, result.getTokens().get("T_MULTI"));
+    }
+
+    @Test
+    void testLegacyExpressionsWorkWithFieldIdApi() {
+        Map<String, String> person = Map.of(
+                "LastName", "Smith",
+                "FirstName", "John",
+                "Sex", "M");
+
+        var result = tokenGenerator.getAllTokensViaFieldId(person);
+        assertTrue(result.getTokens().containsKey("T_LEGACY"));
+        assertEquals("SMITH|J|MALE", result.getTokens().get("T_LEGACY"));
+    }
+
+    @Test
+    void testSignaturesByFieldId() {
+        Map<String, String> person = Map.of(
+                "MotherLastName", "Garcia",
+                "FatherLastName", "Lopez",
+                "FirstName", "Ana",
+                "LastName", "Smith",
+                "Sex", "F");
+
+        var signatures = tokenGenerator.getAllTokenSignaturesViaFieldId(person);
+        assertTrue(signatures.containsKey("T_MULTI"));
+        assertEquals("GARCIA|LOPEZ|A", signatures.get("T_MULTI"));
+        assertTrue(signatures.containsKey("T_LEGACY"));
+        assertEquals("SMITH|A|FEMALE", signatures.get("T_LEGACY"));
+    }
+
+    @Test
+    void testInvalidAttributeTracked() {
+        Map<String, String> person = Map.of(
+                "MotherLastName", "",
+                "FatherLastName", "Lopez",
+                "FirstName", "Ana");
+
+        var result = tokenGenerator.getAllTokensViaFieldId(person);
+        // Invalid attribute produces BLANK token
+        assertEquals(Token.BLANK, result.getTokens().get("T_MULTI"));
+        assertFalse(result.getInvalidAttributes().isEmpty());
+    }
+}

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/tokens/TokenGeneratorIntegrationTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/tokens/TokenGeneratorIntegrationTest.java
@@ -77,4 +77,32 @@ class TokenGeneratorIntegrationTest {
         assertEquals("21c3cf1fdb4fd45197e5def14d0228d26c56bcec1b8641079f9b9ec24f9a6a0b", tokens.get("T4"));
         assertEquals("3756556f2323148cb57e1e13b1abcd457e1c1706a84ae83d522a3fc0ad43506d", tokens.get("T5"));
     }
+
+    @Test
+    void testGetAllTokensViaFieldId_validPersonAttributes_generatesSameTokensAsClassBasedApi() {
+        // Regression test: the field-ID-based API must produce byte-identical tokens
+        // to the deprecated class-based API for the real T1-T5 token definitions.
+        tokenDefinition = new TokenDefinition();
+        tokenGenerator = new TokenGenerator(tokenDefinition, new SHA256Tokenizer(new ArrayList<>()));
+
+        // Person attributes keyed by field ID, matching the same values used in
+        // testGetAllTokens_validPersonAttributes_generatesTokens.
+        Map<String, String> personAttributes = new HashMap<>();
+        personAttributes.put("FirstName", "Alice");
+        personAttributes.put("LastName", "Wonderland");
+        personAttributes.put("SocialSecurityNumber", "345-54-6795");
+        personAttributes.put("Sex", "F");
+        personAttributes.put("BirthDate", "1993-08-10");
+
+        Map<String, String> tokens = tokenGenerator.getAllTokensViaFieldId(personAttributes).getTokens();
+
+        assertNotNull(tokens);
+        assertEquals(5, tokens.size(), "Expected 5 tokens to be generated");
+
+        assertEquals("02292af14559b4c2a28a772536b81760ad7b8ebac8ce49e8450ca0fa5044e37f", tokens.get("T1"));
+        assertEquals("0000000000000000000000000000000000000000000000000000000000000000", tokens.get("T2"));
+        assertEquals("a76c3bff664bec8d0f77b4b47ad555d212dc671949ed3cf1c1edef68733835b2", tokens.get("T3"));
+        assertEquals("21c3cf1fdb4fd45197e5def14d0228d26c56bcec1b8641079f9b9ec24f9a6a0b", tokens.get("T4"));
+        assertEquals("3756556f2323148cb57e1e13b1abcd457e1c1706a84ae83d522a3fc0ad43506d", tokens.get("T5"));
+    }
 }

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -30,7 +30,7 @@
         <java.version>21</java.version>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.compiler.release>17</maven.compiler.release>
-        <junit.jupiter.version>6.1.0</junit.jupiter.version>
+        <junit.jupiter.version>6.1.1</junit.jupiter.version>
         <surefire.plugin.version>3.5.6</surefire.plugin.version>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -34,7 +34,7 @@
         <surefire.plugin.version>3.5.6</surefire.plugin.version>
         <mockito.version>5.23.0</mockito.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <log4j.version>2.26.0</log4j.version>
+        <log4j.version>2.26.1</log4j.version>
     </properties>
 
     <dependencyManagement>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.openlinktoken</groupId>
     <artifactId>openlinktoken-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <name>openlinktoken-parent</name>
     <description>Open Link Token Parent POM - Privacy-preserving record linkage library</description>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>org.openlinktoken</groupId>
                 <artifactId>openlinktoken</artifactId>
-                <version>2.0.0</version>
+                <version>2.1.0</version>
             </dependency>
 
             <!-- JUnit 5 -->

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -131,7 +131,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.22.0</version>
+                <version>2.22.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/lib/python/dev-requirements.txt
+++ b/lib/python/dev-requirements.txt
@@ -11,5 +11,5 @@ pycryptodome>=3.18.0
 
 # Jupyter support (for notebooks in openlinktoken-pyspark)
 jupyter>=1.0.0
-notebook>=7.0.0
+notebook>=7.6.0
 ipykernel>=7.3.0

--- a/lib/python/dev-requirements.txt
+++ b/lib/python/dev-requirements.txt
@@ -1,7 +1,7 @@
 # Consolidated dev requirements for all Python packages
 
 # Testing frameworks
-pytest>=7.0.0
+pytest>=9.1.1
 
 # Code quality and linting
 ruff>=0.9.0

--- a/lib/python/dev-requirements.txt
+++ b/lib/python/dev-requirements.txt
@@ -10,6 +10,6 @@ ruff>=0.15.21
 pycryptodome>=3.18.0
 
 # Jupyter support (for notebooks in openlinktoken-pyspark)
-jupyter>=1.0.0
+jupyter>=1.1.1
 notebook>=7.6.0
 ipykernel>=7.3.0

--- a/lib/python/dev-requirements.txt
+++ b/lib/python/dev-requirements.txt
@@ -12,4 +12,4 @@ pycryptodome>=3.18.0
 # Jupyter support (for notebooks in openlinktoken-pyspark)
 jupyter>=1.0.0
 notebook>=7.0.0
-ipykernel>=6.25.0
+ipykernel>=7.3.0

--- a/lib/python/dev-requirements.txt
+++ b/lib/python/dev-requirements.txt
@@ -4,7 +4,7 @@
 pytest>=9.1.1
 
 # Code quality and linting
-ruff>=0.9.0
+ruff>=0.15.21
 
 # Cryptography for core library tests
 pycryptodome>=3.18.0

--- a/lib/python/openlinktoken-cli/pyproject.toml
+++ b/lib/python/openlinktoken-cli/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pandas==3.0.3; python_version >= '3.11'",
   "pyarrow==24.0.0",
   "csv2parquet==0.0.9",
-  "cryptography==48.0.1",
+  "cryptography==49.0.0",
   "urllib3==2.7.0",
   "jwcrypto==1.5.7",
   "packaging==26.1",

--- a/lib/python/openlinktoken-cli/pyproject.toml
+++ b/lib/python/openlinktoken-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlinktoken-cli"
-version = "2.0.0"
+version = "2.1.0"
 requires-python = ">=3.10"
 dynamic = [
   "authors",

--- a/lib/python/openlinktoken-cli/pyproject.toml
+++ b/lib/python/openlinktoken-cli/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
   "urls",
 ]
 dependencies = [
-  "openlinktoken==2.0.0",
+  "openlinktoken==2.1.0",
   "pandas==2.2.3; python_version < '3.11'",
   "pandas==3.0.3; python_version >= '3.11'",
   "pyarrow==24.0.0",

--- a/lib/python/openlinktoken-cli/requirements.txt
+++ b/lib/python/openlinktoken-cli/requirements.txt
@@ -5,7 +5,7 @@
 -e ./lib/python/openlinktoken-cli
 cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
-cryptography==48.0.1
+cryptography==49.0.0
     # via
     #   jwcrypto
     #   openlinktoken

--- a/lib/python/openlinktoken-cli/setup.py
+++ b/lib/python/openlinktoken-cli/setup.py
@@ -18,7 +18,7 @@ except FileNotFoundError:
 
 setup(
     name="openlinktoken-cli",
-    version="2.0.0",
+    version="2.1.0",
     author="Open Link Token Contributors",
     description="Open Link Token CLI - Command line interface for record linkage",
     long_description=long_description,

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/__init__.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/__init__.py
@@ -6,5 +6,5 @@ This package provides the command line interface for tokenizing and processing
 person attributes using the Open Link Token library.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __author__ = "Open Link Token Contributors"

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -5,16 +5,16 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from openlinktoken.metadata import Metadata
 from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
 from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from openlinktoken.tokentransformer.token_transformer import TokenTransformer
-from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
+from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
 from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
-from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
 from openlinktoken_cli.processor.person_attributes_processor import (
     PersonAttributesProcessingSummary,
@@ -76,6 +76,17 @@ class PackageCommand:
             dest="exchange_config",
             metavar="PATH",
             help="Path to the exchange config JSON (default: ./openlinktoken-YYYY-MM-DD.exchange.json)",
+        )
+
+        parser.add_argument(
+            "--config",
+            required=False,
+            dest="tokenization_config",
+            metavar="PATH",
+            help=(
+                "Path to a YAML tokenization config that defines input field mappings and token rules. "
+                "Supported for CSV and Parquet input."
+            ),
         )
 
         private_key_group = parser.add_mutually_exclusive_group(required=False)
@@ -140,6 +151,7 @@ class PackageCommand:
             return 1
         ring_id = resolve_ring_id(args.ring_id)
         hash_record_ids = getattr(args, "hash_record_ids", False)
+        tokenization_config_path = getattr(args, "tokenization_config", None)
         reporter = CliRunReporter("package", no_progress=args.no_progress)
 
         try:
@@ -165,7 +177,7 @@ class PackageCommand:
                     # Determine total rows via reader to enable %/ETA
                     total_rows: int | None = None
                     try:
-                        reader = PackageCommand._create_reader(
+                        reader = TokenizationConfigHelper.create_reader(
                             args.input_path, input_type)
                         total_rows = reader.row_count()
                         reader.close()
@@ -207,6 +219,7 @@ class PackageCommand:
                             encryption_key,
                             ring_id,
                             hash_record_ids,
+                            tokenization_config_path,
                             progress_callback=reporter.make_progress_callback("Packaging records", "records"),
                         )
 
@@ -243,6 +256,7 @@ class PackageCommand:
         encryption_key: bytes,
         ring_id: str,
         hash_record_ids: bool = False,
+        tokenization_config_path: Optional[str] = None,
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens from person attributes."""
@@ -256,8 +270,11 @@ class PackageCommand:
             raise RuntimeError("Failed to initialize transformers") from e
 
         try:
+            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+                tokenization_config_path
+            )
             with (
-                PackageCommand._create_reader(input_path, input_type) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
                 PackageCommand._create_writer(output_path, output_type) as writer,
             ):
                 # Create metadata
@@ -275,6 +292,7 @@ class PackageCommand:
                     encryption_key,
                     ring_id,
                     hash_record_ids,
+                    token_definition=token_definition,
                     progress_callback=progress_callback,
                 )
 
@@ -311,17 +329,6 @@ class PackageCommand:
         if hash_record_ids:
             lines.append("Record ID hashing: enabled")
         return lines
-
-    @staticmethod
-    def _create_reader(path: str, file_type: str):
-        """Create a PersonAttributesReader based on file type."""
-        file_type_lower = file_type.lower()
-        if file_type_lower == FileTypeDetector.TYPE_CSV:
-            return PersonAttributesCSVReader(path)
-        elif file_type_lower == FileTypeDetector.TYPE_PARQUET:
-            return PersonAttributesParquetReader(path)
-        else:
-            raise ValueError(f"Unsupported input type: {file_type}")
 
     @staticmethod
     def _create_writer(path: str, file_type: str):

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -11,8 +11,6 @@ from openlinktoken.metadata import Metadata
 from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
 from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from openlinktoken.tokentransformer.token_transformer import TokenTransformer
-from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
-from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
 from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
@@ -20,6 +18,8 @@ from openlinktoken_cli.processor.person_attributes_processor import (
     PersonAttributesProcessingSummary,
     PersonAttributesProcessor,
 )
+from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
 from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
@@ -122,15 +122,15 @@ class PackageCommand:
             ),
         )
 
-         # --no-progress / -q: suppress interactive progress indicator
+        # --no-progress / -q: suppress interactive progress indicator
         parser.add_argument(
-              "--no-progress",
-              "-q",
+            "--no-progress",
+            "-q",
             action="store_true",
             default=False,
             dest="no_progress",
             help="Suppress interactive progress indicator (e.g. for non-interactive / CI environments)",
-            )
+        )
 
         parser.set_defaults(func=PackageCommand.execute)
 
@@ -177,8 +177,7 @@ class PackageCommand:
                     # Determine total rows via reader to enable %/ETA
                     total_rows: int | None = None
                     try:
-                        reader = TokenizationConfigHelper.create_reader(
-                            args.input_path, input_type)
+                        reader = TokenizationConfigHelper.create_reader(args.input_path, input_type)
                         total_rows = reader.row_count()
                         reader.close()
                     except Exception:
@@ -270,11 +269,11 @@ class PackageCommand:
             raise RuntimeError("Failed to initialize transformers") from e
 
         try:
-            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+            config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(
                 tokenization_config_path
             )
             with (
-                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, resolver) as reader,
                 PackageCommand._create_writer(output_path, output_type) as writer,
             ):
                 # Create metadata

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
@@ -2,18 +2,16 @@
 
 import logging
 import sys
-from typing import List
+from typing import List, Optional
 
 from openlinktoken.metadata import Metadata
+from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
 from openlinktoken.tokens.tokenizer.passthrough_tokenizer import PassthroughTokenizer
+from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from openlinktoken.tokentransformer.token_transformer import TokenTransformer
-from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
 from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
 from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
-from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import (
-    PersonAttributesParquetReader,
-)
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import (
     PersonAttributesParquetWriter,
 )
@@ -114,6 +112,17 @@ class TokenizeCommand:
             help="Path to the exchange config JSON (default: ./openlinktoken-YYYY-MM-DD.exchange.json)",
         )
 
+        parser.add_argument(
+            "--config",
+            required=False,
+            dest="tokenization_config",
+            metavar="PATH",
+            help=(
+                "Path to a YAML tokenization config that defines input field mappings and token rules. "
+                "Supported for CSV and Parquet input."
+            ),
+        )
+
         private_key_group = parser.add_mutually_exclusive_group(required=False)
         private_key_group.add_argument(
             "--private-key",
@@ -158,6 +167,7 @@ class TokenizeCommand:
         """Execute the tokenize command."""
         mode = getattr(args, "mode", TokenizeCommand._MODE_DEFAULT)
         hash_record_ids = getattr(args, "hash_record_ids", False)
+        tokenization_config_path = getattr(args, "tokenization_config", None)
 
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
@@ -217,7 +227,7 @@ class TokenizeCommand:
                         # Count total rows via reader to enable %/ETA
                     total_rows: int | None = None
                     try:
-                        reader = TokenizeCommand._create_reader(args.input_path, input_type)
+                        reader = TokenizationConfigHelper.create_reader(args.input_path, input_type)
                         total_rows = reader.row_count()
                         reader.close()
                     except Exception:
@@ -233,6 +243,7 @@ class TokenizeCommand:
                             output_path,
                             input_type,
                             output_type,
+                            tokenization_config_path,
                             progress_callback=reporter.make_progress_callback("Tokenizing records", "records"),
                         )
                     elif mode == TokenizeCommand._MODE_HASH_ONLY:
@@ -243,6 +254,7 @@ class TokenizeCommand:
                             input_type,
                             output_type,
                             hash_record_ids,
+                            tokenization_config_path,
                             progress_callback=reporter.make_progress_callback("Tokenizing records", "records"),
                         )
                     else:
@@ -261,6 +273,7 @@ class TokenizeCommand:
                             output_type,
                             exchange.hashing_secret,
                             hash_record_ids,
+                            tokenization_config_path,
                             progress_callback=reporter.make_progress_callback("Tokenizing records", "records"),
                         )
                     logger.info("Token generation completed successfully")
@@ -281,7 +294,7 @@ class TokenizeCommand:
             return 0
         except Exception as error:
             report = archive_cli_error(error, command_name="tokenize", existing_report=reporter.log_report)
-            print(f"Error: {error}", file=sys.stderr)
+            print(f"\033[31mError:\033[0m {error}", file=sys.stderr)
             print(format_error_reference_message(report), file=sys.stderr)
             return 1
 
@@ -293,6 +306,7 @@ class TokenizeCommand:
         output_type: str,
         hashing_secret: str | bytes,
         hash_record_ids: bool = False,
+        tokenization_config_path: Optional[str] = None,
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in normal mode using SHA-256 + HMAC-SHA256."""
@@ -305,8 +319,11 @@ class TokenizeCommand:
             raise RuntimeError("Failed to initialize transformer") from e
 
         try:
+            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+                tokenization_config_path
+            )
             with (
-                TokenizeCommand._create_reader(input_path, input_type) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
                 TokenizeCommand._create_writer(output_path, output_type) as writer,
             ):
                 metadata = Metadata()
@@ -320,6 +337,7 @@ class TokenizeCommand:
                     token_transformer_list,
                     metadata_map,
                     hash_record_ids=hash_record_ids,
+                    token_definition=token_definition,
                     progress_callback=progress_callback,
                 )
 
@@ -337,12 +355,16 @@ class TokenizeCommand:
         input_type: str,
         output_type: str,
         hash_record_ids: bool = False,
+        tokenization_config_path: Optional[str] = None,
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in hash-only mode using SHA-256 only (no HMAC, no secret)."""
         try:
+            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+                tokenization_config_path
+            )
             with (
-                TokenizeCommand._create_reader(input_path, input_type) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
                 TokenizeCommand._create_writer(output_path, output_type) as writer,
             ):
                 metadata = Metadata()
@@ -355,6 +377,7 @@ class TokenizeCommand:
                     [],
                     metadata_map,
                     hash_record_ids=hash_record_ids,
+                    token_definition=token_definition,
                     progress_callback=progress_callback,
                 )
 
@@ -371,12 +394,16 @@ class TokenizeCommand:
         output_path: str,
         input_type: str,
         output_type: str,
+        tokenization_config_path: Optional[str] = None,
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in demo mode using PassthroughTokenizer (no hashing)."""
         try:
+            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+                tokenization_config_path
+            )
             with (
-                TokenizeCommand._create_reader(input_path, input_type) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
                 TokenizeCommand._create_writer(output_path, output_type) as writer,
             ):
                 metadata = Metadata()
@@ -388,6 +415,7 @@ class TokenizeCommand:
                     writer,
                     PassthroughTokenizer([]),
                     metadata_map,
+                    token_definition=token_definition,
                     progress_callback=progress_callback,
                 )
 
@@ -425,17 +453,6 @@ class TokenizeCommand:
         if hash_record_ids:
             lines.append("Record ID hashing: enabled")
         return lines
-
-    @staticmethod
-    def _create_reader(path: str, file_type: str):
-        """Create a PersonAttributesReader based on file type."""
-        file_type_lower = file_type.lower()
-        if file_type_lower == FileTypeDetector.TYPE_CSV:
-            return PersonAttributesCSVReader(path)
-        elif file_type_lower == FileTypeDetector.TYPE_PARQUET:
-            return PersonAttributesParquetReader(path)
-        else:
-            raise ValueError(f"Unsupported input type: {file_type}")
 
     @staticmethod
     def _create_writer(path: str, file_type: str):

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
@@ -5,9 +5,7 @@ import sys
 from typing import List, Optional
 
 from openlinktoken.metadata import Metadata
-from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
 from openlinktoken.tokens.tokenizer.passthrough_tokenizer import PassthroughTokenizer
-from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from openlinktoken.tokentransformer.token_transformer import TokenTransformer
 from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
@@ -19,6 +17,8 @@ from openlinktoken_cli.processor.person_attributes_processor import (
     PersonAttributesProcessingSummary,
     PersonAttributesProcessor,
 )
+from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
 from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
 from openlinktoken_cli.util.exchange_config import resolve_exchange_config
@@ -319,11 +319,11 @@ class TokenizeCommand:
             raise RuntimeError("Failed to initialize transformer") from e
 
         try:
-            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+            config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(
                 tokenization_config_path
             )
             with (
-                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, resolver) as reader,
                 TokenizeCommand._create_writer(output_path, output_type) as writer,
             ):
                 metadata = Metadata()
@@ -360,11 +360,11 @@ class TokenizeCommand:
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in hash-only mode using SHA-256 only (no HMAC, no secret)."""
         try:
-            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+            config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(
                 tokenization_config_path
             )
             with (
-                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, resolver) as reader,
                 TokenizeCommand._create_writer(output_path, output_type) as writer,
             ):
                 metadata = Metadata()
@@ -399,11 +399,11 @@ class TokenizeCommand:
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in demo mode using PassthroughTokenizer (no hashing)."""
         try:
-            config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(
+            config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(
                 tokenization_config_path
             )
             with (
-                TokenizationConfigHelper.create_reader(input_path, input_type, config, factory) as reader,
+                TokenizationConfigHelper.create_reader(input_path, input_type, config, resolver) as reader,
                 TokenizeCommand._create_writer(output_path, output_type) as writer,
             ):
                 metadata = Metadata()

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/csv/person_attributes_csv_reader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/csv/person_attributes_csv_reader.py
@@ -2,7 +2,7 @@
 
 import csv
 import logging
-from typing import Dict, Set, Type
+from typing import Dict, Set
 
 from openlinktoken.attributes.attribute import Attribute
 from openlinktoken.attributes.attribute_loader import AttributeLoader
@@ -17,15 +17,15 @@ class PersonAttributesCSVReader(PersonAttributesReader):
     Implements the PersonAttributesReader interface.
     """
 
-    def __init__(self, file_path: str, attribute_map: Dict[str, Type[Attribute]] | None = None):
+    def __init__(self, file_path: str, attribute_map: Dict[str, str] | None = None):
         """
         Initialize the class with the input file in CSV format.
 
         Args:
             file_path: The input file path.
-            attribute_map: Optional explicit mapping from CSV column name to output key
-                (attribute class or logical field id). When omitted, mapping is discovered
-                via attribute aliases.
+            attribute_map: Optional explicit mapping from CSV column name to field id.
+                When omitted, mapping is discovered via attribute aliases and each column
+                is mapped to its canonical attribute name (e.g. "FirstName", "LastName").
 
         Raises:
             IOError: If an I/O error occurs.
@@ -38,7 +38,7 @@ class PersonAttributesCSVReader(PersonAttributesReader):
             if attribute_map is not None:
                 self.attribute_map = attribute_map.copy()
             else:
-                self.attribute_map = self._build_attribute_map_from_aliases()
+                self.attribute_map = self._build_column_to_field_id_map()
 
         except IOError as e:
             logger.error(f"Error in reading CSV file: {e}")
@@ -70,20 +70,20 @@ class PersonAttributesCSVReader(PersonAttributesReader):
         """Return the iterator object."""
         return self
 
-    def __next__(self) -> Dict[Type[Attribute], str]:
+    def __next__(self) -> Dict[str, str]:
         """
         Get the next record from the CSV file.
 
         Returns:
-            A person attributes map.
+            A person attributes map keyed by field id.
         """
         record = next(self.iterator)
 
-        person_attributes: Dict[Type[Attribute], str] = {}
+        person_attributes: Dict[str, str] = {}
         for key, value in record.items():
-            mapped_key = self.attribute_map.get(key)
-            if mapped_key is not None:
-                person_attributes[mapped_key] = value
+            field_id = self.attribute_map.get(key)
+            if field_id is not None:
+                person_attributes[field_id] = value
             # else ignore attribute as it's not supported
 
         return person_attributes
@@ -93,14 +93,14 @@ class PersonAttributesCSVReader(PersonAttributesReader):
         if self.file_handle:
             self.file_handle.close()
 
-    def _build_attribute_map_from_aliases(self) -> Dict[str, Type[Attribute]]:
-        """Build column-to-attribute mapping using AttributeLoader aliases."""
-        alias_map: Dict[str, Type[Attribute]] = {}
+    def _build_column_to_field_id_map(self) -> Dict[str, str]:
+        """Build column-to-field-id mapping using AttributeLoader aliases."""
+        field_id_map: Dict[str, str] = {}
         attributes: Set[Attribute] = AttributeLoader.load()
         for header_name in self.csv_reader.fieldnames or []:
             for attribute in attributes:
                 for alias in attribute.get_aliases():
                     if header_name.lower() == alias.lower():
-                        alias_map[header_name] = type(attribute)
+                        field_id_map[header_name] = attribute.get_name()
                         break
-        return alias_map
+        return field_id_map

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/csv/person_attributes_csv_reader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/csv/person_attributes_csv_reader.py
@@ -17,12 +17,15 @@ class PersonAttributesCSVReader(PersonAttributesReader):
     Implements the PersonAttributesReader interface.
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, attribute_map: Dict[str, Type[Attribute]] | None = None):
         """
         Initialize the class with the input file in CSV format.
 
         Args:
             file_path: The input file path.
+            attribute_map: Optional explicit mapping from CSV column name to output key
+                (attribute class or logical field id). When omitted, mapping is discovered
+                via attribute aliases.
 
         Raises:
             IOError: If an I/O error occurs.
@@ -32,16 +35,10 @@ class PersonAttributesCSVReader(PersonAttributesReader):
             self.file_handle = open(file_path, "r", encoding="utf-8")
             self.csv_reader = csv.DictReader(self.file_handle)
             self.iterator = iter(self.csv_reader)
-            self.attribute_map: Dict[str, Attribute] = {}
-
-            # Load attributes and build the mapping
-            attributes: Set[Attribute] = AttributeLoader.load()
-            for header_name in self.csv_reader.fieldnames or []:
-                for attribute in attributes:
-                    for alias in attribute.get_aliases():
-                        if header_name.lower() == alias.lower():
-                            self.attribute_map[header_name] = attribute
-                            break
+            if attribute_map is not None:
+                self.attribute_map = attribute_map.copy()
+            else:
+                self.attribute_map = self._build_attribute_map_from_aliases()
 
         except IOError as e:
             logger.error(f"Error in reading CSV file: {e}")
@@ -84,9 +81,9 @@ class PersonAttributesCSVReader(PersonAttributesReader):
 
         person_attributes: Dict[Type[Attribute], str] = {}
         for key, value in record.items():
-            attribute = self.attribute_map.get(key)
-            if attribute is not None:
-                person_attributes[type(attribute)] = value
+            mapped_key = self.attribute_map.get(key)
+            if mapped_key is not None:
+                person_attributes[mapped_key] = value
             # else ignore attribute as it's not supported
 
         return person_attributes
@@ -95,3 +92,15 @@ class PersonAttributesCSVReader(PersonAttributesReader):
         """Close the CSV reader and file handle."""
         if self.file_handle:
             self.file_handle.close()
+
+    def _build_attribute_map_from_aliases(self) -> Dict[str, Type[Attribute]]:
+        """Build column-to-attribute mapping using AttributeLoader aliases."""
+        alias_map: Dict[str, Type[Attribute]] = {}
+        attributes: Set[Attribute] = AttributeLoader.load()
+        for header_name in self.csv_reader.fieldnames or []:
+            for attribute in attributes:
+                for alias in attribute.get_aliases():
+                    if header_name.lower() == alias.lower():
+                        alias_map[header_name] = type(attribute)
+                        break
+        return alias_map

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/parquet/person_attributes_parquet_reader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/parquet/person_attributes_parquet_reader.py
@@ -21,12 +21,15 @@ class PersonAttributesParquetReader(PersonAttributesReader):
     Implements the PersonAttributesReader interface.
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, attribute_map: Dict[str, Type[Attribute]] | None = None):
         """
         Initialize the class with the input file in Parquet format.
 
         Args:
             file_path: The input file path.
+            attribute_map: Optional explicit mapping from input column name to output key
+                (attribute class or logical field id). When omitted, mapping is discovered
+                via built-in attribute aliases.
 
         Raises:
             IOError: If an I/O error occurs.
@@ -40,17 +43,25 @@ class PersonAttributesParquetReader(PersonAttributesReader):
             self.closed = False
             self.has_next_called = False
             self.has_next_result = False
-            self.attribute_map: Dict[str, Attribute] = {}
-
-            # Load attributes and build the mapping
-            attributes: Set[Attribute] = AttributeLoader.load()
-            for attribute in attributes:
-                for alias in attribute.get_aliases():
-                    self.attribute_map[alias.lower()] = attribute
+            self._attribute_map: Dict[str, Type[Attribute]] = {}
+            if attribute_map is not None:
+                self.attribute_map = attribute_map
+            else:
+                self.attribute_map = self._build_attribute_map_from_aliases()
 
         except Exception as e:
             logger.error(f"Error in reading Parquet file: {e}")
             raise IOError(f"Failed to read Parquet file: {file_path}") from e
+
+    @property
+    def attribute_map(self) -> Dict[str, Type[Attribute]]:
+        """Return the normalized input-column mapping for this reader."""
+        return self._attribute_map
+
+    @attribute_map.setter
+    def attribute_map(self, value: Dict[str, Type[Attribute]]) -> None:
+        """Store column mappings using lowercase keys for case-insensitive lookups."""
+        self._attribute_map = {column_name.lower(): mapped_key for column_name, mapped_key in value.items()}
 
     def __iter__(self):
         """Return the iterator object."""
@@ -109,11 +120,10 @@ class PersonAttributesParquetReader(PersonAttributesReader):
         # Map to attribute classes
         attributes: Dict[Type[Attribute], str] = {}
         for field_name, field_value in row_dict.items():
-            attribute = self.attribute_map.get(field_name.lower())
-            if attribute is not None:
-                attribute_class = type(attribute)
-                field_value_str = str(field_value) if field_value is not None else None
-                attributes[attribute_class] = field_value_str
+            mapped_key = self.attribute_map.get(field_name.lower())
+            if mapped_key is not None:
+                field_value_str = str(field_value) if field_value is not None else ""
+                attributes[mapped_key] = field_value_str
 
         return attributes
 
@@ -126,3 +136,12 @@ class PersonAttributesParquetReader(PersonAttributesReader):
         self.closed = True
         # PyArrow handles resource cleanup automatically
         # No explicit file handle to close
+
+    def _build_attribute_map_from_aliases(self) -> Dict[str, Type[Attribute]]:
+        """Build lowercase alias-to-attribute mapping from AttributeLoader."""
+        alias_map: Dict[str, Type[Attribute]] = {}
+        attributes: Set[Attribute] = AttributeLoader.load()
+        for attribute in attributes:
+            for alias in attribute.get_aliases():
+                alias_map[alias.lower()] = type(attribute)
+        return alias_map

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/parquet/person_attributes_parquet_reader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/parquet/person_attributes_parquet_reader.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from typing import Dict, Set, Type
+from typing import Dict, Set
 
 try:
     import pyarrow.parquet as pq
@@ -21,15 +21,15 @@ class PersonAttributesParquetReader(PersonAttributesReader):
     Implements the PersonAttributesReader interface.
     """
 
-    def __init__(self, file_path: str, attribute_map: Dict[str, Type[Attribute]] | None = None):
+    def __init__(self, file_path: str, attribute_map: Dict[str, str] | None = None):
         """
         Initialize the class with the input file in Parquet format.
 
         Args:
             file_path: The input file path.
-            attribute_map: Optional explicit mapping from input column name to output key
-                (attribute class or logical field id). When omitted, mapping is discovered
-                via built-in attribute aliases.
+            attribute_map: Optional explicit mapping from input column name to field id.
+                When omitted, mapping is discovered via built-in attribute aliases and each
+                column is mapped to its canonical attribute name (e.g. "FirstName").
 
         Raises:
             IOError: If an I/O error occurs.
@@ -43,25 +43,25 @@ class PersonAttributesParquetReader(PersonAttributesReader):
             self.closed = False
             self.has_next_called = False
             self.has_next_result = False
-            self._attribute_map: Dict[str, Type[Attribute]] = {}
+            self._attribute_map: Dict[str, str] = {}
             if attribute_map is not None:
                 self.attribute_map = attribute_map
             else:
-                self.attribute_map = self._build_attribute_map_from_aliases()
+                self.attribute_map = self._build_column_to_field_id_map()
 
         except Exception as e:
             logger.error(f"Error in reading Parquet file: {e}")
             raise IOError(f"Failed to read Parquet file: {file_path}") from e
 
     @property
-    def attribute_map(self) -> Dict[str, Type[Attribute]]:
+    def attribute_map(self) -> Dict[str, str]:
         """Return the normalized input-column mapping for this reader."""
         return self._attribute_map
 
     @attribute_map.setter
-    def attribute_map(self, value: Dict[str, Type[Attribute]]) -> None:
+    def attribute_map(self, value: Dict[str, str]) -> None:
         """Store column mappings using lowercase keys for case-insensitive lookups."""
-        self._attribute_map = {column_name.lower(): mapped_key for column_name, mapped_key in value.items()}
+        self._attribute_map = {column_name.lower(): field_id for column_name, field_id in value.items()}
 
     def __iter__(self):
         """Return the iterator object."""
@@ -86,12 +86,12 @@ class PersonAttributesParquetReader(PersonAttributesReader):
 
         return self.has_next_result
 
-    def __next__(self) -> Dict[Type[Attribute], str]:
+    def __next__(self) -> Dict[str, str]:
         """
         Get the next record from the Parquet file.
 
         Returns:
-            A person attributes map.
+            A person attributes map keyed by field id.
 
         Raises:
             StopIteration: When there are no more records or reader is closed.
@@ -117,13 +117,13 @@ class PersonAttributesParquetReader(PersonAttributesReader):
 
         self.current_row += 1
 
-        # Map to attribute classes
-        attributes: Dict[Type[Attribute], str] = {}
+        # Map to field ids
+        attributes: Dict[str, str] = {}
         for field_name, field_value in row_dict.items():
-            mapped_key = self.attribute_map.get(field_name.lower())
-            if mapped_key is not None:
+            field_id = self.attribute_map.get(field_name.lower())
+            if field_id is not None:
                 field_value_str = str(field_value) if field_value is not None else ""
-                attributes[mapped_key] = field_value_str
+                attributes[field_id] = field_value_str
 
         return attributes
 
@@ -137,11 +137,11 @@ class PersonAttributesParquetReader(PersonAttributesReader):
         # PyArrow handles resource cleanup automatically
         # No explicit file handle to close
 
-    def _build_attribute_map_from_aliases(self) -> Dict[str, Type[Attribute]]:
-        """Build lowercase alias-to-attribute mapping from AttributeLoader."""
-        alias_map: Dict[str, Type[Attribute]] = {}
+    def _build_column_to_field_id_map(self) -> Dict[str, str]:
+        """Build lowercase alias-to-field-id mapping from AttributeLoader."""
+        field_id_map: Dict[str, str] = {}
         attributes: Set[Attribute] = AttributeLoader.load()
         for attribute in attributes:
             for alias in attribute.get_aliases():
-                alias_map[alias.lower()] = type(attribute)
-        return alias_map
+                field_id_map[alias.lower()] = attribute.get_name()
+        return field_id_map

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/person_attributes_reader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/io/person_attributes_reader.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: MIT
 
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, Type
-
-from openlinktoken.attributes.attribute import Attribute
+from typing import Dict, Iterator
 
 
-class PersonAttributesReader(ABC, Iterator[Dict[Type[Attribute], str]]):
+class PersonAttributesReader(ABC, Iterator[Dict[str, str]]):
     """
     A generic interface for a streaming person attributes reader.
     """
@@ -17,23 +15,23 @@ class PersonAttributesReader(ABC, Iterator[Dict[Type[Attribute], str]]):
         pass
 
     @abstractmethod
-    def __next__(self) -> Dict[Type[Attribute], str]:
+    def __next__(self) -> Dict[str, str]:
         """
         Retrieve the next set of person attributes from an input source.
 
         Example person attribute map:
         {
-            RecordIdAttribute: "2ea45fee-90c3-494a-a503-36022c9e1281",
-            FirstNameAttribute: "John",
-            LastNameAttribute: "Doe",
-            SexAttribute: "Male",
-            BirthDateAttribute: "01/01/2001",
-            PostalCodeAttribute: "54321",
-            SocialSecurityNumberAttribute: "123-45-6789"
+            "RecordId": "2ea45fee-90c3-494a-a503-36022c9e1281",
+            "FirstName": "John",
+            "LastName": "Doe",
+            "Sex": "Male",
+            "BirthDate": "01/01/2001",
+            "PostalCode": "54321",
+            "SocialSecurityNumber": "123-45-6789"
         }
 
         Returns:
-            A person attributes map.
+            A person attributes map keyed by field id.
         """
         pass
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Set, Type
 
 from openlinktoken.attributes.attribute import Attribute
+from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
 from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
@@ -273,8 +274,14 @@ class PersonAttributesProcessor:
         # Sort token IDs for consistent output
         token_ids = sorted(token_generator_result.tokens.keys())
 
-        # Generate a UUID for RecordId if it's not present in the input data.
-        record_id = row.get("RecordId")
+        # In config-driven mode the row is keyed by unique RecordIdAttribute subclasses,
+        # so scan for any subclass key before falling back to a random UUID.
+        record_id = row.get(RecordIdAttribute) or row.get("RecordId")
+        if record_id is None or record_id == "":
+            for key in row:
+                if isinstance(key, type) and issubclass(key, RecordIdAttribute):
+                    record_id = row[key]
+                    break
         if record_id is None or record_id == "":
             record_id = str(uuid.uuid4())
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Set, Type
 
 from openlinktoken.attributes.attribute import Attribute
-from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
 from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
@@ -148,9 +147,8 @@ class PersonAttributesProcessor:
             ring_id: Optional ring ID for JWE wrapping.
             hash_record_ids: When True, each record ID is SHA-256 hashed before writing.
         """
-        token_generator = TokenGenerator(token_definition, tokenizer)
-        if hasattr(token_definition, 'attribute_instance_overrides'):
-            token_generator.attribute_instance_map.update(token_definition.attribute_instance_overrides)
+        field_registry = getattr(token_definition, "field_registry", None)
+        token_generator = TokenGenerator(token_definition, tokenizer, field_registry=field_registry)
 
         row_counter = 0
         last_reported_count = 0
@@ -178,7 +176,7 @@ class PersonAttributesProcessor:
             for row in reader:
                 row_counter += 1
 
-                token_generator_result = token_generator.get_all_tokens(row)
+                token_generator_result = token_generator.get_all_tokens_via_field_id(row)
                 logger.debug(f"Tokens: {token_generator_result.tokens}")
 
                 PersonAttributesProcessor._keep_track_of_invalid_attributes(
@@ -276,14 +274,7 @@ class PersonAttributesProcessor:
         token_ids = sorted(token_generator_result.tokens.keys())
 
         # Generate a UUID for RecordId if it's not present in the input data.
-        # In config-driven mode the key is a unique subclass of RecordIdAttribute,
-        # so scan all class keys that are subclasses of RecordIdAttribute.
-        record_id = row.get(RecordIdAttribute) or row.get("RecordId")
-        if record_id is None or record_id == "":
-            for key in row:
-                if isinstance(key, type) and issubclass(key, RecordIdAttribute) and key is not RecordIdAttribute:
-                    record_id = row[key]
-                    break
+        record_id = row.get("RecordId")
         if record_id is None or record_id == "":
             record_id = str(uuid.uuid4())
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/processor/person_attributes_processor.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Set, Type
 
 from openlinktoken.attributes.attribute import Attribute
 from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
+from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
 from openlinktoken.tokens.token_generator_result import TokenGeneratorResult
@@ -58,6 +59,7 @@ class PersonAttributesProcessor:
         encryption_key: str = None,
         ring_id: str = None,
         hash_record_ids: bool = False,
+        token_definition: BaseTokenDefinition = None,
         progress_callback=None,
     ) -> PersonAttributesProcessingSummary:
         """
@@ -76,8 +78,7 @@ class PersonAttributesProcessor:
             hash_record_ids: When True, each record ID is SHA-256 hashed before writing
                              to the output. This is a one-way operation with no traceability.
         """
-        # TokenGenerator code
-        token_definition = TokenDefinition()
+        token_definition = token_definition or TokenDefinition()
         return PersonAttributesProcessor._process_with_tokenizer(
             reader,
             writer,
@@ -96,6 +97,7 @@ class PersonAttributesProcessor:
         writer: PersonAttributesWriter,
         tokenizer: Tokenizer,
         metadata_map: Dict[str, Any] = None,
+        token_definition: BaseTokenDefinition = None,
         progress_callback=None,
     ) -> PersonAttributesProcessingSummary:
         """
@@ -111,7 +113,7 @@ class PersonAttributesProcessor:
             tokenizer: The tokenizer to use (e.g. SHA256Tokenizer or PassthroughTokenizer).
             metadata_map: Optional metadata map to update with processing statistics.
         """
-        token_definition = TokenDefinition()
+        token_definition = token_definition or TokenDefinition()
         return PersonAttributesProcessor._process_with_tokenizer(
             reader,
             writer,
@@ -126,7 +128,7 @@ class PersonAttributesProcessor:
         reader: PersonAttributesReader,
         writer: PersonAttributesWriter,
         tokenizer: Tokenizer,
-        token_definition: TokenDefinition,
+        token_definition: BaseTokenDefinition,
         metadata_map: Dict[str, Any] = None,
         encryption_key: str = None,
         ring_id: str = None,
@@ -147,6 +149,8 @@ class PersonAttributesProcessor:
             hash_record_ids: When True, each record ID is SHA-256 hashed before writing.
         """
         token_generator = TokenGenerator(token_definition, tokenizer)
+        if hasattr(token_definition, 'attribute_instance_overrides'):
+            token_generator.attribute_instance_map.update(token_definition.attribute_instance_overrides)
 
         row_counter = 0
         last_reported_count = 0
@@ -246,7 +250,7 @@ class PersonAttributesProcessor:
     @staticmethod
     def _write_tokens(
         writer: PersonAttributesWriter,
-        row: Dict[Type[Attribute], str],
+        row: Dict[object, str],
         row_counter: int,
         token_generator_result: TokenGeneratorResult,
         encryption_key: str = None,
@@ -271,8 +275,15 @@ class PersonAttributesProcessor:
         # Sort token IDs for consistent output
         token_ids = sorted(token_generator_result.tokens.keys())
 
-        # Generate a UUID for RecordId if it's not present in the input data
-        record_id = row.get(RecordIdAttribute)
+        # Generate a UUID for RecordId if it's not present in the input data.
+        # In config-driven mode the key is a unique subclass of RecordIdAttribute,
+        # so scan all class keys that are subclasses of RecordIdAttribute.
+        record_id = row.get(RecordIdAttribute) or row.get("RecordId")
+        if record_id is None or record_id == "":
+            for key in row:
+                if isinstance(key, type) and issubclass(key, RecordIdAttribute) and key is not RecordIdAttribute:
+                    record_id = row[key]
+                    break
         if record_id is None or record_id == "":
             record_id = str(uuid.uuid4())
 
@@ -323,6 +334,7 @@ class PersonAttributesProcessor:
             logger.info(f"Invalid Attributes for row {row_counter:,}: {token_generator_result.invalid_attributes}")
 
             for invalid_attribute in token_generator_result.invalid_attributes:
+                invalid_attribute_count.setdefault(invalid_attribute, 0)
                 invalid_attribute_count[invalid_attribute] += 1
 
     @staticmethod

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/__init__.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/__init__.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/configured_attribute_resolver.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/configured_attribute_resolver.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: MIT
 
-from typing import Dict, Set, Type
+from typing import Dict, Type
 
 from openlinktoken.attributes.attribute import Attribute
 from openlinktoken.attributes.attribute_loader import AttributeLoader
+from openlinktoken.attributes.field_registry import FieldRegistry
 from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
 
 
-class DynamicAttributeFactory:
+class ConfiguredAttributeResolver:
     """Resolves config field ids to built-in attribute classes and column mappings."""
 
     def __init__(self, config: TokenizationConfig):
@@ -17,13 +18,11 @@ class DynamicAttributeFactory:
             config: Parsed tokenization config whose attribute entries drive the mappings.
         """
         self._field_id_to_class: Dict[str, Type[Attribute]] = {}
+        self._field_id_to_instance: Dict[str, Attribute] = {}
         self._column_to_field_id: Dict[str, str] = {}
-        self._attribute_instance_overrides: Dict[Type[Attribute], Attribute] = {}
 
         type_name_to_base_class = self._build_type_name_index()
-        base_class_to_instance: Dict[Type[Attribute], Attribute] = {
-            type(attr): attr for attr in AttributeLoader.load()
-        }
+        base_class_to_instance: Dict[Type[Attribute], Attribute] = {type(attr): attr for attr in AttributeLoader.load()}
         self._register_field_mappings(config.attributes, type_name_to_base_class, base_class_to_instance)
 
     def get_class_for_field(self, field_id: str) -> Type[Attribute]:
@@ -40,21 +39,6 @@ class DynamicAttributeFactory:
         """
         return self._field_id_to_class[field_id]
 
-    def get_class_for_column(self, column: str) -> Type[Attribute]:
-        """Return the attribute class mapped to an input column name.
-
-        Args:
-            column: The input column name as it appears in the data source.
-
-        Returns:
-            The attribute class associated with the column.
-
-        Raises:
-            KeyError: If the column name has no registered mapping.
-        """
-        field_id = self._column_to_field_id[column]
-        return self._field_id_to_class[field_id]
-
     def get_field_for_column(self, column: str) -> str:
         """Return the logical field id for an input column name.
 
@@ -69,26 +53,16 @@ class DynamicAttributeFactory:
         """
         return self._column_to_field_id[column]
 
-    def get_attribute_instance_overrides(self) -> Dict[Type[Attribute], Attribute]:
-        """Return per-field class to attribute instance mappings for TokenGenerator injection.
-
-        Each field gets a unique subclass of its base attribute type so that two fields
-        sharing the same type can coexist in the per-row attribute dict without collision.
-        The returned dict maps each unique field class to the real attribute instance
-        (shared with the base class) so that normalization and validation still work.
+    def build_field_registry(self) -> FieldRegistry:
+        """Build a FieldRegistry from all configured field-to-attribute mappings.
 
         Returns:
-            A dict of unique field class to attribute instance.
+            A registry mapping each configured field id to its attribute instance.
         """
-        return self._attribute_instance_overrides
-
-    def get_all_classes(self) -> Set[Type[Attribute]]:
-        """Return all attribute classes registered across all configured fields.
-
-        Returns:
-            A set of every attribute class present in the config.
-        """
-        return set(self._field_id_to_class.values())
+        builder = FieldRegistry.Builder()
+        for field_id, instance in self._field_id_to_instance.items():
+            builder.register(field_id, self._field_id_to_class[field_id], instance)
+        return builder.build()
 
     def _register_field_mappings(
         self,
@@ -104,14 +78,9 @@ class DynamicAttributeFactory:
                     f"Recognized types are: {sorted(type_name_to_base_class.keys())}."
                 )
 
-            # Each field gets a unique subclass so two fields sharing the same type
-            # produce distinct keys in the per-row attribute dict, preventing silent
-            # overwrites during token generation.
-            field_class = type(f"_DynAttr_{entry.field}", (base_class,), {})
-
-            self._field_id_to_class[entry.field] = field_class
+            self._field_id_to_class[entry.field] = base_class
+            self._field_id_to_instance[entry.field] = base_class_to_instance[base_class]
             self._column_to_field_id[column] = entry.field
-            self._attribute_instance_overrides[field_class] = base_class_to_instance[base_class]
 
     @staticmethod
     def _build_type_name_index() -> Dict[str, Type[Attribute]]:
@@ -122,9 +91,9 @@ class DynamicAttributeFactory:
         )
         for attribute in attributes:
             attribute_class = type(attribute)
-            DynamicAttributeFactory._register_index_mapping(index, attribute.get_name(), attribute_class)
+            ConfiguredAttributeResolver._register_index_mapping(index, attribute.get_name(), attribute_class)
             for alias in attribute.get_aliases():
-                DynamicAttributeFactory._register_index_mapping(index, alias, attribute_class)
+                ConfiguredAttributeResolver._register_index_mapping(index, alias, attribute_class)
         return index
 
     @staticmethod

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/configured_attribute_resolver.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/configured_attribute_resolver.py
@@ -22,8 +22,10 @@ class ConfiguredAttributeResolver:
         self._column_to_field_id: Dict[str, str] = {}
 
         type_name_to_base_class = self._build_type_name_index()
-        base_class_to_instance: Dict[Type[Attribute], Attribute] = {type(attr): attr for attr in AttributeLoader.load()}
-        self._register_field_mappings(config.attributes, type_name_to_base_class, base_class_to_instance)
+        base_class_to_instance: Dict[Type[Attribute], Attribute] = {
+            type(attr): attr for attr in AttributeLoader.load()
+        }
+        self._register_field_mappings(config.column_mappings, type_name_to_base_class, base_class_to_instance)
 
     def get_class_for_field(self, field_id: str) -> Type[Attribute]:
         """Return the attribute class registered for a logical field id.
@@ -70,17 +72,22 @@ class ConfiguredAttributeResolver:
         type_name_to_base_class: Dict[str, Type[Attribute]],
         base_class_to_instance: Dict[Type[Attribute], Attribute],
     ) -> None:
-        for column, entry in attributes.items():
+        for field_id, entry in attributes.items():
             base_class = type_name_to_base_class.get(entry.type)
             if base_class is None:
                 raise ValueError(
-                    f"Unknown attribute type '{entry.type}' for field '{entry.field}'. "
+                    f"Unknown attribute type '{entry.type}' for field '{field_id}'. "
                     f"Recognized types are: {sorted(type_name_to_base_class.keys())}."
                 )
 
-            self._field_id_to_class[entry.field] = base_class
-            self._field_id_to_instance[entry.field] = base_class_to_instance[base_class]
-            self._column_to_field_id[column] = entry.field
+            # Each field gets a unique subclass so two fields sharing the same type
+            # produce distinct keys in the per-row attribute dict, preventing silent
+            # overwrites during token generation.
+            field_class = type(f"_DynAttr_{field_id}", (base_class,), {})
+
+            self._field_id_to_class[field_id] = field_class
+            self._field_id_to_instance[field_id] = base_class_to_instance[base_class]
+            self._column_to_field_id[entry.column_name] = field_id
 
     @staticmethod
     def _build_type_name_index() -> Dict[str, Type[Attribute]]:

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/dynamic_attribute_factory.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/dynamic_attribute_factory.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: MIT
+
+from typing import Dict, Set, Type
+
+from openlinktoken.attributes.attribute import Attribute
+from openlinktoken.attributes.attribute_loader import AttributeLoader
+from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
+
+
+class DynamicAttributeFactory:
+    """Resolves config field ids to built-in attribute classes and column mappings."""
+
+    def __init__(self, config: TokenizationConfig):
+        """Build lookup indexes from a parsed tokenization config.
+
+        Args:
+            config: Parsed tokenization config whose attribute entries drive the mappings.
+        """
+        self._field_id_to_class: Dict[str, Type[Attribute]] = {}
+        self._column_to_field_id: Dict[str, str] = {}
+        self._attribute_instance_overrides: Dict[Type[Attribute], Attribute] = {}
+
+        type_name_to_base_class = self._build_type_name_index()
+        base_class_to_instance: Dict[Type[Attribute], Attribute] = {
+            type(attr): attr for attr in AttributeLoader.load()
+        }
+        self._register_field_mappings(config.attributes, type_name_to_base_class, base_class_to_instance)
+
+    def get_class_for_field(self, field_id: str) -> Type[Attribute]:
+        """Return the attribute class registered for a logical field id.
+
+        Args:
+            field_id: The logical field identifier defined in the tokenization config.
+
+        Returns:
+            The attribute class mapped to the given field id.
+
+        Raises:
+            KeyError: If no class is registered for the field id.
+        """
+        return self._field_id_to_class[field_id]
+
+    def get_class_for_column(self, column: str) -> Type[Attribute]:
+        """Return the attribute class mapped to an input column name.
+
+        Args:
+            column: The input column name as it appears in the data source.
+
+        Returns:
+            The attribute class associated with the column.
+
+        Raises:
+            KeyError: If the column name has no registered mapping.
+        """
+        field_id = self._column_to_field_id[column]
+        return self._field_id_to_class[field_id]
+
+    def get_field_for_column(self, column: str) -> str:
+        """Return the logical field id for an input column name.
+
+        Args:
+            column: The input column name as it appears in the data source.
+
+        Returns:
+            The logical field id mapped to the column.
+
+        Raises:
+            KeyError: If the column name has no registered mapping.
+        """
+        return self._column_to_field_id[column]
+
+    def get_attribute_instance_overrides(self) -> Dict[Type[Attribute], Attribute]:
+        """Return per-field class to attribute instance mappings for TokenGenerator injection.
+
+        Each field gets a unique subclass of its base attribute type so that two fields
+        sharing the same type can coexist in the per-row attribute dict without collision.
+        The returned dict maps each unique field class to the real attribute instance
+        (shared with the base class) so that normalization and validation still work.
+
+        Returns:
+            A dict of unique field class to attribute instance.
+        """
+        return self._attribute_instance_overrides
+
+    def get_all_classes(self) -> Set[Type[Attribute]]:
+        """Return all attribute classes registered across all configured fields.
+
+        Returns:
+            A set of every attribute class present in the config.
+        """
+        return set(self._field_id_to_class.values())
+
+    def _register_field_mappings(
+        self,
+        attributes: Dict[str, AttributeMappingEntry],
+        type_name_to_base_class: Dict[str, Type[Attribute]],
+        base_class_to_instance: Dict[Type[Attribute], Attribute],
+    ) -> None:
+        for column, entry in attributes.items():
+            base_class = type_name_to_base_class.get(entry.type)
+            if base_class is None:
+                raise ValueError(
+                    f"Unknown attribute type '{entry.type}' for field '{entry.field}'. "
+                    f"Recognized types are: {sorted(type_name_to_base_class.keys())}."
+                )
+
+            # Each field gets a unique subclass so two fields sharing the same type
+            # produce distinct keys in the per-row attribute dict, preventing silent
+            # overwrites during token generation.
+            field_class = type(f"_DynAttr_{entry.field}", (base_class,), {})
+
+            self._field_id_to_class[entry.field] = field_class
+            self._column_to_field_id[column] = entry.field
+            self._attribute_instance_overrides[field_class] = base_class_to_instance[base_class]
+
+    @staticmethod
+    def _build_type_name_index() -> Dict[str, Type[Attribute]]:
+        index: Dict[str, Type[Attribute]] = {}
+        attributes = sorted(
+            AttributeLoader.load(),
+            key=lambda attribute: (type(attribute).__name__, attribute.get_name()),
+        )
+        for attribute in attributes:
+            attribute_class = type(attribute)
+            DynamicAttributeFactory._register_index_mapping(index, attribute.get_name(), attribute_class)
+            for alias in attribute.get_aliases():
+                DynamicAttributeFactory._register_index_mapping(index, alias, attribute_class)
+        return index
+
+    @staticmethod
+    def _register_index_mapping(
+        index: Dict[str, Type[Attribute]],
+        type_name: str,
+        attribute_class: Type[Attribute],
+    ) -> None:
+        existing = index.get(type_name)
+        if existing is not None and existing is not attribute_class:
+            raise ValueError(
+                f"Conflicting attribute type mapping for '{type_name}': "
+                f"'{existing.__name__}' and '{attribute_class.__name__}'."
+            )
+
+        index[type_name] = attribute_class

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/dynamic_token_definition.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/dynamic_token_definition.py
@@ -3,8 +3,9 @@
 from typing import Dict, List, Set
 
 from openlinktoken.attributes.attribute_expression import AttributeExpression
+from openlinktoken.attributes.field_registry import FieldRegistry
 from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
 from openlinktoken_cli.tokens.config.tokenization_config import TokenizationConfig
 
 
@@ -13,25 +14,25 @@ class DynamicTokenDefinition(BaseTokenDefinition):
 
     VERSION = "custom"
 
-    def __init__(self, config: TokenizationConfig, factory: DynamicAttributeFactory):
-        """Build token definitions from config entries resolved by the attribute factory.
+    def __init__(self, config: TokenizationConfig, resolver: ConfiguredAttributeResolver):
+        """Build token definitions from config entries resolved by the attribute resolver.
 
         Args:
             config: Parsed tokenization configuration containing token rule entries.
-            factory: Dynamic attribute factory used to resolve each rule field id
-                to its generated attribute class.
+            resolver: Attribute resolver used to resolve each rule field id
+                to its attribute class and build the field registry.
 
         Returns:
             None. Populates ``self._definitions`` for runtime token generation.
         """
         self._definitions: Dict[str, List[AttributeExpression]] = {}
-        self.attribute_instance_overrides = factory.get_attribute_instance_overrides()
+        self.field_registry: FieldRegistry = resolver.build_field_registry()
 
         for token_id, rule_entries in config.token_rules.items():
             expressions = []
             for entry in rule_entries:
-                attribute_class = factory.get_class_for_field(entry.field)
-                expressions.append(AttributeExpression(attribute_class, entry.expression))
+                attribute_class = resolver.get_class_for_field(entry.field)
+                expressions.append(AttributeExpression.of(entry.field, attribute_class, entry.expression))
             self._definitions[token_id] = expressions
 
     def get_version(self) -> str:

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/dynamic_token_definition.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/dynamic_token_definition.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+
+from typing import Dict, List, Set
+
+from openlinktoken.attributes.attribute_expression import AttributeExpression
+from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.tokenization_config import TokenizationConfig
+
+
+class DynamicTokenDefinition(BaseTokenDefinition):
+    """A token definition built at runtime from a custom tokenization configuration."""
+
+    VERSION = "custom"
+
+    def __init__(self, config: TokenizationConfig, factory: DynamicAttributeFactory):
+        """Build token definitions from config entries resolved by the attribute factory.
+
+        Args:
+            config: Parsed tokenization configuration containing token rule entries.
+            factory: Dynamic attribute factory used to resolve each rule field id
+                to its generated attribute class.
+
+        Returns:
+            None. Populates ``self._definitions`` for runtime token generation.
+        """
+        self._definitions: Dict[str, List[AttributeExpression]] = {}
+        self.attribute_instance_overrides = factory.get_attribute_instance_overrides()
+
+        for token_id, rule_entries in config.token_rules.items():
+            expressions = []
+            for entry in rule_entries:
+                attribute_class = factory.get_class_for_field(entry.field)
+                expressions.append(AttributeExpression(attribute_class, entry.expression))
+            self._definitions[token_id] = expressions
+
+    def get_version(self) -> str:
+        """Return the runtime token-definition version identifier.
+
+        Returns:
+            The string ``"custom"`` indicating config-driven token definitions.
+        """
+        return self.VERSION
+
+    def get_token_identifiers(self) -> Set[str]:
+        """Return all configured token/rule ids.
+
+        Returns:
+            A set of token ids defined in the input configuration.
+        """
+        return set(self._definitions.keys())
+
+    def get_token_definition(self, token_id: str) -> List[AttributeExpression]:
+        """Return the ordered attribute-expression definition for a token id.
+
+        Args:
+            token_id: Token/rule identifier to retrieve.
+
+        Returns:
+            The list of ``AttributeExpression`` entries for the token id, or an
+            empty list when the token id is not present.
+        """
+        return self._definitions.get(token_id, [])

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 class AttributeMappingEntry:
     """Represents a single attribute mapping entry from the config file."""
 
-    field: str
+    column_name: str
     type: str
 
 
@@ -24,5 +24,5 @@ class TokenRuleEntry:
 class TokenizationConfig:
     """Parsed representation of a custom tokenization configuration file."""
 
-    attributes: Dict[str, AttributeMappingEntry] = field(default_factory=dict)
+    column_mappings: Dict[str, AttributeMappingEntry] = field(default_factory=dict)
     token_rules: Dict[str, List[TokenRuleEntry]] = field(default_factory=dict)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class AttributeMappingEntry:
+    """Represents a single attribute mapping entry from the config file."""
+
+    field: str
+    type: str
+
+
+@dataclass
+class TokenRuleEntry:
+    """Represents a single entry in a token rule definition."""
+
+    field: str
+    expression: str
+
+
+@dataclass
+class TokenizationConfig:
+    """Parsed representation of a custom tokenization configuration file."""
+
+    attributes: Dict[str, AttributeMappingEntry] = field(default_factory=dict)
+    token_rules: Dict[str, List[TokenRuleEntry]] = field(default_factory=dict)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_helper.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_helper.py
@@ -1,0 +1,72 @@
+"""Shared helper utilities for config-driven tokenization workflows."""
+
+import logging
+from typing import Optional
+
+from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
+from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.tokenization_config import TokenizationConfig
+from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
+logger = logging.getLogger(__name__)
+
+
+class TokenizationConfigHelper:
+    """Utilities for mapping config-driven attributes and creating readers."""
+
+    @staticmethod
+    def build_configured_input_attribute_map(
+        config: TokenizationConfig,
+        factory: DynamicAttributeFactory,
+    ) -> dict:
+        """Build input-column-to-attribute-class mapping from tokenization config.
+
+        Args:
+            config: Parsed tokenization config containing the attribute column mappings.
+            factory: Factory used to resolve each config column to its built-in attribute class.
+
+        Returns:
+            A dict mapping each input column name to its corresponding attribute class.
+        """
+        attribute_map = {}
+        for column in config.attributes:
+            try:
+                attribute_map[column] = factory.get_class_for_column(column)
+            except KeyError:
+                logger.warning("Column '%s' is in config but has no dynamic class registered.", column)
+        return attribute_map
+
+    @staticmethod
+    def create_reader(
+        path: str,
+        file_type: str,
+        config: Optional[TokenizationConfig] = None,
+        factory: Optional[DynamicAttributeFactory] = None,
+    ):
+        """Create and optionally configure a reader for CSV or Parquet inputs.
+
+        Args:
+            path: Path to the input file.
+            file_type: Format of the input file; must be 'csv' or 'parquet' (case-insensitive).
+            config: Optional tokenization config used to build the attribute map.
+            factory: Optional factory required when config is provided.
+
+        Returns:
+            A PersonAttributesCSVReader or PersonAttributesParquetReader initialised with
+            the resolved attribute map when a config is supplied, or with no map otherwise.
+
+        Raises:
+            ValueError: If file_type is not 'csv' or 'parquet'.
+        """
+        attribute_map = None
+        if config is not None and factory is not None:
+            attribute_map = TokenizationConfigHelper.build_configured_input_attribute_map(config, factory)
+
+        file_type_lower = file_type.lower()
+        if file_type_lower == FileTypeDetector.TYPE_CSV:
+            return PersonAttributesCSVReader(path, attribute_map=attribute_map)
+        if file_type_lower == FileTypeDetector.TYPE_PARQUET:
+            return PersonAttributesParquetReader(path, attribute_map=attribute_map)
+
+        raise ValueError(f"Unsupported input type: {file_type}")

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_helper.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_helper.py
@@ -30,11 +30,11 @@ class TokenizationConfigHelper:
             A dict mapping each input column name to its corresponding field id string.
         """
         attribute_map = {}
-        for column in config.attributes:
+        for field_id, entry in config.column_mappings.items():
             try:
-                attribute_map[column] = resolver.get_field_for_column(column)
+                attribute_map[entry.column_name] = resolver.get_field_for_column(entry.column_name)
             except KeyError:
-                logger.warning("Column '%s' is in config but has no field id registered.", column)
+                logger.warning("Column '%s' is in config but has no field id registered.", entry.column_name)
         return attribute_map
 
     @staticmethod

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_helper.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_helper.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
 from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
 from openlinktoken_cli.tokens.config.tokenization_config import TokenizationConfig
 from openlinktoken_cli.util.file_type_detector import FileTypeDetector
 
@@ -18,23 +18,23 @@ class TokenizationConfigHelper:
     @staticmethod
     def build_configured_input_attribute_map(
         config: TokenizationConfig,
-        factory: DynamicAttributeFactory,
+        resolver: ConfiguredAttributeResolver,
     ) -> dict:
-        """Build input-column-to-attribute-class mapping from tokenization config.
+        """Build input-column-to-field-id mapping from tokenization config.
 
         Args:
             config: Parsed tokenization config containing the attribute column mappings.
-            factory: Factory used to resolve each config column to its built-in attribute class.
+            resolver: Resolver used to resolve each config column to its logical field id.
 
         Returns:
-            A dict mapping each input column name to its corresponding attribute class.
+            A dict mapping each input column name to its corresponding field id string.
         """
         attribute_map = {}
         for column in config.attributes:
             try:
-                attribute_map[column] = factory.get_class_for_column(column)
+                attribute_map[column] = resolver.get_field_for_column(column)
             except KeyError:
-                logger.warning("Column '%s' is in config but has no dynamic class registered.", column)
+                logger.warning("Column '%s' is in config but has no field id registered.", column)
         return attribute_map
 
     @staticmethod
@@ -42,7 +42,7 @@ class TokenizationConfigHelper:
         path: str,
         file_type: str,
         config: Optional[TokenizationConfig] = None,
-        factory: Optional[DynamicAttributeFactory] = None,
+        resolver: Optional[ConfiguredAttributeResolver] = None,
     ):
         """Create and optionally configure a reader for CSV or Parquet inputs.
 
@@ -50,7 +50,7 @@ class TokenizationConfigHelper:
             path: Path to the input file.
             file_type: Format of the input file; must be 'csv' or 'parquet' (case-insensitive).
             config: Optional tokenization config used to build the attribute map.
-            factory: Optional factory required when config is provided.
+            resolver: Optional resolver required when config is provided.
 
         Returns:
             A PersonAttributesCSVReader or PersonAttributesParquetReader initialised with
@@ -60,8 +60,8 @@ class TokenizationConfigHelper:
             ValueError: If file_type is not 'csv' or 'parquet'.
         """
         attribute_map = None
-        if config is not None and factory is not None:
-            attribute_map = TokenizationConfigHelper.build_configured_input_attribute_map(config, factory)
+        if config is not None and resolver is not None:
+            attribute_map = TokenizationConfigHelper.build_configured_input_attribute_map(config, resolver)
 
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_loader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_loader.py
@@ -20,6 +20,14 @@ logger = logging.getLogger(__name__)
 class TokenizationConfigLoader:
     """Loads and validates a tokenization configuration from a YAML file."""
 
+    KEY_COLUMN_MAPPINGS = "column_mappings"
+    KEY_TOKEN_RULES = "token_rules"
+    KEY_COLUMN_NAME = "column_name"
+    KEY_TYPE = "type"
+    KEY_FIELD = "field"
+    KEY_EXPRESSION = "expression"
+    RECORD_ID_TYPE = "RecordId"
+
     @staticmethod
     def load_runtime_components(
         tokenization_config_path: Optional[str] = None,
@@ -71,51 +79,67 @@ class TokenizationConfigLoader:
         Returns:
             Parsed TokenizationConfig with normalized attributes and token rules.
         """
-        if "attributes" not in raw or not raw["attributes"]:
-            raise ValueError(f"Configuration '{file_path}' must define a non-empty 'attributes' section.")
+        if (
+            TokenizationConfigLoader.KEY_COLUMN_MAPPINGS not in raw
+            or not raw[TokenizationConfigLoader.KEY_COLUMN_MAPPINGS]
+        ):
+            raise ValueError(f"Configuration '{file_path}' must define a non-empty 'column_mappings' section.")
 
-        if "token_rules" not in raw or not raw["token_rules"]:
+        if TokenizationConfigLoader.KEY_TOKEN_RULES not in raw or not raw[TokenizationConfigLoader.KEY_TOKEN_RULES]:
             raise ValueError(f"Configuration '{file_path}' must define a non-empty 'token_rules' section.")
 
-        attributes = TokenizationConfigLoader._parse_attributes(raw["attributes"], file_path)
-        token_rules = TokenizationConfigLoader._parse_token_rules(raw["token_rules"], attributes, file_path)
+        column_mappings = TokenizationConfigLoader._parse_column_mappings(
+            raw[TokenizationConfigLoader.KEY_COLUMN_MAPPINGS], file_path
+        )
+        token_rules = TokenizationConfigLoader._parse_token_rules(
+            raw[TokenizationConfigLoader.KEY_TOKEN_RULES], column_mappings, file_path
+        )
 
-        if not any(entry.type == "RecordId" for entry in attributes.values()):
+        if not any(entry.type == TokenizationConfigLoader.RECORD_ID_TYPE for entry in column_mappings.values()):
             logger.warning(
-                "Configuration '%s' does not map any column to type 'RecordId'. "
+                "Configuration '%s' does not map any field to type 'RecordId'. "
                 "Source record IDs will not be preserved — output will use randomly generated UUIDs instead.",
                 file_path,
             )
 
-        return TokenizationConfig(attributes=attributes, token_rules=token_rules)
+        return TokenizationConfig(column_mappings=column_mappings, token_rules=token_rules)
 
     @staticmethod
-    def _parse_attributes(raw_attributes: Any, file_path: str) -> Dict[str, AttributeMappingEntry]:
-        """Parse attribute mappings keyed by source column name.
+    def _parse_column_mappings(raw_column_mappings: Any, file_path: str) -> Dict[str, AttributeMappingEntry]:
+        """Parse column mappings keyed by logical field id.
 
         Args:
-            raw_attributes: Raw attributes section from the YAML payload.
+            raw_column_mappings: Raw column_mappings section from the YAML payload.
             file_path: Source path used for validation error context.
 
         Returns:
-            Mapping of source column names to AttributeMappingEntry values.
+            Mapping of logical field ids to AttributeMappingEntry values.
         """
-        if not isinstance(raw_attributes, dict):
-            raise ValueError(f"Configuration '{file_path}': 'attributes' must be a mapping.")
+        if not isinstance(raw_column_mappings, dict):
+            raise ValueError(f"Configuration '{file_path}': 'column_mappings' must be a mapping.")
 
-        attributes = {}
-        for column, entry in raw_attributes.items():
+        column_mappings = {}
+        for field_id, entry in raw_column_mappings.items():
             if not isinstance(entry, dict):
-                raise ValueError(f"Configuration '{file_path}': attribute entry for '{column}' must be a mapping.")
-            if "field" not in entry or not entry["field"]:
+                raise ValueError(f"Configuration '{file_path}': attribute entry for '{field_id}' must be a mapping.")
+            if (
+                TokenizationConfigLoader.KEY_COLUMN_NAME not in entry
+                or not entry[TokenizationConfigLoader.KEY_COLUMN_NAME]
+            ):
                 raise ValueError(
-                    f"Configuration '{file_path}': attribute '{column}' is missing required field 'field'."
+                    f"Configuration '{file_path}': column_mappings entry '{field_id}' "
+                    f"is missing required field 'column_name'."
                 )
-            if "type" not in entry or not entry["type"]:
-                raise ValueError(f"Configuration '{file_path}': attribute '{column}' is missing required field 'type'.")
-            attributes[column] = AttributeMappingEntry(field=entry["field"], type=entry["type"])
+            if TokenizationConfigLoader.KEY_TYPE not in entry or not entry[TokenizationConfigLoader.KEY_TYPE]:
+                raise ValueError(
+                    f"Configuration '{file_path}': attribute '{field_id}' is missing required field 'type'."
+                )
+            column_mappings[field_id] = AttributeMappingEntry(
+                column_name=entry[TokenizationConfigLoader.KEY_COLUMN_NAME],
+                type=entry[TokenizationConfigLoader.KEY_TYPE],
+            )
 
-        return attributes
+        return column_mappings
 
     @staticmethod
     def _parse_token_rules(
@@ -136,8 +160,8 @@ class TokenizationConfigLoader:
         if not isinstance(raw_token_rules, dict):
             raise ValueError(f"Configuration '{file_path}': 'token_rules' must be a mapping.")
 
-        # Token rules reference logical field ids, not input column names.
-        valid_field_ids = {entry.field for entry in attributes.values()}
+        # Token rules reference logical field ids defined in column_mappings.
+        valid_field_ids = set(attributes.keys())
         token_rules = {}
         for token_id, entries in raw_token_rules.items():
             if not isinstance(entries, list) or not entries:
@@ -148,23 +172,33 @@ class TokenizationConfigLoader:
                     raise ValueError(
                         f"Configuration '{file_path}': token rule '{token_id}' entry {index} must be a mapping."
                     )
-                if "field" not in entry or not entry["field"]:
+                if TokenizationConfigLoader.KEY_FIELD not in entry or not entry[TokenizationConfigLoader.KEY_FIELD]:
                     raise ValueError(
                         f"Configuration '{file_path}': token rule '{token_id}' entry {index} is missing 'field'."
                     )
-                if "expression" not in entry or not entry["expression"]:
+                if (
+                    TokenizationConfigLoader.KEY_EXPRESSION not in entry
+                    or not entry[TokenizationConfigLoader.KEY_EXPRESSION]
+                ):
                     raise ValueError(
                         f"Configuration '{file_path}': token rule '{token_id}' entry {index} is missing 'expression'."
                     )
-                field_id = entry["field"]
+                field_id = entry[TokenizationConfigLoader.KEY_FIELD]
                 if field_id not in valid_field_ids:
                     raise ValueError(
                         # Include valid ids in the error so configuration issues are actionable.
                         f"Configuration '{file_path}': token rule '{token_id}' references unknown field "
                         f"'{field_id}'. Valid field ids are: {sorted(valid_field_ids)}."
                     )
-                TokenizationConfigLoader._validate_expression(entry["expression"], token_id, index, file_path)
-                rule_entries.append(TokenRuleEntry(field=field_id, expression=entry["expression"]))
+                TokenizationConfigLoader._validate_expression(
+                    entry[TokenizationConfigLoader.KEY_EXPRESSION], token_id, index, file_path
+                )
+                rule_entries.append(
+                    TokenRuleEntry(
+                        field=field_id,
+                        expression=entry[TokenizationConfigLoader.KEY_EXPRESSION],
+                    )
+                )
             token_rules[token_id] = rule_entries
 
         return token_rules

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_loader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_loader.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: MIT
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+import yaml
+
+from openlinktoken_cli.tokens.config.tokenization_config import (
+    AttributeMappingEntry,
+    TokenizationConfig,
+    TokenRuleEntry,
+)
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
+
+logger = logging.getLogger(__name__)
+
+
+class TokenizationConfigLoader:
+    """Loads and validates a tokenization configuration from a YAML file."""
+
+    @staticmethod
+    def load_runtime_components(
+        tokenization_config_path: Optional[str] = None,
+    ) -> tuple[TokenizationConfig | None, DynamicAttributeFactory | None, DynamicTokenDefinition | None]:
+        """Load config and build runtime components used by tokenization commands.
+
+        Args:
+            tokenization_config_path: Optional path to a YAML tokenization config.
+                When omitted or None, returns a tuple of Nones.
+
+        Returns:
+            Tuple of (TokenizationConfig, DynamicAttributeFactory, DynamicTokenDefinition)
+            or (None, None, None) when no config path is provided.
+        """
+        if not tokenization_config_path:
+            return None, None, None
+
+        config = TokenizationConfigLoader.load(tokenization_config_path)
+        factory = DynamicAttributeFactory(config)
+        token_definition = DynamicTokenDefinition(config, factory)
+        return config, factory, token_definition
+
+    @staticmethod
+    def load(file_path: str) -> TokenizationConfig:
+        """Read YAML from disk and return a validated tokenization config.
+
+        Args:
+            file_path: Path to the YAML configuration file.
+
+        Returns:
+            Parsed and validated TokenizationConfig instance.
+        """
+        with open(file_path, "r", encoding="utf-8") as file:
+            raw = yaml.safe_load(file)
+
+        if not isinstance(raw, dict):
+            raise ValueError(f"Configuration file '{file_path}' is not a valid YAML mapping.")
+
+        return TokenizationConfigLoader._parse(raw, file_path)
+
+    @staticmethod
+    def _parse(raw: Dict[str, Any], file_path: str) -> TokenizationConfig:
+        """Validate top-level sections, then parse attributes and token rules.
+
+        Args:
+            raw: Raw YAML payload represented as a Python mapping.
+            file_path: Source path used for validation error context.
+
+        Returns:
+            Parsed TokenizationConfig with normalized attributes and token rules.
+        """
+        if "attributes" not in raw or not raw["attributes"]:
+            raise ValueError(f"Configuration '{file_path}' must define a non-empty 'attributes' section.")
+
+        if "token_rules" not in raw or not raw["token_rules"]:
+            raise ValueError(f"Configuration '{file_path}' must define a non-empty 'token_rules' section.")
+
+        attributes = TokenizationConfigLoader._parse_attributes(raw["attributes"], file_path)
+        token_rules = TokenizationConfigLoader._parse_token_rules(raw["token_rules"], attributes, file_path)
+
+        if not any(entry.type == "RecordId" for entry in attributes.values()):
+            logger.warning(
+                "Configuration '%s' does not map any column to type 'RecordId'. "
+                "Source record IDs will not be preserved — output will use randomly generated UUIDs instead.",
+                file_path,
+            )
+
+        return TokenizationConfig(attributes=attributes, token_rules=token_rules)
+
+    @staticmethod
+    def _parse_attributes(raw_attributes: Any, file_path: str) -> Dict[str, AttributeMappingEntry]:
+        """Parse attribute mappings keyed by source column name.
+
+        Args:
+            raw_attributes: Raw attributes section from the YAML payload.
+            file_path: Source path used for validation error context.
+
+        Returns:
+            Mapping of source column names to AttributeMappingEntry values.
+        """
+        if not isinstance(raw_attributes, dict):
+            raise ValueError(f"Configuration '{file_path}': 'attributes' must be a mapping.")
+
+        attributes = {}
+        for column, entry in raw_attributes.items():
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"Configuration '{file_path}': attribute entry for '{column}' must be a mapping."
+                )
+            if "field" not in entry or not entry["field"]:
+                raise ValueError(
+                    f"Configuration '{file_path}': attribute '{column}' is missing required field 'field'."
+                )
+            if "type" not in entry or not entry["type"]:
+                raise ValueError(
+                    f"Configuration '{file_path}': attribute '{column}' is missing required field 'type'."
+                )
+            attributes[column] = AttributeMappingEntry(field=entry["field"], type=entry["type"])
+
+        return attributes
+
+    @staticmethod
+    def _parse_token_rules(
+        raw_token_rules: Any,
+        attributes: Dict[str, AttributeMappingEntry],
+        file_path: str,
+    ) -> Dict[str, list]:
+        """Parse token rules and ensure each referenced field exists in attributes.
+
+        Args:
+            raw_token_rules: Raw token_rules section from the YAML payload.
+            attributes: Parsed attributes used to validate referenced field ids.
+            file_path: Source path used for validation error context.
+
+        Returns:
+            Mapping of token ids to ordered TokenRuleEntry lists.
+        """
+        if not isinstance(raw_token_rules, dict):
+            raise ValueError(f"Configuration '{file_path}': 'token_rules' must be a mapping.")
+
+        # Token rules reference logical field ids, not input column names.
+        valid_field_ids = {entry.field for entry in attributes.values()}
+        token_rules = {}
+        for token_id, entries in raw_token_rules.items():
+            if not isinstance(entries, list) or not entries:
+                raise ValueError(
+                    f"Configuration '{file_path}': token rule '{token_id}' must be a non-empty list."
+                )
+            rule_entries = []
+            for index, entry in enumerate(entries):
+                if not isinstance(entry, dict):
+                    raise ValueError(
+                        f"Configuration '{file_path}': token rule '{token_id}' entry {index} must be a mapping."
+                    )
+                if "field" not in entry or not entry["field"]:
+                    raise ValueError(
+                        f"Configuration '{file_path}': token rule '{token_id}' entry {index} is missing 'field'."
+                    )
+                if "expression" not in entry or not entry["expression"]:
+                    raise ValueError(
+                        f"Configuration '{file_path}': token rule '{token_id}' entry {index} is missing 'expression'."
+                    )
+                field_id = entry["field"]
+                if field_id not in valid_field_ids:
+                    raise ValueError(
+                        # Include valid ids in the error so configuration issues are actionable.
+                        f"Configuration '{file_path}': token rule '{token_id}' references unknown field "
+                        f"'{field_id}'. Valid field ids are: {sorted(valid_field_ids)}."
+                    )
+                TokenizationConfigLoader._validate_expression(entry["expression"], token_id, index, file_path)
+                rule_entries.append(TokenRuleEntry(field=field_id, expression=entry["expression"]))
+            token_rules[token_id] = rule_entries
+
+        return token_rules
+
+    @staticmethod
+    def _validate_expression(expression: str, token_id: str, index: int, file_path: str) -> None:
+        """Raise ValueError if expression contains an unrecognised operator."""
+        _KNOWN_OPERATORS = {"T", "U", "S", "D", "M", "R"}
+        _OPERATOR_PATTERN = re.compile(r"\s*(?P<op>[A-Za-z]+)(?:\([^)]*\))?", re.IGNORECASE)
+        for part in expression.split("|"):
+            part = part.strip()
+            if not part:
+                continue
+            match = _OPERATOR_PATTERN.fullmatch(part)
+            if not match or match.group("op").upper() not in _KNOWN_OPERATORS:
+                raise ValueError(
+                    f"Configuration '{file_path}': token rule '{token_id}' entry {index} "
+                    f"contains unknown expression operator '{part}'. "
+                    f"Accepted operators are: {sorted(_KNOWN_OPERATORS)}."
+                )

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_loader.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/tokens/config/tokenization_config_loader.py
@@ -6,13 +6,13 @@ from typing import Any, Dict, Optional
 
 import yaml
 
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
+from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
 from openlinktoken_cli.tokens.config.tokenization_config import (
     AttributeMappingEntry,
     TokenizationConfig,
     TokenRuleEntry,
 )
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
-from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class TokenizationConfigLoader:
     @staticmethod
     def load_runtime_components(
         tokenization_config_path: Optional[str] = None,
-    ) -> tuple[TokenizationConfig | None, DynamicAttributeFactory | None, DynamicTokenDefinition | None]:
+    ) -> tuple[TokenizationConfig | None, ConfiguredAttributeResolver | None, DynamicTokenDefinition | None]:
         """Load config and build runtime components used by tokenization commands.
 
         Args:
@@ -31,16 +31,16 @@ class TokenizationConfigLoader:
                 When omitted or None, returns a tuple of Nones.
 
         Returns:
-            Tuple of (TokenizationConfig, DynamicAttributeFactory, DynamicTokenDefinition)
+            Tuple of (TokenizationConfig, ConfiguredAttributeResolver, DynamicTokenDefinition)
             or (None, None, None) when no config path is provided.
         """
         if not tokenization_config_path:
             return None, None, None
 
         config = TokenizationConfigLoader.load(tokenization_config_path)
-        factory = DynamicAttributeFactory(config)
-        token_definition = DynamicTokenDefinition(config, factory)
-        return config, factory, token_definition
+        resolver = ConfiguredAttributeResolver(config)
+        token_definition = DynamicTokenDefinition(config, resolver)
+        return config, resolver, token_definition
 
     @staticmethod
     def load(file_path: str) -> TokenizationConfig:
@@ -106,17 +106,13 @@ class TokenizationConfigLoader:
         attributes = {}
         for column, entry in raw_attributes.items():
             if not isinstance(entry, dict):
-                raise ValueError(
-                    f"Configuration '{file_path}': attribute entry for '{column}' must be a mapping."
-                )
+                raise ValueError(f"Configuration '{file_path}': attribute entry for '{column}' must be a mapping.")
             if "field" not in entry or not entry["field"]:
                 raise ValueError(
                     f"Configuration '{file_path}': attribute '{column}' is missing required field 'field'."
                 )
             if "type" not in entry or not entry["type"]:
-                raise ValueError(
-                    f"Configuration '{file_path}': attribute '{column}' is missing required field 'type'."
-                )
+                raise ValueError(f"Configuration '{file_path}': attribute '{column}' is missing required field 'type'.")
             attributes[column] = AttributeMappingEntry(field=entry["field"], type=entry["type"])
 
         return attributes
@@ -145,9 +141,7 @@ class TokenizationConfigLoader:
         token_rules = {}
         for token_id, entries in raw_token_rules.items():
             if not isinstance(entries, list) or not entries:
-                raise ValueError(
-                    f"Configuration '{file_path}': token rule '{token_id}' must be a non-empty list."
-                )
+                raise ValueError(f"Configuration '{file_path}': token rule '{token_id}' must be a non-empty list.")
             rule_entries = []
             for index, entry in enumerate(entries):
                 if not isinstance(entry, dict):

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/version_checker.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/version_checker.py
@@ -36,7 +36,7 @@ class VersionChecker:
         Initialize the VersionChecker.
 
         Args:
-            current_version: The currently running version string (e.g. "2.0.0").
+            current_version: The currently running version string (e.g. "2.1.0").
             no_update_check: When True the checker is disabled entirely.
         """
         self._current_version = current_version

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/configured_person_attributes_csv_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/configured_person_attributes_csv_reader_test.py
@@ -1,0 +1,80 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
+from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
+
+
+class TestConfiguredAttributeMappingInPersonAttributesCSVReader:
+    """Test config-driven column mapping through the unified CSV reader."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        self.temp_file_path = self.temp_file.name
+        self.temp_file.close()
+
+        self.config = TokenizationConfig(
+            attributes={
+                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
+                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            },
+            token_rules={},
+        )
+        self.factory = DynamicAttributeFactory(self.config)
+
+    def teardown_method(self):
+        """Clean up after each test method."""
+        if os.path.exists(self.temp_file_path):
+            os.unlink(self.temp_file_path)
+
+    def test_read_valid_csv_with_configured_columns(self):
+        """Reads configured columns into their corresponding dynamic attribute classes."""
+        with open(self.temp_file_path, "w", encoding="utf-8") as f:
+            f.write("given_nm,family_nm,ignored\n")
+            f.write("Maria,Garcia,something\n")
+
+        given_name_class = self.factory.get_class_for_column("given_nm")
+        family_name_class = self.factory.get_class_for_column("family_nm")
+
+        attribute_map = {
+            "given_nm": given_name_class,
+            "family_nm": family_name_class,
+        }
+
+        with PersonAttributesCSVReader(self.temp_file_path, attribute_map=attribute_map) as reader:
+            record = next(reader)
+
+        assert record[given_name_class] == "Maria"
+        assert record[family_name_class] == "Garcia"
+        assert len(record) == 2
+
+    def test_missing_configured_column_is_skipped(self):
+        """Skips configured columns that are absent from the CSV header."""
+        with open(self.temp_file_path, "w", encoding="utf-8") as f:
+            f.write("given_nm\n")
+            f.write("Maria\n")
+
+        family_name_class = self.factory.get_class_for_column("family_nm")
+
+        attribute_map = {
+            "given_nm": self.factory.get_class_for_column("given_nm"),
+            "family_nm": family_name_class,
+        }
+
+        with PersonAttributesCSVReader(self.temp_file_path, attribute_map=attribute_map) as reader:
+            record = next(reader)
+
+        assert family_name_class not in record
+
+    def test_constructor_throws_io_exception(self):
+        """Raises IOError for a missing CSV file path."""
+        with pytest.raises(IOError):
+            PersonAttributesCSVReader("non_existent_file.csv")

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/configured_person_attributes_csv_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/configured_person_attributes_csv_reader_test.py
@@ -7,9 +7,9 @@ import tempfile
 
 import pytest
 
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
-from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
 from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
+from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
 
 
 class TestConfiguredAttributeMappingInPersonAttributesCSVReader:
@@ -28,7 +28,7 @@ class TestConfiguredAttributeMappingInPersonAttributesCSVReader:
             },
             token_rules={},
         )
-        self.factory = DynamicAttributeFactory(self.config)
+        self.resolver = ConfiguredAttributeResolver(self.config)
 
     def teardown_method(self):
         """Clean up after each test method."""
@@ -36,24 +36,21 @@ class TestConfiguredAttributeMappingInPersonAttributesCSVReader:
             os.unlink(self.temp_file_path)
 
     def test_read_valid_csv_with_configured_columns(self):
-        """Reads configured columns into their corresponding dynamic attribute classes."""
+        """Reads configured columns into their corresponding field ids."""
         with open(self.temp_file_path, "w", encoding="utf-8") as f:
             f.write("given_nm,family_nm,ignored\n")
             f.write("Maria,Garcia,something\n")
 
-        given_name_class = self.factory.get_class_for_column("given_nm")
-        family_name_class = self.factory.get_class_for_column("family_nm")
-
         attribute_map = {
-            "given_nm": given_name_class,
-            "family_nm": family_name_class,
+            "given_nm": self.resolver.get_field_for_column("given_nm"),
+            "family_nm": self.resolver.get_field_for_column("family_nm"),
         }
 
         with PersonAttributesCSVReader(self.temp_file_path, attribute_map=attribute_map) as reader:
             record = next(reader)
 
-        assert record[given_name_class] == "Maria"
-        assert record[family_name_class] == "Garcia"
+        assert record["FirstName"] == "Maria"
+        assert record["FamilyName"] == "Garcia"
         assert len(record) == 2
 
     def test_missing_configured_column_is_skipped(self):
@@ -62,17 +59,15 @@ class TestConfiguredAttributeMappingInPersonAttributesCSVReader:
             f.write("given_nm\n")
             f.write("Maria\n")
 
-        family_name_class = self.factory.get_class_for_column("family_nm")
-
         attribute_map = {
-            "given_nm": self.factory.get_class_for_column("given_nm"),
-            "family_nm": family_name_class,
+            "given_nm": self.resolver.get_field_for_column("given_nm"),
+            "family_nm": self.resolver.get_field_for_column("family_nm"),
         }
 
         with PersonAttributesCSVReader(self.temp_file_path, attribute_map=attribute_map) as reader:
             record = next(reader)
 
-        assert family_name_class not in record
+        assert "FamilyName" not in record
 
     def test_constructor_throws_io_exception(self):
         """Raises IOError for a missing CSV file path."""

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/configured_person_attributes_csv_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/configured_person_attributes_csv_reader_test.py
@@ -22,9 +22,9 @@ class TestConfiguredAttributeMappingInPersonAttributesCSVReader:
         self.temp_file.close()
 
         self.config = TokenizationConfig(
-            attributes={
-                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
-                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            column_mappings={
+                "FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName"),
+                "FamilyName": AttributeMappingEntry(column_name="family_nm", type="LastName"),
             },
             token_rules={},
         )

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/person_attributes_csv_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/csv/person_attributes_csv_reader_test.py
@@ -5,10 +5,6 @@ import tempfile
 
 import pytest
 
-from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken_cli.io.csv.person_attributes_csv_reader import PersonAttributesCSVReader
 
 
@@ -36,17 +32,17 @@ class TestPersonAttributesCSVReader:
         with PersonAttributesCSVReader(self.temp_file_path) as reader:
             # Test first record
             first_record = next(reader)
-            assert first_record[RecordIdAttribute] == "1"
-            assert first_record[SocialSecurityNumberAttribute] == "123-45-6789"
-            assert first_record[FirstNameAttribute] == "John"
-            assert first_record[LastNameAttribute] == "Doe"
+            assert first_record["RecordId"] == "1"
+            assert first_record["SocialSecurityNumber"] == "123-45-6789"
+            assert first_record["FirstName"] == "John"
+            assert first_record["LastName"] == "Doe"
 
             # Test second record
             second_record = next(reader)
-            assert second_record[RecordIdAttribute] == "2"
-            assert second_record[SocialSecurityNumberAttribute] == "987-65-4321"
-            assert second_record[FirstNameAttribute] == "Jane"
-            assert second_record[LastNameAttribute] == "Smith"
+            assert second_record["RecordId"] == "2"
+            assert second_record["SocialSecurityNumber"] == "987-65-4321"
+            assert second_record["FirstName"] == "Jane"
+            assert second_record["LastName"] == "Smith"
 
             # Test no more records
             with pytest.raises(StopIteration):
@@ -70,10 +66,10 @@ class TestPersonAttributesCSVReader:
         with PersonAttributesCSVReader(self.temp_file_path) as reader:
             # Test that we can iterate
             for record in reader:
-                assert record[RecordIdAttribute] == "1"
-                assert record[SocialSecurityNumberAttribute] == "123-45-6789"
-                assert record[FirstNameAttribute] == "John"
-                assert record[LastNameAttribute] == "Doe"
+                assert record["RecordId"] == "1"
+                assert record["SocialSecurityNumber"] == "123-45-6789"
+                assert record["FirstName"] == "John"
+                assert record["LastName"] == "Doe"
                 break
 
     def test_next(self):
@@ -85,10 +81,10 @@ class TestPersonAttributesCSVReader:
         with PersonAttributesCSVReader(self.temp_file_path) as reader:
             record = next(reader)
             assert record is not None
-            assert record[RecordIdAttribute] == "1"
-            assert record[SocialSecurityNumberAttribute] == "123-45-6789"
-            assert record[FirstNameAttribute] == "John"
-            assert record[LastNameAttribute] == "Doe"
+            assert record["RecordId"] == "1"
+            assert record["SocialSecurityNumber"] == "123-45-6789"
+            assert record["FirstName"] == "John"
+            assert record["LastName"] == "Doe"
 
     def test_close(self):
         """Test close method."""
@@ -122,5 +118,5 @@ class TestPersonAttributesCSVReader:
             first_record = next(reader)
             second_record = next(reader)
 
-            assert first_record[RecordIdAttribute] == "1"
-            assert second_record[RecordIdAttribute] == "2"
+            assert first_record["RecordId"] == "1"
+            assert second_record["RecordId"] == "2"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/configured_person_attributes_parquet_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/configured_person_attributes_parquet_reader_test.py
@@ -14,7 +14,7 @@ except ImportError:
     pytest.skip("PyArrow required for Parquet tests", allow_module_level=True)
 
 from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
 from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
 
 
@@ -34,7 +34,7 @@ class TestConfiguredAttributeMappingInPersonAttributesParquetReader:
             },
             token_rules={},
         )
-        self.factory = DynamicAttributeFactory(self.config)
+        self.resolver = ConfiguredAttributeResolver(self.config)
 
     def teardown_method(self):
         """Clean up after each test method."""
@@ -42,7 +42,7 @@ class TestConfiguredAttributeMappingInPersonAttributesParquetReader:
             os.unlink(self.temp_file_path)
 
     def test_read_valid_parquet_with_configured_columns(self):
-        """Reads configured columns into their corresponding dynamic attribute classes."""
+        """Reads configured columns into their corresponding field ids."""
         table = pa.table(
             {
                 "given_nm": ["Maria"],
@@ -52,19 +52,16 @@ class TestConfiguredAttributeMappingInPersonAttributesParquetReader:
         )
         pq.write_table(table, self.temp_file_path)
 
-        given_name_class = self.factory.get_class_for_column("given_nm")
-        family_name_class = self.factory.get_class_for_column("family_nm")
-
         attribute_map = {
-            "given_nm": given_name_class,
-            "family_nm": family_name_class,
+            "given_nm": self.resolver.get_field_for_column("given_nm"),
+            "family_nm": self.resolver.get_field_for_column("family_nm"),
         }
 
         with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
             record = next(reader)
 
-        assert record[given_name_class] == "Maria"
-        assert record[family_name_class] == "Garcia"
+        assert record["FirstName"] == "Maria"
+        assert record["FamilyName"] == "Garcia"
         assert len(record) == 2
 
     def test_parquet_mapping_is_case_insensitive(self):
@@ -77,35 +74,29 @@ class TestConfiguredAttributeMappingInPersonAttributesParquetReader:
         )
         pq.write_table(table, self.temp_file_path)
 
-        given_name_class = self.factory.get_class_for_column("given_nm")
-        family_name_class = self.factory.get_class_for_column("family_nm")
-
         attribute_map = {
-            "given_nm": given_name_class,
-            "family_nm": family_name_class,
+            "given_nm": self.resolver.get_field_for_column("given_nm"),
+            "family_nm": self.resolver.get_field_for_column("family_nm"),
         }
 
         with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
             record = next(reader)
 
-        assert record[given_name_class] == "Maria"
-        assert record[family_name_class] == "Garcia"
+        assert record["FirstName"] == "Maria"
+        assert record["FamilyName"] == "Garcia"
 
     def test_missing_configured_column_is_skipped(self):
         """Skips configured columns that are absent from the Parquet schema."""
         table = pa.table({"given_nm": ["Maria"]})
         pq.write_table(table, self.temp_file_path)
 
-        given_name_class = self.factory.get_class_for_column("given_nm")
-        family_name_class = self.factory.get_class_for_column("family_nm")
-
         attribute_map = {
-            "given_nm": given_name_class,
-            "family_nm": family_name_class,
+            "given_nm": self.resolver.get_field_for_column("given_nm"),
+            "family_nm": self.resolver.get_field_for_column("family_nm"),
         }
 
         with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
             record = next(reader)
 
-        assert record[given_name_class] == "Maria"
-        assert family_name_class not in record
+        assert record["FirstName"] == "Maria"
+        assert "FamilyName" not in record

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/configured_person_attributes_parquet_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/configured_person_attributes_parquet_reader_test.py
@@ -28,9 +28,9 @@ class TestConfiguredAttributeMappingInPersonAttributesParquetReader:
         self.temp_file.close()
 
         self.config = TokenizationConfig(
-            attributes={
-                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
-                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            column_mappings={
+                "FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName"),
+                "FamilyName": AttributeMappingEntry(column_name="family_nm", type="LastName"),
             },
             token_rules={},
         )

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/configured_person_attributes_parquet_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/configured_person_attributes_parquet_reader_test.py
@@ -1,0 +1,111 @@
+"""
+Copyright (c) Truveta. All rights reserved.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except ImportError:
+    pytest.skip("PyArrow required for Parquet tests", allow_module_level=True)
+
+from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
+
+
+class TestConfiguredAttributeMappingInPersonAttributesParquetReader:
+    """Test config-driven column mapping through the unified Parquet reader."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.temp_file = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+        self.temp_file_path = self.temp_file.name
+        self.temp_file.close()
+
+        self.config = TokenizationConfig(
+            attributes={
+                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
+                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            },
+            token_rules={},
+        )
+        self.factory = DynamicAttributeFactory(self.config)
+
+    def teardown_method(self):
+        """Clean up after each test method."""
+        if os.path.exists(self.temp_file_path):
+            os.unlink(self.temp_file_path)
+
+    def test_read_valid_parquet_with_configured_columns(self):
+        """Reads configured columns into their corresponding dynamic attribute classes."""
+        table = pa.table(
+            {
+                "given_nm": ["Maria"],
+                "family_nm": ["Garcia"],
+                "ignored": ["something"],
+            }
+        )
+        pq.write_table(table, self.temp_file_path)
+
+        given_name_class = self.factory.get_class_for_column("given_nm")
+        family_name_class = self.factory.get_class_for_column("family_nm")
+
+        attribute_map = {
+            "given_nm": given_name_class,
+            "family_nm": family_name_class,
+        }
+
+        with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
+            record = next(reader)
+
+        assert record[given_name_class] == "Maria"
+        assert record[family_name_class] == "Garcia"
+        assert len(record) == 2
+
+    def test_parquet_mapping_is_case_insensitive(self):
+        """Matches configured mappings even when Parquet column casing differs."""
+        table = pa.table(
+            {
+                "Given_Nm": ["Maria"],
+                "FAMILY_NM": ["Garcia"],
+            }
+        )
+        pq.write_table(table, self.temp_file_path)
+
+        given_name_class = self.factory.get_class_for_column("given_nm")
+        family_name_class = self.factory.get_class_for_column("family_nm")
+
+        attribute_map = {
+            "given_nm": given_name_class,
+            "family_nm": family_name_class,
+        }
+
+        with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
+            record = next(reader)
+
+        assert record[given_name_class] == "Maria"
+        assert record[family_name_class] == "Garcia"
+
+    def test_missing_configured_column_is_skipped(self):
+        """Skips configured columns that are absent from the Parquet schema."""
+        table = pa.table({"given_nm": ["Maria"]})
+        pq.write_table(table, self.temp_file_path)
+
+        given_name_class = self.factory.get_class_for_column("given_nm")
+        family_name_class = self.factory.get_class_for_column("family_nm")
+
+        attribute_map = {
+            "given_nm": given_name_class,
+            "family_nm": family_name_class,
+        }
+
+        with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
+            record = next(reader)
+
+        assert record[given_name_class] == "Maria"
+        assert family_name_class not in record

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/person_attributes_parquet_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/person_attributes_parquet_reader_test.py
@@ -11,10 +11,6 @@ try:
 except ImportError:
     pytest.skip("PyArrow required for Parquet tests", allow_module_level=True)
 
-from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
 
@@ -45,15 +41,15 @@ class TestPersonAttributesParquetReader:
         with PersonAttributesParquetReader(self.temp_file_path) as reader:
             # Test first record
             first_record = next(reader)
-            assert first_record[RecordIdAttribute] == "1"
-            assert first_record[SocialSecurityNumberAttribute] == "123-45-6789"
-            assert first_record[FirstNameAttribute] == "John"
+            assert first_record["RecordId"] == "1"
+            assert first_record["SocialSecurityNumber"] == "123-45-6789"
+            assert first_record["FirstName"] == "John"
 
             # Test second record
             second_record = next(reader)
-            assert second_record[RecordIdAttribute] == "2"
-            assert second_record[SocialSecurityNumberAttribute] == "987-65-4321"
-            assert second_record[FirstNameAttribute] == "Jane"
+            assert second_record["RecordId"] == "2"
+            assert second_record["SocialSecurityNumber"] == "987-65-4321"
+            assert second_record["FirstName"] == "Jane"
 
             # Test no more records
             with pytest.raises(StopIteration):
@@ -91,9 +87,9 @@ class TestPersonAttributesParquetReader:
         with PersonAttributesParquetReader(self.temp_file_path) as reader:
             # Test that we can iterate
             for record in reader:
-                assert record[RecordIdAttribute] == "1"
-                assert record[SocialSecurityNumberAttribute] == "123-45-6789"
-                assert record[FirstNameAttribute] == "John"
+                assert record["RecordId"] == "1"
+                assert record["SocialSecurityNumber"] == "123-45-6789"
+                assert record["FirstName"] == "John"
                 break
 
     def test_next(self):
@@ -105,9 +101,9 @@ class TestPersonAttributesParquetReader:
         with PersonAttributesParquetReader(self.temp_file_path) as reader:
             record = next(reader)
             assert record is not None
-            assert record[RecordIdAttribute] == "1"
-            assert record[SocialSecurityNumberAttribute] == "123-45-6789"
-            assert record[FirstNameAttribute] == "John"
+            assert record["RecordId"] == "1"
+            assert record["SocialSecurityNumber"] == "123-45-6789"
+            assert record["FirstName"] == "John"
 
     def test_close(self):
         """Test close method."""
@@ -129,7 +125,7 @@ class TestPersonAttributesParquetReader:
             PersonAttributesParquetReader(invalid_file_path)
 
     def test_read_parquet_with_explicit_attribute_map(self):
-        """Supports config-style explicit column mappings for non-standard Parquet fields."""
+        """Supports config-style explicit field id mappings for non-standard Parquet fields."""
         table = pa.table(
             {
                 "member_id": ["A-1"],
@@ -140,15 +136,15 @@ class TestPersonAttributesParquetReader:
         pq.write_table(table, self.temp_file_path)
 
         attribute_map = {
-            "given_nm": FirstNameAttribute,
-            "surname_txt": LastNameAttribute,
+            "given_nm": "FirstName",
+            "surname_txt": "LastName",
         }
 
         with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
             record = next(reader)
 
-        assert record[FirstNameAttribute] == "Ana"
-        assert record[LastNameAttribute] == "Lopez"
+        assert record["FirstName"] == "Ana"
+        assert record["LastName"] == "Lopez"
         assert len(record) == 2
 
     def test_row_count_returns_total_rows(self):
@@ -161,4 +157,4 @@ class TestPersonAttributesParquetReader:
             assert reader.row_count() == 2
 
             first_record = next(reader)
-            assert first_record[RecordIdAttribute] == "1"
+            assert first_record["RecordId"] == "1"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/person_attributes_parquet_reader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/person_attributes_parquet_reader_test.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
 from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
+from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
 from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
@@ -126,6 +127,29 @@ class TestPersonAttributesParquetReader:
         invalid_file_path = "non_existent_file.parquet"
         with pytest.raises(IOError):
             PersonAttributesParquetReader(invalid_file_path)
+
+    def test_read_parquet_with_explicit_attribute_map(self):
+        """Supports config-style explicit column mappings for non-standard Parquet fields."""
+        table = pa.table(
+            {
+                "member_id": ["A-1"],
+                "given_nm": ["Ana"],
+                "surname_txt": ["Lopez"],
+            }
+        )
+        pq.write_table(table, self.temp_file_path)
+
+        attribute_map = {
+            "given_nm": FirstNameAttribute,
+            "surname_txt": LastNameAttribute,
+        }
+
+        with PersonAttributesParquetReader(self.temp_file_path, attribute_map=attribute_map) as reader:
+            record = next(reader)
+
+        assert record[FirstNameAttribute] == "Ana"
+        assert record[LastNameAttribute] == "Lopez"
+        assert len(record) == 2
 
     def test_row_count_returns_total_rows(self):
         """Row counting should return the Parquet row total without breaking iteration."""

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/person_attributes_parquet_writer_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/io/parquet/person_attributes_parquet_writer_test.py
@@ -3,9 +3,6 @@
 import os
 import tempfile
 
-from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken_cli.io.parquet.person_attributes_parquet_reader import PersonAttributesParquetReader
 from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
 
@@ -37,14 +34,13 @@ class TestPersonAttributesParquetWriter:
         with PersonAttributesParquetReader(self.temp_file_path) as reader:
             record = next(reader)
             assert record is not None
-            assert record[RecordIdAttribute] == "123"
-            assert record[SocialSecurityNumberAttribute] == "123-45-6789"
-            assert record[FirstNameAttribute] == "John"
+            assert record["RecordId"] == "123"
+            assert record["SocialSecurityNumber"] == "123-45-6789"
+            assert record["FirstName"] == "John"
 
     def test_write_multiple_records(self):
         """Test writing multiple records to Parquet."""
         data1 = {"RecordId": "123", "FirstName": "John", "SocialSecurityNumber": "123-45-6789"}
-
         data2 = {"RecordId": "456", "FirstName": "Jane", "SocialSecurityNumber": "987-65-4321"}
 
         self.writer.write_attributes(data1)
@@ -55,16 +51,16 @@ class TestPersonAttributesParquetWriter:
             # Test first record
             record = next(reader)
             assert record is not None
-            assert record[RecordIdAttribute] == "123"
-            assert record[SocialSecurityNumberAttribute] == "123-45-6789"
-            assert record[FirstNameAttribute] == "John"
+            assert record["RecordId"] == "123"
+            assert record["SocialSecurityNumber"] == "123-45-6789"
+            assert record["FirstName"] == "John"
 
             # Test second record
             record = next(reader)
             assert record is not None
-            assert record[RecordIdAttribute] == "456"
-            assert record[SocialSecurityNumberAttribute] == "987-65-4321"
-            assert record[FirstNameAttribute] == "Jane"
+            assert record["RecordId"] == "456"
+            assert record["SocialSecurityNumber"] == "987-65-4321"
+            assert record["FirstName"] == "Jane"
 
     def test_write_basename_output_path_in_current_directory(self, tmp_path, monkeypatch):
         """Test that a basename-only output path writes to the current directory."""

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -762,7 +762,7 @@ class TestOpenLinkTokenCommand:
         log_files = list(log_dir.glob("*.log"))
 
         assert exit_code != 0
-        assert "Error: boom" in captured.err
+        assert "\x1b[31mError:\x1b[0m boom" in captured.err
         assert "\x1b[90mStack trace:" in captured.err
         assert len(log_files) == 1
         assert str(log_files[0]) in captured.err

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_integration_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_integration_test.py
@@ -12,8 +12,6 @@ from typing import Dict, List
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken.metadata import Metadata
 from openlinktoken.tokens.token import Token
 from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
@@ -330,8 +328,8 @@ class TestPersonAttributesProcessorIntegration:
 
         with PersonAttributesCSVReader(input_csv_file_path) as reader:
             for row in reader:
-                ssn = row.get(SocialSecurityNumberAttribute)
-                record_id = row.get(RecordIdAttribute)
+                ssn = row.get("SocialSecurityNumber")
+                record_id = row.get("RecordId")
 
                 if ssn not in ssn_to_record_ids_map:
                     ssn_to_record_ids_map[ssn] = []

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_test.py
@@ -2,27 +2,20 @@
 
 from unittest.mock import Mock
 
-from openlinktoken.attributes.general.record_id_attribute import RecordIdAttribute
-from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
-from openlinktoken.attributes.person.sex_attribute import SexAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
-from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.metadata import Metadata
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
-from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
-from openlinktoken_cli.tokens.config.tokenization_config import (
-    AttributeMappingEntry,
-    TokenRuleEntry,
-    TokenizationConfig,
-)
+from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from openlinktoken.tokentransformer.token_transformer import TokenTransformer
 from openlinktoken_cli.io.person_attributes_reader import PersonAttributesReader
 from openlinktoken_cli.io.person_attributes_writer import PersonAttributesWriter
 from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
+from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
+from openlinktoken_cli.tokens.config.tokenization_config import (
+    AttributeMappingEntry,
+    TokenizationConfig,
+    TokenRuleEntry,
+)
 
 
 class TestPersonAttributesProcessor:
@@ -31,7 +24,7 @@ class TestPersonAttributesProcessor:
     def test_process_happy_path(self):
         """Test process happy path."""
         token_transformer_list = [Mock(spec=HashTokenTransformer)]
-        data = {RecordIdAttribute: "TestRecordId", FirstNameAttribute: "John", LastNameAttribute: "Spencer"}
+        data = {"RecordId": "TestRecordId", "FirstName": "John", "LastName": "Spencer"}
 
         reader = Mock(spec=PersonAttributesReader)
         writer = Mock(spec=PersonAttributesWriter)
@@ -50,7 +43,7 @@ class TestPersonAttributesProcessor:
     def test_process_io_exception_writing_attributes(self):
         """Test process with IOException writing attributes."""
         token_transformer_list = [Mock(spec=TokenTransformer)]
-        data = {RecordIdAttribute: "TestRecordId", FirstNameAttribute: "John", LastNameAttribute: "Spencer"}
+        data = {"RecordId": "TestRecordId", "FirstName": "John", "LastName": "Spencer"}
 
         reader = Mock(spec=PersonAttributesReader)
         writer = Mock(spec=PersonAttributesWriter)
@@ -73,7 +66,7 @@ class TestPersonAttributesProcessor:
     def test_metadata_map_contains_correct_values(self):
         """Test metadata map contains correct values."""
         token_transformer_list = [Mock(spec=HashTokenTransformer)]
-        data = {RecordIdAttribute: "TestRecordId", FirstNameAttribute: "John", LastNameAttribute: "Spencer"}
+        data = {"RecordId": "TestRecordId", "FirstName": "John", "LastName": "Spencer"}
 
         reader = Mock(spec=PersonAttributesReader)
         writer = Mock(spec=PersonAttributesWriter)
@@ -123,13 +116,13 @@ class TestPersonAttributesProcessor:
         token_transformer_list = [Mock(spec=HashTokenTransformer)]
         # Provide all required attributes so no blank tokens are generated
         data = {
-            RecordIdAttribute: "TestRecordId",
-            FirstNameAttribute: "John",
-            LastNameAttribute: "Spencer",
-            SocialSecurityNumberAttribute: "234-56-7890",
-            BirthDateAttribute: "1990-01-15",
-            SexAttribute: "Male",
-            PostalCodeAttribute: "98052",
+            "RecordId": "TestRecordId",
+            "FirstName": "John",
+            "LastName": "Spencer",
+            "SocialSecurityNumber": "234-56-7890",
+            "BirthDate": "1990-01-15",
+            "Sex": "Male",
+            "PostalCode": "98052",
         }
 
         reader = Mock(spec=PersonAttributesReader)
@@ -161,9 +154,9 @@ class TestPersonAttributesProcessor:
         token_transformer_list = [Mock(spec=HashTokenTransformer)]
 
         # Create three data records
-        data1 = {RecordIdAttribute: "TestRecordId1", FirstNameAttribute: "John", LastNameAttribute: "Spencer"}
-        data2 = {RecordIdAttribute: "TestRecordId2", FirstNameAttribute: "Jane", LastNameAttribute: "Doe"}
-        data3 = {RecordIdAttribute: "TestRecordId3", FirstNameAttribute: "Alex", LastNameAttribute: "Smith"}
+        data1 = {"RecordId": "TestRecordId1", "FirstName": "John", "LastName": "Spencer"}
+        data2 = {"RecordId": "TestRecordId2", "FirstName": "Jane", "LastName": "Doe"}
+        data3 = {"RecordId": "TestRecordId3", "FirstName": "Alex", "LastName": "Smith"}
 
         reader = Mock(spec=PersonAttributesReader)
         writer = Mock(spec=PersonAttributesWriter)
@@ -183,7 +176,7 @@ class TestPersonAttributesProcessor:
     def test_metadata_map_preserves_existing_entries(self):
         """Test metadata map preserves existing entries."""
         token_transformer_list = [Mock(spec=HashTokenTransformer)]
-        data = {RecordIdAttribute: "TestRecordId", FirstNameAttribute: "John", LastNameAttribute: "Spencer"}
+        data = {"RecordId": "TestRecordId", "FirstName": "John", "LastName": "Spencer"}
 
         reader = Mock(spec=PersonAttributesReader)
         writer = Mock(spec=PersonAttributesWriter)
@@ -218,15 +211,13 @@ class TestPersonAttributesProcessor:
                 ]
             },
         )
-        factory = DynamicAttributeFactory(config)
-        token_definition = DynamicTokenDefinition(config, factory)
+        resolver = ConfiguredAttributeResolver(config)
+        token_definition = DynamicTokenDefinition(config, resolver)
 
-        given_name_class = factory.get_class_for_field("FirstName")
-        family_name_class = factory.get_class_for_field("FamilyName")
         row = {
-            RecordIdAttribute: "TestRecordId",
-            given_name_class: "John",
-            family_name_class: "Spencer",
+            "RecordId": "TestRecordId",
+            "FirstName": "John",
+            "FamilyName": "Spencer",
         }
 
         reader = Mock(spec=PersonAttributesReader)
@@ -251,13 +242,13 @@ class TestPersonAttributesProcessor:
         token_transformer_list = [Mock(spec=HashTokenTransformer)]
         # Invalid birth date should surface as Date/BirthDate depending on attribute implementation.
         data = {
-            RecordIdAttribute: "TestRecordId",
-            FirstNameAttribute: "John",
-            LastNameAttribute: "Spencer",
-            SocialSecurityNumberAttribute: "234-56-7890",
-            BirthDateAttribute: "",
-            SexAttribute: "Male",
-            PostalCodeAttribute: "98052",
+            "RecordId": "TestRecordId",
+            "FirstName": "John",
+            "LastName": "Spencer",
+            "SocialSecurityNumber": "234-56-7890",
+            "BirthDate": "",
+            "Sex": "Male",
+            "PostalCode": "98052",
         }
 
         reader = Mock(spec=PersonAttributesReader)

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_test.py
@@ -9,7 +9,15 @@ from openlinktoken.attributes.person.last_name_attribute import LastNameAttribut
 from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
 from openlinktoken.attributes.person.sex_attribute import SexAttribute
 from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
+from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.metadata import Metadata
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
+from openlinktoken_cli.tokens.config.tokenization_config import (
+    AttributeMappingEntry,
+    TokenRuleEntry,
+    TokenizationConfig,
+)
 from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
 from openlinktoken.tokentransformer.token_transformer import TokenTransformer
 from openlinktoken_cli.io.person_attributes_reader import PersonAttributesReader
@@ -195,3 +203,75 @@ class TestPersonAttributesProcessor:
 
         # And new entries are added
         assert "TotalRows" in metadata_map, "Metadata should contain totalRows key"
+
+    def test_process_with_custom_token_definition(self):
+        """Processes records using a runtime-defined token definition from config."""
+        config = TokenizationConfig(
+            attributes={
+                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
+                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            },
+            token_rules={
+                "T1": [
+                    TokenRuleEntry(field="FamilyName", expression="T|U"),
+                    TokenRuleEntry(field="FirstName", expression="T|S(0,1)|U"),
+                ]
+            },
+        )
+        factory = DynamicAttributeFactory(config)
+        token_definition = DynamicTokenDefinition(config, factory)
+
+        given_name_class = factory.get_class_for_field("FirstName")
+        family_name_class = factory.get_class_for_field("FamilyName")
+        row = {
+            RecordIdAttribute: "TestRecordId",
+            given_name_class: "John",
+            family_name_class: "Spencer",
+        }
+
+        reader = Mock(spec=PersonAttributesReader)
+        writer = Mock(spec=PersonAttributesWriter)
+        reader.__iter__ = Mock(return_value=iter([row]))
+        metadata_map = Metadata().initialize()
+
+        summary = PersonAttributesProcessor.process(
+            reader,
+            writer,
+            [],
+            metadata_map,
+            token_definition=token_definition,
+        )
+
+        assert summary.total_rows == 1
+        assert writer.write_attributes.call_count == 1
+        assert summary.blank_tokens_by_rule["T1"] == 0
+
+    def test_process_tracks_unknown_invalid_attribute_name_without_crashing(self):
+        """Handles invalid attribute names that were not pre-initialized in metadata maps."""
+        token_transformer_list = [Mock(spec=HashTokenTransformer)]
+        # Invalid birth date should surface as Date/BirthDate depending on attribute implementation.
+        data = {
+            RecordIdAttribute: "TestRecordId",
+            FirstNameAttribute: "John",
+            LastNameAttribute: "Spencer",
+            SocialSecurityNumberAttribute: "234-56-7890",
+            BirthDateAttribute: "",
+            SexAttribute: "Male",
+            PostalCodeAttribute: "98052",
+        }
+
+        reader = Mock(spec=PersonAttributesReader)
+        writer = Mock(spec=PersonAttributesWriter)
+        reader.__iter__ = Mock(return_value=iter([data]))
+        metadata_map = Metadata().initialize()
+
+        summary = PersonAttributesProcessor.process(
+            reader,
+            writer,
+            token_transformer_list,
+            metadata_map,
+            token_definition=TokenDefinition(),
+        )
+
+        assert summary.total_rows == 1
+        assert summary.total_rows_with_invalid_attributes == 1

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/processor/person_attributes_processor_test.py
@@ -200,9 +200,9 @@ class TestPersonAttributesProcessor:
     def test_process_with_custom_token_definition(self):
         """Processes records using a runtime-defined token definition from config."""
         config = TokenizationConfig(
-            attributes={
-                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
-                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            column_mappings={
+                "FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName"),
+                "FamilyName": AttributeMappingEntry(column_name="family_nm", type="LastName"),
             },
             token_rules={
                 "T1": [
@@ -236,6 +236,44 @@ class TestPersonAttributesProcessor:
         assert summary.total_rows == 1
         assert writer.write_attributes.call_count == 1
         assert summary.blank_tokens_by_rule["T1"] == 0
+
+    def test_process_preserves_record_id_from_config_mapped_column(self):
+        """Config-mapped RecordId column is used as output record ID, not replaced by a UUID.
+
+        The field id ("EncounterId") intentionally differs from the type ("RecordId") to
+        verify that the fix handles any RecordIdAttribute subclass key, not just ones named
+        "RecordId".
+        """
+        config = TokenizationConfig(
+            column_mappings={
+                "EncounterId": AttributeMappingEntry(column_name="encounter_id", type="RecordId"),
+                "FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName"),
+            },
+            token_rules={
+                "T1": [TokenRuleEntry(field="FirstName", expression="T|U")],
+            },
+        )
+        resolver = ConfiguredAttributeResolver(config)
+        token_definition = DynamicTokenDefinition(config, resolver)
+
+        # Simulate the per-row dict as produced by a config-driven reader:
+        # keys are unique attribute subclasses, not plain strings.
+        record_id_class = resolver.get_class_for_field("EncounterId")
+        first_name_class = resolver.get_class_for_field("FirstName")
+        row = {
+            record_id_class: "enc-001",
+            first_name_class: "Ana",
+        }
+
+        reader = Mock(spec=PersonAttributesReader)
+        writer = Mock(spec=PersonAttributesWriter)
+        reader.__iter__ = Mock(return_value=iter([row]))
+        metadata_map = Metadata().initialize()
+
+        PersonAttributesProcessor.process(reader, writer, [], metadata_map, token_definition=token_definition)
+
+        written = writer.write_attributes.call_args[0][0]
+        assert written["RecordId"] == "enc-001", "Source record ID must be preserved, not replaced by a UUID"
 
     def test_process_tracks_unknown_invalid_attribute_name_without_crashing(self):
         """Handles invalid attribute names that were not pre-initialized in metadata maps."""

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/__init__.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: MIT

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/configured_attribute_resolver_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/configured_attribute_resolver_test.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
 from openlinktoken.attributes.attribute_loader import AttributeLoader
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
 from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
 
 
-class TestDynamicAttributeFactory:
-    def test_maps_same_base_type_to_distinct_field_classes(self):
+class TestConfiguredAttributeResolver:
+    def test_maps_same_base_type_to_same_class_with_distinct_field_ids(self):
         config = TokenizationConfig(
             attributes={
                 "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
@@ -18,19 +18,33 @@ class TestDynamicAttributeFactory:
             token_rules={},
         )
 
-        factory = DynamicAttributeFactory(config)
-        patient_class = factory.get_class_for_field("PatientZip")
-        hospital_class = factory.get_class_for_field("HospitalZip")
+        resolver = ConfiguredAttributeResolver(config)
+        patient_class = resolver.get_class_for_field("PatientZip")
+        hospital_class = resolver.get_class_for_field("HospitalZip")
 
-        # Each field gets a unique subclass so they produce distinct per-row dict keys,
-        # preventing silent overwrites when two fields share the same attribute type.
-        assert patient_class is not hospital_class
-        assert issubclass(patient_class, PostalCodeAttribute)
-        assert issubclass(hospital_class, PostalCodeAttribute)
-        assert factory.get_field_for_column("patient_zip") == "PatientZip"
-        assert factory.get_field_for_column("hospital_zip") == "HospitalZip"
-        assert factory.get_class_for_column("patient_zip") is patient_class
-        assert factory.get_class_for_column("hospital_zip") is hospital_class
+        # Both fields map to the same base class; field IDs are the distinguishing keys.
+        assert patient_class is PostalCodeAttribute
+        assert hospital_class is PostalCodeAttribute
+        assert resolver.get_field_for_column("patient_zip") == "PatientZip"
+        assert resolver.get_field_for_column("hospital_zip") == "HospitalZip"
+
+    def test_build_field_registry_contains_all_configured_fields(self):
+        config = TokenizationConfig(
+            attributes={
+                "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
+                "hospital_zip": AttributeMappingEntry(field="HospitalZip", type="PostalCode"),
+            },
+            token_rules={},
+        )
+
+        resolver = ConfiguredAttributeResolver(config)
+        registry = resolver.build_field_registry()
+
+        assert "PatientZip" in registry.get_field_ids()
+        assert "HospitalZip" in registry.get_field_ids()
+        assert registry.get_attribute("PatientZip") is not None
+        assert registry.get_attribute("HospitalZip") is not None
+        assert isinstance(registry.get_attribute("PatientZip"), PostalCodeAttribute)
 
     def test_unknown_field_lookup_raises_key_error(self):
         config = TokenizationConfig(
@@ -40,10 +54,10 @@ class TestDynamicAttributeFactory:
             token_rules={},
         )
 
-        factory = DynamicAttributeFactory(config)
+        resolver = ConfiguredAttributeResolver(config)
 
         with pytest.raises(KeyError):
-            factory.get_class_for_field("DoesNotExist")
+            resolver.get_class_for_field("DoesNotExist")
 
     def test_unknown_attribute_type_raises_value_error(self):
         config = TokenizationConfig(
@@ -54,7 +68,7 @@ class TestDynamicAttributeFactory:
         )
 
         with pytest.raises(ValueError, match="Unknown attribute type"):
-            DynamicAttributeFactory(config)
+            ConfiguredAttributeResolver(config)
 
     def test_conflicting_aliases_raise_value_error(self, monkeypatch):
         class FirstAttribute:
@@ -81,4 +95,4 @@ class TestDynamicAttributeFactory:
         )
 
         with pytest.raises(ValueError, match="Conflicting attribute type mapping for 'SharedAlias'"):
-            DynamicAttributeFactory(config)
+            ConfiguredAttributeResolver(config)

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/configured_attribute_resolver_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/configured_attribute_resolver_test.py
@@ -11,9 +11,9 @@ from openlinktoken_cli.tokens.config.tokenization_config import AttributeMapping
 class TestConfiguredAttributeResolver:
     def test_maps_same_base_type_to_same_class_with_distinct_field_ids(self):
         config = TokenizationConfig(
-            attributes={
-                "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
-                "hospital_zip": AttributeMappingEntry(field="HospitalZip", type="PostalCode"),
+            column_mappings={
+                "PatientZip": AttributeMappingEntry(column_name="patient_zip", type="PostalCode"),
+                "HospitalZip": AttributeMappingEntry(column_name="hospital_zip", type="PostalCode"),
             },
             token_rules={},
         )
@@ -23,16 +23,18 @@ class TestConfiguredAttributeResolver:
         hospital_class = resolver.get_class_for_field("HospitalZip")
 
         # Both fields map to the same base class; field IDs are the distinguishing keys.
-        assert patient_class is PostalCodeAttribute
-        assert hospital_class is PostalCodeAttribute
+        assert issubclass(patient_class, PostalCodeAttribute)
+        assert issubclass(hospital_class, PostalCodeAttribute)
+        # Each field gets a distinct dynamic subclass so they don't collide.
+        assert patient_class is not hospital_class
         assert resolver.get_field_for_column("patient_zip") == "PatientZip"
         assert resolver.get_field_for_column("hospital_zip") == "HospitalZip"
 
     def test_build_field_registry_contains_all_configured_fields(self):
         config = TokenizationConfig(
-            attributes={
-                "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
-                "hospital_zip": AttributeMappingEntry(field="HospitalZip", type="PostalCode"),
+            column_mappings={
+                "PatientZip": AttributeMappingEntry(column_name="patient_zip", type="PostalCode"),
+                "HospitalZip": AttributeMappingEntry(column_name="hospital_zip", type="PostalCode"),
             },
             token_rules={},
         )
@@ -48,8 +50,8 @@ class TestConfiguredAttributeResolver:
 
     def test_unknown_field_lookup_raises_key_error(self):
         config = TokenizationConfig(
-            attributes={
-                "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
+            column_mappings={
+                "PatientZip": AttributeMappingEntry(column_name="patient_zip", type="PostalCode"),
             },
             token_rules={},
         )
@@ -61,8 +63,8 @@ class TestConfiguredAttributeResolver:
 
     def test_unknown_attribute_type_raises_value_error(self):
         config = TokenizationConfig(
-            attributes={
-                "some_column": AttributeMappingEntry(field="SomeField", type="NotARealType"),
+            column_mappings={
+                "SomeField": AttributeMappingEntry(column_name="some_column", type="NotARealType"),
             },
             token_rules={},
         )
@@ -88,8 +90,8 @@ class TestConfiguredAttributeResolver:
         monkeypatch.setattr(AttributeLoader, "load", lambda: [FirstAttribute(), SecondAttribute()])
 
         config = TokenizationConfig(
-            attributes={
-                "source": AttributeMappingEntry(field="SomeField", type="SharedAlias"),
+            column_mappings={
+                "SomeField": AttributeMappingEntry(column_name="source", type="SharedAlias"),
             },
             token_rules={},
         )

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_attribute_factory_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_attribute_factory_test.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
+from openlinktoken.attributes.attribute_loader import AttributeLoader
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
+
+
+class TestDynamicAttributeFactory:
+    def test_maps_same_base_type_to_distinct_field_classes(self):
+        config = TokenizationConfig(
+            attributes={
+                "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
+                "hospital_zip": AttributeMappingEntry(field="HospitalZip", type="PostalCode"),
+            },
+            token_rules={},
+        )
+
+        factory = DynamicAttributeFactory(config)
+        patient_class = factory.get_class_for_field("PatientZip")
+        hospital_class = factory.get_class_for_field("HospitalZip")
+
+        # Each field gets a unique subclass so they produce distinct per-row dict keys,
+        # preventing silent overwrites when two fields share the same attribute type.
+        assert patient_class is not hospital_class
+        assert issubclass(patient_class, PostalCodeAttribute)
+        assert issubclass(hospital_class, PostalCodeAttribute)
+        assert factory.get_field_for_column("patient_zip") == "PatientZip"
+        assert factory.get_field_for_column("hospital_zip") == "HospitalZip"
+        assert factory.get_class_for_column("patient_zip") is patient_class
+        assert factory.get_class_for_column("hospital_zip") is hospital_class
+
+    def test_unknown_field_lookup_raises_key_error(self):
+        config = TokenizationConfig(
+            attributes={
+                "patient_zip": AttributeMappingEntry(field="PatientZip", type="PostalCode"),
+            },
+            token_rules={},
+        )
+
+        factory = DynamicAttributeFactory(config)
+
+        with pytest.raises(KeyError):
+            factory.get_class_for_field("DoesNotExist")
+
+    def test_unknown_attribute_type_raises_value_error(self):
+        config = TokenizationConfig(
+            attributes={
+                "some_column": AttributeMappingEntry(field="SomeField", type="NotARealType"),
+            },
+            token_rules={},
+        )
+
+        with pytest.raises(ValueError, match="Unknown attribute type"):
+            DynamicAttributeFactory(config)
+
+    def test_conflicting_aliases_raise_value_error(self, monkeypatch):
+        class FirstAttribute:
+            def get_name(self):
+                return "TypeOne"
+
+            def get_aliases(self):
+                return ["SharedAlias"]
+
+        class SecondAttribute:
+            def get_name(self):
+                return "TypeTwo"
+
+            def get_aliases(self):
+                return ["SharedAlias"]
+
+        monkeypatch.setattr(AttributeLoader, "load", lambda: [FirstAttribute(), SecondAttribute()])
+
+        config = TokenizationConfig(
+            attributes={
+                "source": AttributeMappingEntry(field="SomeField", type="SharedAlias"),
+            },
+            token_rules={},
+        )
+
+        with pytest.raises(ValueError, match="Conflicting attribute type mapping for 'SharedAlias'"):
+            DynamicAttributeFactory(config)

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_token_definition_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_token_definition_test.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
+from openlinktoken_cli.tokens.config.tokenization_config import (
+    AttributeMappingEntry,
+    TokenizationConfig,
+    TokenRuleEntry,
+)
+
+
+class TestDynamicTokenDefinition:
+    def test_builds_token_definitions_from_config(self):
+        config = TokenizationConfig(
+            attributes={
+                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
+            },
+            token_rules={
+                "T1": [
+                    TokenRuleEntry(field="FamilyName", expression="T|U"),
+                    TokenRuleEntry(field="FirstName", expression="T|S(0,1)|U"),
+                ]
+            },
+        )
+
+        factory = DynamicAttributeFactory(config)
+        definition = DynamicTokenDefinition(config, factory)
+
+        assert definition.get_version() == "custom"
+        assert definition.get_token_identifiers() == {"T1"}
+
+        t1_definition = definition.get_token_definition("T1")
+        assert len(t1_definition) == 2
+        assert t1_definition[0].attribute_class is factory.get_class_for_field("FamilyName")
+        assert t1_definition[0].expressions == "T|U"
+        assert t1_definition[1].attribute_class is factory.get_class_for_field("FirstName")
+        assert t1_definition[1].expressions == "T|S(0,1)|U"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_token_definition_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_token_definition_test.py
@@ -12,9 +12,9 @@ from openlinktoken_cli.tokens.config.tokenization_config import (
 class TestDynamicTokenDefinition:
     def test_builds_token_definitions_from_config(self):
         config = TokenizationConfig(
-            attributes={
-                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
-                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
+            column_mappings={
+                "FamilyName": AttributeMappingEntry(column_name="family_nm", type="LastName"),
+                "FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName"),
             },
             token_rules={
                 "T1": [

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_token_definition_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/dynamic_token_definition_test.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
 from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
 from openlinktoken_cli.tokens.config.tokenization_config import (
     AttributeMappingEntry,
@@ -24,15 +24,19 @@ class TestDynamicTokenDefinition:
             },
         )
 
-        factory = DynamicAttributeFactory(config)
-        definition = DynamicTokenDefinition(config, factory)
+        resolver = ConfiguredAttributeResolver(config)
+        definition = DynamicTokenDefinition(config, resolver)
 
         assert definition.get_version() == "custom"
         assert definition.get_token_identifiers() == {"T1"}
+        assert "FamilyName" in definition.field_registry.get_field_ids()
+        assert "FirstName" in definition.field_registry.get_field_ids()
 
         t1_definition = definition.get_token_definition("T1")
         assert len(t1_definition) == 2
-        assert t1_definition[0].attribute_class is factory.get_class_for_field("FamilyName")
+        assert t1_definition[0].attribute_class is resolver.get_class_for_field("FamilyName")
+        assert t1_definition[0].field_id == "FamilyName"
         assert t1_definition[0].expressions == "T|U"
-        assert t1_definition[1].attribute_class is factory.get_class_for_field("FirstName")
+        assert t1_definition[1].attribute_class is resolver.get_class_for_field("FirstName")
+        assert t1_definition[1].field_id == "FirstName"
         assert t1_definition[1].expressions == "T|S(0,1)|U"

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_helper_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_helper_test.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: MIT
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
+from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
+
+
+class TestTokenizationConfigHelper:
+    def test_build_configured_input_attribute_map_warns_when_factory_misses_entry(self, caplog):
+        config = TokenizationConfig(
+            attributes={
+                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
+                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            },
+            token_rules={},
+        )
+
+        factory = MagicMock()
+        factory.get_class_for_column.side_effect = [FirstNameAttribute, KeyError("missing")]
+
+        attribute_map = TokenizationConfigHelper.build_configured_input_attribute_map(config, factory)
+
+        assert attribute_map == {"given_nm": FirstNameAttribute}
+        assert "has no dynamic class registered" in caplog.text
+
+    def test_create_reader_csv_applies_attribute_map(self):
+        config = TokenizationConfig(
+            attributes={"given_nm": AttributeMappingEntry(field="FirstName", type="GivenName")},
+            token_rules={},
+        )
+        factory = MagicMock()
+
+        with patch(
+            "openlinktoken_cli.tokens.config.tokenization_config_helper.TokenizationConfigHelper"
+            ".build_configured_input_attribute_map",
+            return_value={"given_nm": FirstNameAttribute},
+        ), patch(
+            "openlinktoken_cli.tokens.config.tokenization_config_helper.PersonAttributesCSVReader"
+        ) as mock_reader_cls:
+            reader = MagicMock()
+            mock_reader_cls.return_value = reader
+
+            created_reader = TokenizationConfigHelper.create_reader("input.csv", "csv", config, factory)
+
+        assert created_reader is reader
+        mock_reader_cls.assert_called_once_with("input.csv", attribute_map={"given_nm": FirstNameAttribute})
+
+    def test_create_reader_parquet_applies_attribute_map(self):
+        config = TokenizationConfig(
+            attributes={"given_nm": AttributeMappingEntry(field="FirstName", type="GivenName")},
+            token_rules={},
+        )
+        factory = MagicMock()
+
+        with patch(
+            "openlinktoken_cli.tokens.config.tokenization_config_helper.TokenizationConfigHelper"
+            ".build_configured_input_attribute_map",
+            return_value={"given_nm": FirstNameAttribute},
+        ), patch(
+            "openlinktoken_cli.tokens.config.tokenization_config_helper.PersonAttributesParquetReader"
+        ) as mock_reader_cls:
+            reader = MagicMock()
+            mock_reader_cls.return_value = reader
+
+            created_reader = TokenizationConfigHelper.create_reader("input.parquet", "parquet", config, factory)
+
+        assert created_reader is reader
+        mock_reader_cls.assert_called_once_with("input.parquet", attribute_map={"given_nm": FirstNameAttribute})
+
+    def test_create_reader_raises_for_unsupported_type(self):
+        with pytest.raises(ValueError, match="Unsupported input type"):
+            TokenizationConfigHelper.create_reader("input.unknown", "json")

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_helper_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_helper_test.py
@@ -4,13 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
 from openlinktoken_cli.tokens.config.tokenization_config import AttributeMappingEntry, TokenizationConfig
 from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
 
 
 class TestTokenizationConfigHelper:
-    def test_build_configured_input_attribute_map_warns_when_factory_misses_entry(self, caplog):
+    def test_build_configured_input_attribute_map_warns_when_resolver_misses_entry(self, caplog):
         config = TokenizationConfig(
             attributes={
                 "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
@@ -19,32 +19,35 @@ class TestTokenizationConfigHelper:
             token_rules={},
         )
 
-        factory = MagicMock()
-        factory.get_class_for_column.side_effect = [FirstNameAttribute, KeyError("missing")]
+        resolver = MagicMock()
+        resolver.get_field_for_column.side_effect = ["FirstName", KeyError("missing")]
 
-        attribute_map = TokenizationConfigHelper.build_configured_input_attribute_map(config, factory)
+        attribute_map = TokenizationConfigHelper.build_configured_input_attribute_map(config, resolver)
 
-        assert attribute_map == {"given_nm": FirstNameAttribute}
-        assert "has no dynamic class registered" in caplog.text
+        assert attribute_map == {"given_nm": "FirstName"}
+        assert "has no field id registered" in caplog.text
 
     def test_create_reader_csv_applies_attribute_map(self):
         config = TokenizationConfig(
             attributes={"given_nm": AttributeMappingEntry(field="FirstName", type="GivenName")},
             token_rules={},
         )
-        factory = MagicMock()
+        resolver = MagicMock()
 
-        with patch(
-            "openlinktoken_cli.tokens.config.tokenization_config_helper.TokenizationConfigHelper"
-            ".build_configured_input_attribute_map",
-            return_value={"given_nm": FirstNameAttribute},
-        ), patch(
-            "openlinktoken_cli.tokens.config.tokenization_config_helper.PersonAttributesCSVReader"
-        ) as mock_reader_cls:
+        with (
+            patch(
+                "openlinktoken_cli.tokens.config.tokenization_config_helper.TokenizationConfigHelper"
+                ".build_configured_input_attribute_map",
+                return_value={"given_nm": FirstNameAttribute},
+            ),
+            patch(
+                "openlinktoken_cli.tokens.config.tokenization_config_helper.PersonAttributesCSVReader"
+            ) as mock_reader_cls,
+        ):
             reader = MagicMock()
             mock_reader_cls.return_value = reader
 
-            created_reader = TokenizationConfigHelper.create_reader("input.csv", "csv", config, factory)
+            created_reader = TokenizationConfigHelper.create_reader("input.csv", "csv", config, resolver)
 
         assert created_reader is reader
         mock_reader_cls.assert_called_once_with("input.csv", attribute_map={"given_nm": FirstNameAttribute})
@@ -54,19 +57,22 @@ class TestTokenizationConfigHelper:
             attributes={"given_nm": AttributeMappingEntry(field="FirstName", type="GivenName")},
             token_rules={},
         )
-        factory = MagicMock()
+        resolver = MagicMock()
 
-        with patch(
-            "openlinktoken_cli.tokens.config.tokenization_config_helper.TokenizationConfigHelper"
-            ".build_configured_input_attribute_map",
-            return_value={"given_nm": FirstNameAttribute},
-        ), patch(
-            "openlinktoken_cli.tokens.config.tokenization_config_helper.PersonAttributesParquetReader"
-        ) as mock_reader_cls:
+        with (
+            patch(
+                "openlinktoken_cli.tokens.config.tokenization_config_helper.TokenizationConfigHelper"
+                ".build_configured_input_attribute_map",
+                return_value={"given_nm": FirstNameAttribute},
+            ),
+            patch(
+                "openlinktoken_cli.tokens.config.tokenization_config_helper.PersonAttributesParquetReader"
+            ) as mock_reader_cls,
+        ):
             reader = MagicMock()
             mock_reader_cls.return_value = reader
 
-            created_reader = TokenizationConfigHelper.create_reader("input.parquet", "parquet", config, factory)
+            created_reader = TokenizationConfigHelper.create_reader("input.parquet", "parquet", config, resolver)
 
         assert created_reader is reader
         mock_reader_cls.assert_called_once_with("input.parquet", attribute_map={"given_nm": FirstNameAttribute})

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_helper_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_helper_test.py
@@ -12,9 +12,9 @@ from openlinktoken_cli.tokens.config.tokenization_config_helper import Tokenizat
 class TestTokenizationConfigHelper:
     def test_build_configured_input_attribute_map_warns_when_resolver_misses_entry(self, caplog):
         config = TokenizationConfig(
-            attributes={
-                "given_nm": AttributeMappingEntry(field="FirstName", type="GivenName"),
-                "family_nm": AttributeMappingEntry(field="FamilyName", type="LastName"),
+            column_mappings={
+                "FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName"),
+                "FamilyName": AttributeMappingEntry(column_name="family_nm", type="LastName"),
             },
             token_rules={},
         )
@@ -29,7 +29,7 @@ class TestTokenizationConfigHelper:
 
     def test_create_reader_csv_applies_attribute_map(self):
         config = TokenizationConfig(
-            attributes={"given_nm": AttributeMappingEntry(field="FirstName", type="GivenName")},
+            column_mappings={"FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName")},
             token_rules={},
         )
         resolver = MagicMock()
@@ -54,7 +54,7 @@ class TestTokenizationConfigHelper:
 
     def test_create_reader_parquet_applies_attribute_map(self):
         config = TokenizationConfig(
-            attributes={"given_nm": AttributeMappingEntry(field="FirstName", type="GivenName")},
+            column_mappings={"FirstName": AttributeMappingEntry(column_name="given_nm", type="GivenName")},
             token_rules={},
         )
         resolver = MagicMock()

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_loader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_loader_test.py
@@ -21,9 +21,9 @@ class TestTokenizationConfigLoader:
         config_path = tmp_path / "tokenization-config.yaml"
         config_path.write_text(
             """
-attributes:
-  given_nm:
-    field: FirstName
+column_mappings:
+  FirstName:
+    column_name: "given_nm"
     type: GivenName
 token_rules:
   T1:
@@ -43,12 +43,12 @@ token_rules:
         config_path = tmp_path / "tokenization-config.yaml"
         config_path.write_text(
             """
-attributes:
-  given_nm:
-    field: FirstName
+column_mappings:
+  FirstName:
+    column_name: "given_nm"
     type: GivenName
-  family_nm:
-    field: FamilyName
+  FamilyName:
+    column_name: "family nm"
     type: LastName
 
 token_rules:
@@ -63,8 +63,8 @@ token_rules:
 
         config = TokenizationConfigLoader.load(str(config_path))
 
-        assert config.attributes["given_nm"].field == "FirstName"
-        assert config.attributes["given_nm"].type == "GivenName"
+        assert config.column_mappings["FirstName"].column_name == "given_nm"
+        assert config.column_mappings["FirstName"].type == "GivenName"
         assert "T1" in config.token_rules
         assert config.token_rules["T1"][0].field == "FamilyName"
         assert config.token_rules["T1"][0].expression == "T|U"
@@ -73,8 +73,8 @@ token_rules:
         config_path = tmp_path / "invalid-config.yaml"
         config_path.write_text(
             """
-attributes:
-  given_nm:
+column_mappings:
+  FirstName:
     type: GivenName
 
 token_rules:
@@ -85,16 +85,16 @@ token_rules:
             encoding="utf-8",
         )
 
-        with pytest.raises(ValueError, match="missing required field 'field'"):
+        with pytest.raises(ValueError, match="missing required field 'column_name'"):
             TokenizationConfigLoader.load(str(config_path))
 
     def test_load_unknown_field_reference_raises(self, tmp_path: Path):
         config_path = tmp_path / "invalid-config.yaml"
         config_path.write_text(
             """
-attributes:
-  given_nm:
-    field: FirstName
+column_mappings:
+  FirstName:
+    column_name: "given_nm"
     type: GivenName
 
 token_rules:
@@ -112,9 +112,9 @@ token_rules:
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             """
-attributes:
-  given_nm:
-    field: FirstName
+column_mappings:
+  FirstName:
+    column_name: "given_nm"
     type: GivenName
 
 token_rules:

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_loader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_loader_test.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+
+from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
+from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
+
+
+class TestTokenizationConfigLoader:
+    def test_load_runtime_components_without_path_returns_none_tuple(self):
+        config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(None)
+
+        assert config is None
+        assert factory is None
+        assert token_definition is None
+
+    def test_load_runtime_components_with_path_builds_runtime_objects(self, tmp_path: Path):
+        config_path = tmp_path / "tokenization-config.yaml"
+        config_path.write_text(
+            """
+attributes:
+  given_nm:
+    field: FirstName
+    type: GivenName
+token_rules:
+  T1:
+    - field: FirstName
+      expression: T|U
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(str(config_path))
+
+        assert config is not None
+        assert isinstance(factory, DynamicAttributeFactory)
+        assert isinstance(token_definition, DynamicTokenDefinition)
+
+    def test_load_valid_config(self, tmp_path: Path):
+        config_path = tmp_path / "tokenization-config.yaml"
+        config_path.write_text(
+            """
+attributes:
+  given_nm:
+    field: FirstName
+    type: GivenName
+  family_nm:
+    field: FamilyName
+    type: LastName
+
+token_rules:
+  T1:
+    - field: FamilyName
+      expression: "T|U"
+    - field: FirstName
+      expression: "T|S(0,1)|U"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        config = TokenizationConfigLoader.load(str(config_path))
+
+        assert config.attributes["given_nm"].field == "FirstName"
+        assert config.attributes["given_nm"].type == "GivenName"
+        assert "T1" in config.token_rules
+        assert config.token_rules["T1"][0].field == "FamilyName"
+        assert config.token_rules["T1"][0].expression == "T|U"
+
+    def test_load_missing_attribute_field_raises(self, tmp_path: Path):
+        config_path = tmp_path / "invalid-config.yaml"
+        config_path.write_text(
+            """
+attributes:
+  given_nm:
+    type: GivenName
+
+token_rules:
+  T1:
+    - field: FirstName
+      expression: "T|U"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="missing required field 'field'"):
+            TokenizationConfigLoader.load(str(config_path))
+
+    def test_load_unknown_field_reference_raises(self, tmp_path: Path):
+        config_path = tmp_path / "invalid-config.yaml"
+        config_path.write_text(
+            """
+attributes:
+  given_nm:
+    field: FirstName
+    type: GivenName
+
+token_rules:
+  T1:
+    - field: UnknownField
+      expression: "T|U"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="references unknown field"):
+            TokenizationConfigLoader.load(str(config_path))
+
+    def test_load_raises_on_unknown_expression_operator(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            """
+attributes:
+  given_nm:
+    field: FirstName
+    type: GivenName
+
+token_rules:
+  T1:
+    - field: FirstName
+      expression: "T|Y"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="unknown expression operator"):
+            TokenizationConfigLoader.load(str(config_path))

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_loader_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/tokens/config/tokenization_config_loader_test.py
@@ -4,17 +4,17 @@ from pathlib import Path
 
 import pytest
 
-from openlinktoken_cli.tokens.config.dynamic_attribute_factory import DynamicAttributeFactory
+from openlinktoken_cli.tokens.config.configured_attribute_resolver import ConfiguredAttributeResolver
 from openlinktoken_cli.tokens.config.dynamic_token_definition import DynamicTokenDefinition
 from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
 
 
 class TestTokenizationConfigLoader:
     def test_load_runtime_components_without_path_returns_none_tuple(self):
-        config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(None)
+        config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(None)
 
         assert config is None
-        assert factory is None
+        assert resolver is None
         assert token_definition is None
 
     def test_load_runtime_components_with_path_builds_runtime_objects(self, tmp_path: Path):
@@ -33,10 +33,10 @@ token_rules:
             encoding="utf-8",
         )
 
-        config, factory, token_definition = TokenizationConfigLoader.load_runtime_components(str(config_path))
+        config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(str(config_path))
 
         assert config is not None
-        assert isinstance(factory, DynamicAttributeFactory)
+        assert isinstance(resolver, ConfiguredAttributeResolver)
         assert isinstance(token_definition, DynamicTokenDefinition)
 
     def test_load_valid_config(self, tmp_path: Path):

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/update_command_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/update_command_test.py
@@ -14,8 +14,8 @@ from openlinktoken_cli.commands.update_command import UpdateCommand
 # ---------------------------------------------------------------------------
 
 _FAKE_VERSION = "2.0.0"
-_NEWER_VERSION = "2.1.0"
-_NEWER_TAG = "v2.1.0"
+_NEWER_VERSION = "99.9.9"
+_NEWER_TAG = f"v{_NEWER_VERSION}"
 
 
 def _make_release(tag: str = _NEWER_TAG, assets: list | None = None) -> dict:
@@ -184,7 +184,7 @@ class TestAlreadyUpToDate:
 class TestChecksumMismatch:
     def test_checksum_mismatch_returns_nonzero(self, tmp_path, capsys):
         release = _make_release()
-        fake_binary = tmp_path / "openlinktoken-v2.1.0-linux-x86_64"
+        fake_binary = tmp_path / f"openlinktoken-{_NEWER_TAG}-linux-x86_64"
         fake_binary.write_bytes(b"fake binary content")
 
         args = _make_args()

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/version_checker_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/version_checker_test.py
@@ -55,11 +55,10 @@ class TestIsNewer:
         assert not VersionChecker._is_newer("1.9.0", "2.0.0")
 
     def test_prerelease_vs_release(self):
-        # 2.0.0-alpha is older than 2.0.0
-        assert VersionChecker._is_newer("2.0.0", "2.0.0-alpha")
+        assert VersionChecker._is_newer("1.6.8", "1.6.8-alpha")
 
     def test_alpha_not_newer_than_same_alpha(self):
-        assert not VersionChecker._is_newer("2.0.0-alpha", "2.0.0-alpha")
+        assert not VersionChecker._is_newer("1.4.5-alpha", "1.4.5-alpha")
 
 
 # ---------------------------------------------------------------------------

--- a/lib/python/openlinktoken-pyspark/pyproject.toml
+++ b/lib/python/openlinktoken-pyspark/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlinktoken-pyspark"
-version = "2.0.0"
+version = "2.1.0"
 requires-python = ">=3.10"
 dynamic = [
   "authors",

--- a/lib/python/openlinktoken-pyspark/pyproject.toml
+++ b/lib/python/openlinktoken-pyspark/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = [
 ]
 
 [build-system]
-requires = ["setuptools==82.0.1", "wheel"]
+requires = ["setuptools==83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]

--- a/lib/python/openlinktoken-pyspark/requirements.txt
+++ b/lib/python/openlinktoken-pyspark/requirements.txt
@@ -1,5 +1,5 @@
 # Core openlinktoken dependency
-openlinktoken==2.0.0
+openlinktoken==2.1.0
 
 # Cryptography for token decryption in overlap analysis
 pycryptodome==3.23.0

--- a/lib/python/openlinktoken-pyspark/setup.py
+++ b/lib/python/openlinktoken-pyspark/setup.py
@@ -60,7 +60,7 @@ setup(
             "pyarrow==19.0.0",
             "pandas==2.2.3; python_version < '3.11'",
             "pandas==3.0.3; python_version >= '3.11'",
-            "setuptools==82.0.1; python_version >= '3.12'",
+            "setuptools==83.0.0; python_version >= '3.12'",
         ],
         # Spark 3.4.x - Legacy support
         "spark34": [
@@ -68,7 +68,7 @@ setup(
             "pyarrow==15.0.0",
             "pandas==2.1.4; python_version < '3.11'",
             "pandas==3.0.3; python_version >= '3.11'",
-            "setuptools==82.0.1; python_version >= '3.12'",
+            "setuptools==83.0.0; python_version >= '3.12'",
         ],
         # Development dependencies
         "dev": [

--- a/lib/python/openlinktoken-pyspark/setup.py
+++ b/lib/python/openlinktoken-pyspark/setup.py
@@ -18,14 +18,14 @@ except FileNotFoundError:
 
 # Core dependencies (version-agnostic, no PySpark)
 core_requirements = [
-    "openlinktoken==2.0.0",
+    "openlinktoken==2.1.0",
     "pycryptodome==3.23.0",
     "jwcrypto==1.5.7",
 ]
 
 setup(
     name="openlinktoken-pyspark",
-    version="2.0.0",
+    version="2.1.0",
     author="Open Link Token Contributors",
     description="Open Link Token PySpark bridge for distributed token generation",
     long_description=long_description,

--- a/lib/python/openlinktoken-pyspark/setup.py
+++ b/lib/python/openlinktoken-pyspark/setup.py
@@ -76,7 +76,7 @@ setup(
             "pytest-cov==7.1.0",
             "flake8==7.3.0",
             "jupyter==1.1.1",
-            "notebook==7.5.7",
+            "notebook==7.6.0",
             "ipykernel==7.3.0",
         ],
     },

--- a/lib/python/openlinktoken-pyspark/setup.py
+++ b/lib/python/openlinktoken-pyspark/setup.py
@@ -72,7 +72,7 @@ setup(
         ],
         # Development dependencies
         "dev": [
-            "pytest==9.0.3",
+            "pytest==9.1.1",
             "pytest-cov==7.1.0",
             "flake8==7.3.0",
             "jupyter==1.1.1",

--- a/lib/python/openlinktoken-pyspark/src/main/openlinktoken_pyspark/__init__.py
+++ b/lib/python/openlinktoken-pyspark/src/main/openlinktoken_pyspark/__init__.py
@@ -3,7 +3,7 @@
 Open Link Token PySpark Bridge - Distributed token generation for PySpark DataFrames.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from openlinktoken_pyspark.notebook_helpers import (
     CustomTokenDefinition,

--- a/lib/python/openlinktoken/pyproject.toml
+++ b/lib/python/openlinktoken/pyproject.toml
@@ -12,6 +12,7 @@ dynamic = [
 dependencies = [
   "cryptography==48.0.1",
   "jwcrypto==1.5.7",
+  "PyYAML==6.0.3",
 ]
 
 [build-system]

--- a/lib/python/openlinktoken/pyproject.toml
+++ b/lib/python/openlinktoken/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
   "urls",
 ]
 dependencies = [
-  "cryptography==48.0.1",
+  "cryptography==49.0.0",
   "jwcrypto==1.5.7",
   "PyYAML==6.0.3",
 ]

--- a/lib/python/openlinktoken/pyproject.toml
+++ b/lib/python/openlinktoken/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlinktoken"
-version = "2.0.0"
+version = "2.1.0"
 requires-python = ">=3.10"
 dynamic = [
   "authors",

--- a/lib/python/openlinktoken/requirements.txt
+++ b/lib/python/openlinktoken/requirements.txt
@@ -1,5 +1,5 @@
 # Cryptography - mandate secure version to address CVE-2026-44432
-cryptography==48.0.1
+cryptography==49.0.0
 
 # JOSE/JWE for match token format
 jwcrypto==1.5.7

--- a/lib/python/openlinktoken/requirements.txt
+++ b/lib/python/openlinktoken/requirements.txt
@@ -3,3 +3,6 @@ cryptography==48.0.1
 
 # JOSE/JWE for match token format
 jwcrypto==1.5.7
+
+# YAML parsing for tokenization config loader
+PyYAML==6.0.3

--- a/lib/python/openlinktoken/setup.py
+++ b/lib/python/openlinktoken/setup.py
@@ -17,7 +17,7 @@ except FileNotFoundError:
     long_description = "Open Link Token Python implementation for record linkage."
 setup(
     name="openlinktoken",
-    version="2.0.0",
+    version="2.1.0",
     author="Open Link Token Contributors",
     description="Open Link Token Python core library for record linkage",
     long_description=long_description,

--- a/lib/python/openlinktoken/setup.py
+++ b/lib/python/openlinktoken/setup.py
@@ -15,7 +15,6 @@ try:
 except FileNotFoundError:
     # Fallback to a short description if README is unavailable
     long_description = "Open Link Token Python implementation for record linkage."
-
 setup(
     name="openlinktoken",
     version="2.0.0",

--- a/lib/python/openlinktoken/src/main/openlinktoken/__init__.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/__init__.py
@@ -6,7 +6,7 @@ This package provides utilities for tokenizing and processing person attributes
 using various cryptographic transformations.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __author__ = "Open Link Token Contributors"
 
 __all__ = [

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/__init__.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/__init__.py
@@ -2,16 +2,20 @@
 
 from .attribute import Attribute
 from .attribute_expression import AttributeExpression
+from .attribute_field import AttributeField
 from .attribute_loader import AttributeLoader
 from .base_attribute import BaseAttribute
 from .combined_attribute import CombinedAttribute
+from .field_registry import FieldRegistry
 from .serializable_attribute import SerializableAttribute
 
 __all__ = [
     "Attribute",
     "AttributeExpression",
+    "AttributeField",
     "AttributeLoader",
     "BaseAttribute",
     "CombinedAttribute",
+    "FieldRegistry",
     "SerializableAttribute",
 ]

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/attribute_expression.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/attribute_expression.py
@@ -32,16 +32,39 @@ class AttributeExpression:
 
     EXPRESSION_PATTERN = re.compile(r"\s*(?P<expr>[^ (]+)(?:\((?P<args>[^\)]+)\))?")
 
-    def __init__(self, attribute_class: Type["Attribute"], expressions: Optional[str]):
+    def __init__(
+        self,
+        attribute_class: Type["Attribute"],
+        expressions: Optional[str],
+        field_id: Optional[str] = None,
+    ):
         """
         Initialize the AttributeExpression.
 
         Args:
             attribute_class: The class of the attribute being processed.
             expressions: The string of expressions to apply.
+            field_id: Optional field identifier for field-based lookup. When None,
+                the attribute class is used directly as the identity key (legacy behavior).
         """
         self.attribute_class = attribute_class
         self.expressions = expressions
+        self.field_id = field_id
+
+    @classmethod
+    def of(cls, field_id: str, attribute_class: Type["Attribute"], expressions: Optional[str]) -> "AttributeExpression":
+        """
+        Create an attribute expression using a field ID for identity.
+
+        Args:
+            field_id: Unique field identifier from the FieldRegistry.
+            attribute_class: The class of the attribute providing normalization and validation.
+            expressions: The string of expressions to apply.
+
+        Returns:
+            A new AttributeExpression with field_id set.
+        """
+        return cls(attribute_class, expressions, field_id=field_id)
 
     def get_effective_value(self, value: Optional[str]) -> str:
         """

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/attribute_field.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/attribute_field.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+
+from typing import TYPE_CHECKING, Type
+
+if TYPE_CHECKING:
+    from openlinktoken.attributes.attribute import Attribute
+
+
+class AttributeField:
+    """
+    Represents a named field slot in a person record.
+
+    An AttributeField separates two concerns that were previously conflated:
+    - Field identity: "which value from the person record?" (the field_id)
+    - Attribute behavior: "how to normalize/validate?" (the attribute_class)
+
+    This allows multiple fields to share the same attribute type (e.g., two fields
+    both using StringAttribute normalization) while remaining distinct keys in the
+    person attributes map.
+    """
+
+    def __init__(self, field_id: str, attribute_class: Type["Attribute"]):
+        """
+        Create an attribute field with the given identity and attribute type.
+
+        Args:
+            field_id: Unique field identifier (e.g., "LastName", "MotherLastName").
+            attribute_class: The attribute class providing normalization and validation behavior.
+        """
+        if field_id is None:
+            raise ValueError("field_id must not be None")
+        if attribute_class is None:
+            raise ValueError("attribute_class must not be None")
+        self._field_id = field_id
+        self._attribute_class = attribute_class
+
+    @property
+    def field_id(self) -> str:
+        """Get the unique field identifier."""
+        return self._field_id
+
+    @property
+    def attribute_class(self) -> Type["Attribute"]:
+        """Get the attribute class providing normalization and validation behavior."""
+        return self._attribute_class
+
+    def __eq__(self, other: object) -> bool:
+        if self is other:
+            return True
+        if not isinstance(other, AttributeField):
+            return False
+        return self._field_id == other._field_id
+
+    def __hash__(self) -> int:
+        return hash(self._field_id)
+
+    def __repr__(self) -> str:
+        return f"AttributeField(field_id='{self._field_id}', attribute_class={self._attribute_class.__name__})"

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/field_registry.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/field_registry.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+
+from typing import Dict, Optional, Set, Type
+
+from openlinktoken.attributes.attribute import Attribute
+from openlinktoken.attributes.attribute_field import AttributeField
+from openlinktoken.attributes.attribute_loader import AttributeLoader
+
+
+class FieldRegistry:
+    """
+    Registry mapping field identifiers to their corresponding Attribute instances.
+
+    The FieldRegistry is the resolution layer that connects field identifiers
+    (string keys used in person-attribute maps) to the attribute instances that provide
+    normalization and validation behavior.
+
+    Built-in attributes are auto-registered using their canonical name as the field ID.
+    Config-driven fields can register additional mappings (e.g., "MotherLastName" → StringAttribute).
+    """
+
+    def __init__(self, fields: Dict[str, AttributeField], field_to_attribute: Dict[str, Attribute]):
+        """
+        Initialize a FieldRegistry with the given mappings.
+
+        Use FieldRegistry.create_default() or FieldRegistry.Builder for construction.
+
+        Args:
+            fields: Mapping of field ID to AttributeField.
+            field_to_attribute: Mapping of field ID to Attribute instance.
+        """
+        self._fields: Dict[str, AttributeField] = dict(fields)
+        self._field_to_attribute: Dict[str, Attribute] = dict(field_to_attribute)
+
+    @classmethod
+    def create_default(cls) -> "FieldRegistry":
+        """
+        Create a default registry populated with all built-in attributes.
+
+        Each attribute is registered using its canonical name (from get_name()) as the field ID.
+
+        Returns:
+            A new registry with built-in attribute registrations.
+        """
+        builder = cls.Builder()
+        for attribute in AttributeLoader.load():
+            builder.register(attribute.get_name(), type(attribute), attribute)
+        return builder.build()
+
+    def get_attribute(self, field_id: str) -> Optional[Attribute]:
+        """
+        Resolve the attribute instance for a given field ID.
+
+        Args:
+            field_id: The field identifier.
+
+        Returns:
+            The attribute if registered, None otherwise.
+        """
+        return self._field_to_attribute.get(field_id)
+
+    def get_field(self, field_id: str) -> Optional[AttributeField]:
+        """
+        Resolve the attribute field definition for a given field ID.
+
+        Args:
+            field_id: The field identifier.
+
+        Returns:
+            The AttributeField if registered, None otherwise.
+        """
+        return self._fields.get(field_id)
+
+    def get_field_ids(self) -> Set[str]:
+        """
+        Return all registered field IDs.
+
+        Returns:
+            A set of field identifiers.
+        """
+        return set(self._fields.keys())
+
+    def size(self) -> int:
+        """
+        Return the number of registered fields.
+
+        Returns:
+            The registry size.
+        """
+        return len(self._fields)
+
+    class Builder:
+        """Builder for constructing a FieldRegistry with custom registrations."""
+
+        def __init__(self):
+            self._fields: Dict[str, AttributeField] = {}
+            self._field_to_attribute: Dict[str, Attribute] = {}
+
+        @classmethod
+        def from_defaults(cls) -> "FieldRegistry.Builder":
+            """
+            Create a builder pre-populated with all built-in attribute registrations.
+
+            Returns:
+                A new builder with defaults loaded.
+            """
+            builder = cls()
+            for attribute in AttributeLoader.load():
+                builder.register(attribute.get_name(), type(attribute), attribute)
+            return builder
+
+        def register(
+            self, field_id: str, attribute_class: Type[Attribute], attribute: Attribute
+        ) -> "FieldRegistry.Builder":
+            """
+            Register a field ID with its attribute class and instance.
+
+            Args:
+                field_id: The unique field identifier.
+                attribute_class: The attribute class providing behavior.
+                attribute: The attribute instance for normalization/validation.
+
+            Returns:
+                This builder for chaining.
+            """
+            self._fields[field_id] = AttributeField(field_id, attribute_class)
+            self._field_to_attribute[field_id] = attribute
+            return self
+
+        def build(self) -> "FieldRegistry":
+            """
+            Build an immutable FieldRegistry from the current registrations.
+
+            Returns:
+                The constructed registry.
+            """
+            return FieldRegistry(self._fields, self._field_to_attribute)

--- a/lib/python/openlinktoken/src/main/openlinktoken/metadata.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/metadata.py
@@ -22,7 +22,7 @@ class Metadata:
     METADATA_FILE_EXTENSION = ".metadata.json"
     SYSTEM_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 
-    DEFAULT_VERSION = "2.0.0"
+    DEFAULT_VERSION = "2.1.0"
 
     # Output format values
     OUTPUT_FORMAT_JSON = "JSON"

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/field_ids.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/field_ids.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+
+
+class FieldIds:
+    """
+    Field identifiers referenced by the built-in T1-T5 token definitions.
+
+    Centralizing these values avoids duplicating the same field-id strings across
+    multiple token definition modules.
+    """
+
+    LAST_NAME = "LastName"
+    FIRST_NAME = "FirstName"
+    SEX = "Sex"
+    BIRTH_DATE = "BirthDate"
+    POSTAL_CODE = "PostalCode"
+    SOCIAL_SECURITY_NUMBER = "SocialSecurityNumber"

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t1_token.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t1_token.py
@@ -7,6 +7,7 @@ from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttrib
 from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
 from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
 from openlinktoken.attributes.person.sex_attribute import SexAttribute
+from openlinktoken.tokens.definitions.field_ids import FieldIds
 from openlinktoken.tokens.token import Token
 
 
@@ -24,10 +25,10 @@ class T1Token(Token):
     def __init__(self):
         """Initialize the T1 token definition."""
         self._definition = [
-            AttributeExpression(LastNameAttribute, "T|U"),
-            AttributeExpression(FirstNameAttribute, "T|S(0,1)|U"),
-            AttributeExpression(SexAttribute, "T|U"),
-            AttributeExpression(BirthDateAttribute, "T|D"),
+            AttributeExpression(LastNameAttribute, "T|U", field_id=FieldIds.LAST_NAME),
+            AttributeExpression(FirstNameAttribute, "T|S(0,1)|U", field_id=FieldIds.FIRST_NAME),
+            AttributeExpression(SexAttribute, "T|U", field_id=FieldIds.SEX),
+            AttributeExpression(BirthDateAttribute, "T|D", field_id=FieldIds.BIRTH_DATE),
         ]
 
     def get_identifier(self) -> str:

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t2_token.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t2_token.py
@@ -7,6 +7,7 @@ from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttrib
 from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
 from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
 from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
+from openlinktoken.tokens.definitions.field_ids import FieldIds
 from openlinktoken.tokens.token import Token
 
 
@@ -24,10 +25,10 @@ class T2Token(Token):
     def __init__(self):
         """Initialize the T2 token definition."""
         self._definition = [
-            AttributeExpression(LastNameAttribute, "T|U"),
-            AttributeExpression(FirstNameAttribute, "T|U"),
-            AttributeExpression(BirthDateAttribute, "T|D"),
-            AttributeExpression(PostalCodeAttribute, "T|S(0,3)|U"),
+            AttributeExpression(LastNameAttribute, "T|U", field_id=FieldIds.LAST_NAME),
+            AttributeExpression(FirstNameAttribute, "T|U", field_id=FieldIds.FIRST_NAME),
+            AttributeExpression(BirthDateAttribute, "T|D", field_id=FieldIds.BIRTH_DATE),
+            AttributeExpression(PostalCodeAttribute, "T|S(0,3)|U", field_id=FieldIds.POSTAL_CODE),
         ]
 
     def get_identifier(self) -> str:

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t3_token.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t3_token.py
@@ -7,6 +7,7 @@ from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttrib
 from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
 from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
 from openlinktoken.attributes.person.sex_attribute import SexAttribute
+from openlinktoken.tokens.definitions.field_ids import FieldIds
 from openlinktoken.tokens.token import Token
 
 
@@ -24,10 +25,10 @@ class T3Token(Token):
     def __init__(self):
         """Initialize the T3 token definition."""
         self._definition = [
-            AttributeExpression(LastNameAttribute, "T|U"),
-            AttributeExpression(FirstNameAttribute, "T|U"),
-            AttributeExpression(SexAttribute, "T|U"),
-            AttributeExpression(BirthDateAttribute, "T|D"),
+            AttributeExpression(LastNameAttribute, "T|U", field_id=FieldIds.LAST_NAME),
+            AttributeExpression(FirstNameAttribute, "T|U", field_id=FieldIds.FIRST_NAME),
+            AttributeExpression(SexAttribute, "T|U", field_id=FieldIds.SEX),
+            AttributeExpression(BirthDateAttribute, "T|D", field_id=FieldIds.BIRTH_DATE),
         ]
 
     def get_identifier(self) -> str:

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t4_token.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t4_token.py
@@ -6,6 +6,7 @@ from openlinktoken.attributes.attribute_expression import AttributeExpression
 from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttribute
 from openlinktoken.attributes.person.sex_attribute import SexAttribute
 from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
+from openlinktoken.tokens.definitions.field_ids import FieldIds
 from openlinktoken.tokens.token import Token
 
 
@@ -23,9 +24,9 @@ class T4Token(Token):
     def __init__(self):
         """Initialize the T4 token definition."""
         self._definition = [
-            AttributeExpression(SocialSecurityNumberAttribute, "T|M(\\d+)"),
-            AttributeExpression(SexAttribute, "T|U"),
-            AttributeExpression(BirthDateAttribute, "T|D"),
+            AttributeExpression(SocialSecurityNumberAttribute, "T|M(\\d+)", field_id=FieldIds.SOCIAL_SECURITY_NUMBER),
+            AttributeExpression(SexAttribute, "T|U", field_id=FieldIds.SEX),
+            AttributeExpression(BirthDateAttribute, "T|D", field_id=FieldIds.BIRTH_DATE),
         ]
 
     def get_identifier(self) -> str:

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t5_token.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/definitions/t5_token.py
@@ -6,6 +6,7 @@ from openlinktoken.attributes.attribute_expression import AttributeExpression
 from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
 from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
 from openlinktoken.attributes.person.sex_attribute import SexAttribute
+from openlinktoken.tokens.definitions.field_ids import FieldIds
 from openlinktoken.tokens.token import Token
 
 
@@ -23,9 +24,9 @@ class T5Token(Token):
     def __init__(self):
         """Initialize the T5 token definition."""
         self._definition = [
-            AttributeExpression(LastNameAttribute, "T|U"),
-            AttributeExpression(FirstNameAttribute, "T|S(0,3)|U"),
-            AttributeExpression(SexAttribute, "T|U"),
+            AttributeExpression(LastNameAttribute, "T|U", field_id=FieldIds.LAST_NAME),
+            AttributeExpression(FirstNameAttribute, "T|S(0,3)|U", field_id=FieldIds.FIRST_NAME),
+            AttributeExpression(SexAttribute, "T|U", field_id=FieldIds.SEX),
         ]
 
     def get_identifier(self) -> str:

--- a/lib/python/openlinktoken/src/main/openlinktoken/tokens/token_generator.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/tokens/token_generator.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Set, Type
 
 from openlinktoken.attributes.attribute import Attribute
 from openlinktoken.attributes.attribute_loader import AttributeLoader
+from openlinktoken.attributes.field_registry import FieldRegistry
 from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
 from openlinktoken.tokens.token import Token
 from openlinktoken.tokens.token_generation_exception import TokenGenerationException
@@ -35,13 +36,20 @@ class TokenGenerator:
         """
         return cls(token_definition, SHA256Tokenizer(token_transformer_list))
 
-    def __init__(self, token_definition: BaseTokenDefinition, tokenizer: Tokenizer):
+    def __init__(
+        self,
+        token_definition: BaseTokenDefinition,
+        tokenizer: Tokenizer,
+        field_registry: Optional[FieldRegistry] = None,
+    ):
         """
         Initialize the token generator with an explicit tokenizer.
 
         Args:
             token_definition: The token definition.
             tokenizer: Tokenizer implementation. Use PassthroughTokenizer for plain mode.
+            field_registry: Optional custom field registry for field-ID-based lookups.
+                When None, a default registry is created from built-in attributes.
         """
         self.token_definition = token_definition
         self.attribute_instance_map: Dict[Type[Attribute], Attribute] = {}
@@ -51,19 +59,20 @@ class TokenGenerator:
             self.attribute_instance_map[type(attribute)] = attribute
 
         self.tokenizer = tokenizer
+        self.field_registry = field_registry or FieldRegistry.create_default()
 
     def _get_token_signature(
         self, token_id: str, person_attributes: Dict[Type[Attribute], str], result: TokenGeneratorResult
     ) -> Optional[str]:
         """
-        Get the token signature for a given token identifier.
+        Get the token signature using a class-keyed person attributes map.
 
-        Populates the invalid_attributes list in the result object with the attributes
-        that are invalid.
+        .. deprecated::
+            Use :meth:`_get_token_signature_via_field_id` with a field-ID-keyed map instead.
 
         Args:
             token_id: The token identifier.
-            person_attributes: The person attributes map.
+            person_attributes: The person attributes map, keyed by attribute class.
             result: The token generator result.
 
         Returns:
@@ -107,12 +116,13 @@ class TokenGenerator:
 
     def get_all_token_signatures(self, person_attributes: Dict[Type[Attribute], str]) -> Dict[str, str]:
         """
-        Get the token signatures for all token/rule identifiers.
+        Get the token signatures for all token/rule identifiers using a class-keyed map.
 
-        This is mostly a debug/logging/test method.
+        .. deprecated::
+            Use :meth:`get_all_token_signatures_via_field_id` with a field-ID-keyed map instead.
 
         Args:
-            person_attributes: The person attributes map.
+            person_attributes: The person attributes map, keyed by attribute class.
 
         Returns:
             A map of token/rule identifier to the token signature.
@@ -133,18 +143,10 @@ class TokenGenerator:
         self, token_id: str, person_attributes: Dict[Type[Attribute], str], result: TokenGeneratorResult
     ) -> Optional[str]:
         """
-        Get token for a given token identifier.
+        Get token for a given token identifier using a class-keyed person attributes map.
 
-        Args:
-            token_id: The token identifier.
-            person_attributes: The person attributes map.
-            result: The token generator result.
-
-        Returns:
-            The token using the token definition for the given token identifier.
-
-        Raises:
-            TokenGenerationException: In case of failure to generate the token.
+        .. deprecated::
+            Use :meth:`get_all_tokens_via_field_id` with a field-ID-keyed map instead.
         """
         signature = self._get_token_signature(token_id, person_attributes, result)
         logger.debug(f"Token signature for token id {token_id}: {signature}")
@@ -161,10 +163,13 @@ class TokenGenerator:
 
     def get_all_tokens(self, person_attributes: Dict[Type[Attribute], str]) -> TokenGeneratorResult:
         """
-        Get the tokens for all token/rule identifiers.
+        Get the tokens for all token/rule identifiers using a class-keyed person attributes map.
+
+        .. deprecated::
+            Use :meth:`get_all_tokens_via_field_id` with a field-ID-keyed ``Dict[str, str]`` map instead.
 
         Args:
-            person_attributes: The person attributes map.
+            person_attributes: The person attributes map, keyed by attribute class.
 
         Returns:
             A TokenGeneratorResult object containing the tokens and invalid attributes.
@@ -185,8 +190,11 @@ class TokenGenerator:
         """
         Get invalid person attribute names.
 
+        .. deprecated::
+            Use field-ID-keyed person attributes with :meth:`get_all_tokens_via_field_id` instead.
+
         Args:
-            person_attributes: The person attributes map.
+            person_attributes: The person attributes map, keyed by attribute class.
 
         Returns:
             A set of invalid person attribute names.
@@ -199,3 +207,124 @@ class TokenGenerator:
                 response.add(attribute.get_name())
 
         return response
+
+    # ===== Primary API =====
+
+    def _get_token_signature_via_field_id(
+        self, token_id: str, person_attributes: Dict[str, str], result: TokenGeneratorResult
+    ) -> Optional[str]:
+        """
+        Get the token signature for a given token identifier.
+
+        Args:
+            token_id: The token identifier.
+            person_attributes: Person attributes keyed by field ID (e.g., "LastName" → "Smith").
+            result: The token generator result.
+
+        Returns:
+            The token signature, or None if required fields are missing or invalid.
+        """
+        definition = self.token_definition.get_token_definition(token_id)
+
+        if person_attributes is None:
+            raise ValueError("Person attributes cannot be null.")
+
+        values = []
+
+        for attribute_expression in definition:
+            resolved_field_id = self._resolve_field_id(attribute_expression)
+            if resolved_field_id is None or resolved_field_id not in person_attributes:
+                return None
+
+            attribute = self._resolve_attribute(attribute_expression, resolved_field_id)
+            if attribute is None:
+                return None
+
+            attribute_value = person_attributes[resolved_field_id]
+
+            if not attribute.validate(attribute_value):
+                result.invalid_attributes.add(attribute.get_name())
+                return None
+
+            attribute_value = attribute.normalize(attribute_value)
+
+            try:
+                attribute_value = attribute_expression.get_effective_value(attribute_value)
+                values.append(attribute_value)
+            except ValueError as e:
+                logger.error(str(e))
+                return None
+
+        filtered_values = [v for v in values if v is not None and v.strip() != ""]
+        return "|".join(filtered_values)
+
+    def get_all_tokens_via_field_id(self, person_attributes: Dict[str, str]) -> TokenGeneratorResult:
+        """
+        Get the tokens for all token/rule identifiers.
+
+        This is the preferred API. It natively supports multiple fields sharing the same
+        attribute type (e.g., "MotherLastName" and "FatherLastName" both backed by StringAttribute).
+
+        Args:
+            person_attributes: Person attributes keyed by field ID (e.g., "LastName" → "Smith").
+
+        Returns:
+            A TokenGeneratorResult object containing the tokens and invalid attributes.
+        """
+        result = TokenGeneratorResult()
+
+        for token_id in self.token_definition.get_token_identifiers():
+            try:
+                signature = self._get_token_signature_via_field_id(token_id, person_attributes, result)
+                logger.debug(f"Token signature for token id {token_id}: {signature}")
+                try:
+                    token = self.tokenizer.tokenize(signature)
+                    if Token.BLANK == token:
+                        result.blank_tokens_by_rule.add(token_id)
+                    if token is not None:
+                        result.tokens[token_id] = token
+                except Exception as e:
+                    logger.error(f"Error generating token for token id: {token_id}", exc_info=e)
+            except Exception as e:
+                logger.error(f"Error generating token for token id: {token_id}", exc_info=e)
+
+        return result
+
+    def get_all_token_signatures_via_field_id(self, person_attributes: Dict[str, str]) -> Dict[str, str]:
+        """
+        Get the token signatures for all token/rule identifiers. Mostly useful for debugging.
+
+        Args:
+            person_attributes: Person attributes keyed by field ID.
+
+        Returns:
+            A map of token/rule identifier to the token signature.
+        """
+        signatures = {}
+
+        for token_id in self.token_definition.get_token_identifiers():
+            try:
+                signature = self._get_token_signature_via_field_id(token_id, person_attributes, TokenGeneratorResult())
+                if signature is not None:
+                    signatures[token_id] = signature
+            except Exception as e:
+                logger.error(f"Error generating token signature for token id: {token_id}", exc_info=e)
+
+        return signatures
+
+    def _resolve_field_id(self, expression) -> Optional[str]:
+        """Resolve the effective field ID from an AttributeExpression."""
+        if expression.field_id is not None:
+            return expression.field_id
+        # Legacy fallback: derive field ID from attribute class name
+        attribute = self.attribute_instance_map.get(expression.attribute_class)
+        return attribute.get_name() if attribute else None
+
+    def _resolve_attribute(self, expression, resolved_field_id: str) -> Optional[Attribute]:
+        """Resolve the attribute instance for an expression and field ID."""
+        # Try field registry first
+        from_registry = self.field_registry.get_attribute(resolved_field_id)
+        if from_registry is not None:
+            return from_registry
+        # Fallback to class-based lookup
+        return self.attribute_instance_map.get(expression.attribute_class)

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/attribute_field_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/attribute_field_test.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from openlinktoken.attributes.attribute_field import AttributeField
+from openlinktoken.attributes.general.string_attribute import StringAttribute
+from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
+from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
+
+
+class TestAttributeField:
+    """Test cases for AttributeField."""
+
+    def test_constructor(self):
+        """Test basic field construction."""
+        field = AttributeField("LastName", LastNameAttribute)
+        assert field.field_id == "LastName"
+        assert field.attribute_class == LastNameAttribute
+
+    def test_constructor_rejects_none_field_id(self):
+        """Test that None field_id raises ValueError."""
+        with pytest.raises(ValueError, match="field_id must not be None"):
+            AttributeField(None, StringAttribute)
+
+    def test_constructor_rejects_none_attribute_class(self):
+        """Test that None attribute_class raises ValueError."""
+        with pytest.raises(ValueError, match="attribute_class must not be None"):
+            AttributeField("Test", None)
+
+    def test_equality_by_field_id(self):
+        """Test that equality is determined by field_id only."""
+        field1 = AttributeField("Name", StringAttribute)
+        field2 = AttributeField("Name", FirstNameAttribute)
+        assert field1 == field2
+        assert hash(field1) == hash(field2)
+
+    def test_inequality_by_field_id(self):
+        """Test that different field_ids produce inequality."""
+        field1 = AttributeField("FirstName", StringAttribute)
+        field2 = AttributeField("LastName", StringAttribute)
+        assert field1 != field2
+
+    def test_repr(self):
+        """Test string representation."""
+        field = AttributeField("BirthDate", StringAttribute)
+        assert "BirthDate" in repr(field)
+        assert "StringAttribute" in repr(field)

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/field_registry_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/field_registry_test.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+
+
+from openlinktoken.attributes.field_registry import FieldRegistry
+from openlinktoken.attributes.general.string_attribute import StringAttribute
+from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
+
+
+class TestFieldRegistry:
+    """Test cases for FieldRegistry."""
+
+    def test_create_default_loads_built_in_attributes(self):
+        """Test that create_default populates the registry with built-in attributes."""
+        registry = FieldRegistry.create_default()
+        assert registry.size() > 0
+        assert "FirstName" in registry.get_field_ids()
+        assert "LastName" in registry.get_field_ids()
+        assert "String" in registry.get_field_ids()
+
+    def test_get_attribute_returns_registered_instance(self):
+        """Test resolving an attribute by field ID."""
+        registry = FieldRegistry.create_default()
+        attribute = registry.get_attribute("FirstName")
+        assert attribute is not None
+        assert attribute.get_name() == "FirstName"
+
+    def test_get_attribute_returns_none_for_unknown_field(self):
+        """Test that unknown field IDs return None."""
+        registry = FieldRegistry.create_default()
+        attribute = registry.get_attribute("NonExistent")
+        assert attribute is None
+
+    def test_get_field_returns_attribute_field(self):
+        """Test resolving an AttributeField by field ID."""
+        registry = FieldRegistry.create_default()
+        field = registry.get_field("LastName")
+        assert field is not None
+        assert field.field_id == "LastName"
+        assert field.attribute_class == LastNameAttribute
+
+    def test_builder_registers_custom_field(self):
+        """Test that the builder can register custom fields with shared attribute types."""
+        attribute = StringAttribute()
+        registry = (
+            FieldRegistry.Builder.from_defaults()
+            .register("MotherLastName", StringAttribute, attribute)
+            .register("FatherLastName", StringAttribute, attribute)
+            .build()
+        )
+
+        assert "MotherLastName" in registry.get_field_ids()
+        assert "FatherLastName" in registry.get_field_ids()
+
+        mother_attr = registry.get_attribute("MotherLastName")
+        father_attr = registry.get_attribute("FatherLastName")
+        assert mother_attr is attribute
+        assert father_attr is attribute
+
+    def test_builder_from_defaults_includes_built_ins(self):
+        """Test that from_defaults pre-populates built-in attributes."""
+        registry = FieldRegistry.Builder.from_defaults().build()
+        assert "FirstName" in registry.get_field_ids()
+        assert "LastName" in registry.get_field_ids()
+
+    def test_multiple_fields_same_attribute_type(self):
+        """Test that multiple fields can share the same attribute type."""
+        string_attr = StringAttribute()
+        registry = (
+            FieldRegistry.Builder()
+            .register("Field1", StringAttribute, string_attr)
+            .register("Field2", StringAttribute, string_attr)
+            .register("Field3", StringAttribute, string_attr)
+            .build()
+        )
+
+        assert registry.size() == 3
+        assert registry.get_field("Field1") is not None
+        assert registry.get_field("Field2") is not None
+        assert registry.get_field("Field3") is not None
+        assert registry.get_attribute("Field1") is not None
+        assert registry.get_attribute("Field2") is not None
+        assert registry.get_attribute("Field3") is not None

--- a/lib/python/openlinktoken/src/test/openlinktoken/tokens/token_generator_field_id_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/tokens/token_generator_field_id_test.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: MIT
+
+"""Integration tests for field-ID-based token generation API."""
+
+from openlinktoken.attributes.attribute_expression import AttributeExpression
+from openlinktoken.attributes.field_registry import FieldRegistry
+from openlinktoken.attributes.general.string_attribute import StringAttribute
+from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
+from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
+from openlinktoken.attributes.person.sex_attribute import SexAttribute
+from openlinktoken.tokens.base_token_definition import BaseTokenDefinition
+from openlinktoken.tokens.token_generator import TokenGenerator
+from openlinktoken.tokens.tokenizer.passthrough_tokenizer import PassthroughTokenizer
+
+
+class _MultiFieldTokenDefinition(BaseTokenDefinition):
+    """Token definition with multiple StringAttribute fields for testing."""
+
+    def __init__(self):
+        self._definitions = {
+            "T_MULTI": [
+                AttributeExpression.of("MotherLastName", StringAttribute, "T|U"),
+                AttributeExpression.of("FatherLastName", StringAttribute, "T|U"),
+                AttributeExpression.of("FirstName", FirstNameAttribute, "T|S(0,1)|U"),
+            ],
+            "T_LEGACY": [
+                AttributeExpression(LastNameAttribute, "T|U"),
+                AttributeExpression(FirstNameAttribute, "T|S(0,1)|U"),
+                AttributeExpression(SexAttribute, "T|U"),
+            ],
+        }
+
+    def get_version(self):
+        return "test"
+
+    def get_token_identifiers(self):
+        return set(self._definitions.keys())
+
+    def get_token_definition(self, token_id):
+        return self._definitions.get(token_id, [])
+
+
+class TestTokenGeneratorFieldIdApi:
+    """Test the field-ID-based token generation API."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        string_attr = StringAttribute()
+        registry = (
+            FieldRegistry.Builder.from_defaults()
+            .register("MotherLastName", StringAttribute, string_attr)
+            .register("FatherLastName", StringAttribute, string_attr)
+            .build()
+        )
+        self.token_definition = _MultiFieldTokenDefinition()
+        self.token_generator = TokenGenerator(
+            self.token_definition,
+            PassthroughTokenizer([]),
+            field_registry=registry,
+        )
+
+    def test_multi_field_same_type_generates_token(self):
+        """Test that two StringAttribute fields produce a valid token signature."""
+        person = {
+            "MotherLastName": "Garcia",
+            "FatherLastName": "Lopez",
+            "FirstName": "Ana",
+        }
+
+        result = self.token_generator.get_all_tokens_via_field_id(person)
+        assert "T_MULTI" in result.tokens
+        assert result.tokens["T_MULTI"] == "GARCIA|LOPEZ|A"
+
+    def test_multi_field_missing_field_skips_token(self):
+        """Test that a missing field causes the token to produce BLANK."""
+        person = {
+            "MotherLastName": "Garcia",
+            "FirstName": "Ana",
+        }
+
+        result = self.token_generator.get_all_tokens_via_field_id(person)
+        # T_MULTI should get BLANK since FatherLastName is missing
+        from openlinktoken.tokens.token import Token
+
+        assert result.tokens.get("T_MULTI") == Token.BLANK
+
+    def test_legacy_expressions_work_with_field_id_api(self):
+        """Test that legacy (class-based) expressions still work via field ID resolution."""
+        person = {
+            "LastName": "Smith",
+            "FirstName": "John",
+            "Sex": "M",
+        }
+
+        result = self.token_generator.get_all_tokens_via_field_id(person)
+        assert "T_LEGACY" in result.tokens
+        assert result.tokens["T_LEGACY"] == "SMITH|J|MALE"
+
+    def test_signatures_by_field_id(self):
+        """Test getting token signatures using field-ID-based API."""
+        person = {
+            "MotherLastName": "Garcia",
+            "FatherLastName": "Lopez",
+            "FirstName": "Ana",
+            "LastName": "Smith",
+            "Sex": "F",
+        }
+
+        signatures = self.token_generator.get_all_token_signatures_via_field_id(person)
+        assert "T_MULTI" in signatures
+        assert signatures["T_MULTI"] == "GARCIA|LOPEZ|A"
+        assert "T_LEGACY" in signatures
+        assert signatures["T_LEGACY"] == "SMITH|A|FEMALE"
+
+    def test_invalid_attribute_tracked(self):
+        """Test that invalid values are tracked in the result."""
+        person = {
+            "MotherLastName": "",
+            "FatherLastName": "Lopez",
+            "FirstName": "Ana",
+        }
+
+        result = self.token_generator.get_all_tokens_via_field_id(person)
+        # T_MULTI should be BLANK since MotherLastName is empty (invalid)
+        from openlinktoken.tokens.token import Token
+
+        assert result.tokens.get("T_MULTI") == Token.BLANK
+        assert len(result.invalid_attributes) > 0

--- a/lib/python/openlinktoken/src/test/openlinktoken/tokens/token_generator_integration_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/tokens/token_generator_integration_test.py
@@ -53,3 +53,30 @@ class TestTokenGeneratorIntegration:
         assert tokens.get("T3") == "a76c3bff664bec8d0f77b4b47ad555d212dc671949ed3cf1c1edef68733835b2"
         assert tokens.get("T4") == "21c3cf1fdb4fd45197e5def14d0228d26c56bcec1b8641079f9b9ec24f9a6a0b"
         assert tokens.get("T5") == "3756556f2323148cb57e1e13b1abcd457e1c1706a84ae83d522a3fc0ad43506d"
+
+    def test_get_all_tokens_via_field_id_produces_same_tokens_as_class_based_api(self):
+        """Regression test: field-ID-based API must produce byte-identical tokens
+        to the deprecated class-based API for the real T1-T5 token definitions."""
+        token_definition = TokenDefinition()
+        token_generator = TokenGenerator.from_transformers(token_definition, [])
+
+        # Person attributes keyed by field ID, matching the same values used in
+        # test_get_all_tokens_valid_person_attributes_generates_tokens.
+        person_attributes = {
+            "FirstName": "Alice",
+            "LastName": "Wonderland",
+            "SocialSecurityNumber": "345-54-6795",
+            "Sex": "F",
+            "BirthDate": "1993-08-10",
+        }
+
+        tokens = token_generator.get_all_tokens_via_field_id(person_attributes).tokens
+
+        assert tokens is not None
+        assert len(tokens) == 5, "Expected 5 tokens to be generated"
+
+        assert tokens.get("T1") == "02292af14559b4c2a28a772536b81760ad7b8ebac8ce49e8450ca0fa5044e37f"
+        assert tokens.get("T2") == "0000000000000000000000000000000000000000000000000000000000000000"
+        assert tokens.get("T3") == "a76c3bff664bec8d0f77b4b47ad555d212dc671949ed3cf1c1edef68733835b2"
+        assert tokens.get("T4") == "21c3cf1fdb4fd45197e5def14d0228d26c56bcec1b8641079f9b9ec24f9a6a0b"
+        assert tokens.get("T5") == "3756556f2323148cb57e1e13b1abcd457e1c1706a84ae83d522a3fc0ad43506d"

--- a/pages/concepts/token-rules.md
+++ b/pages/concepts/token-rules.md
@@ -225,6 +225,29 @@ Notes:
 
 ---
 
+## Expression Syntax
+
+Each `AttributeExpression` takes an expression string — a `|`-separated pipeline of operators applied to the attribute value before token generation:
+
+| Operator       | Description                                             |
+| -------------- | ------------------------------------------------------- |
+| `T`            | Trim whitespace                                         |
+| `U`            | Convert to upper case                                   |
+| `S(start,end)` | Substring from `start` (inclusive) to `end` (exclusive) |
+| `D`            | Parse as a date in `yyyy-MM-dd` format                  |
+| `M(regex)`     | Assert value matches the regular expression             |
+| `R(old,new)`   | Replace all occurrences of `old` with `new`             |
+
+Examples:
+
+```
+T|S(0,3)|U      # trim, take first 3 chars, uppercase
+T|D             # trim, treat as date
+T|M("\\d+")    # trim, assert all digits
+```
+
+---
+
 ## Custom Token Rules
 
 Open Link Token supports defining custom token rules:

--- a/pages/concepts/token-rules.md
+++ b/pages/concepts/token-rules.md
@@ -252,6 +252,8 @@ T|M("\\d+")    # trim, assert all digits
 
 Open Link Token supports defining custom token rules:
 
+Each `AttributeExpression` is given an explicit field ID (`"LastName"`, `"BirthDate"`) that is used as the lookup key in the person-attributes map at token generation time. See [FieldRegistry and Field IDs](../reference/token-registration.md#fieldregistry-and-field-ids) for how field IDs resolve to attribute behavior, including how to register custom fields that reuse an existing attribute type (e.g. `MotherLastName`/`FatherLastName`, both backed by `StringAttribute`).
+
 ### Java
 
 ```java
@@ -270,8 +272,8 @@ public class CustomToken implements Token {
 
   public CustomToken() {
     // Example signature: U(LastName)|BirthDate
-    definition.add(new AttributeExpression(LastNameAttribute.class, "T|U"));
-    definition.add(new AttributeExpression(BirthDateAttribute.class, "T|D"));
+    definition.add(new AttributeExpression("LastName", LastNameAttribute.class, "T|U"));
+    definition.add(new AttributeExpression("BirthDate", BirthDateAttribute.class, "T|D"));
   }
 
   @Override
@@ -302,8 +304,8 @@ class CustomToken(Token):
   def __init__(self):
     # Example signature: U(LastName)|BirthDate
     self._definition = [
-      AttributeExpression(LastNameAttribute, "T|U"),
-      AttributeExpression(BirthDateAttribute, "T|D"),
+      AttributeExpression(LastNameAttribute, "T|U", field_id="LastName"),
+      AttributeExpression(BirthDateAttribute, "T|D", field_id="BirthDate"),
     ]
 
   def get_identifier(self) -> str:
@@ -313,7 +315,7 @@ class CustomToken(Token):
     return self._definition
 ```
 
-See [Token Registration](../reference/token-registration.md) for registration details.
+See [Token Registration](../reference/token-registration.md) for registration details, including the `FieldRegistry` custom-field example.
 
 ---
 

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -36,8 +36,8 @@ Each downloadable ZIP is also published with a matching `.sha256` sidecar for ma
 
 ```bash
 # Extract the zip file
-unzip openlinktoken-cli-2.0.0-macos-universal.zip
-cd openlinktoken-cli-2.0.0-macos-universal
+unzip openlinktoken-cli-2.1.0-macos-universal.zip
+cd openlinktoken-cli-2.1.0-macos-universal
 
 # Make executable (if needed)
 chmod +x openlinktoken
@@ -54,8 +54,8 @@ chmod +x openlinktoken
 
 ```powershell
 # Extract the zip file
-Expand-Archive openlinktoken-cli-2.0.0-windows-x64.zip
-cd openlinktoken-cli-2.0.0-windows-x64
+Expand-Archive openlinktoken-cli-2.1.0-windows-x64.zip
+cd openlinktoken-cli-2.1.0-windows-x64
 
 # Simulate receiving the recipient's public key (in practice, your partner provides this)
 .\olt.exe generate-key-pair --name recipient

--- a/pages/quickstarts/java-quickstart.md
+++ b/pages/quickstarts/java-quickstart.md
@@ -28,7 +28,7 @@ Add the Open Link Token library to your project's `pom.xml`:
 <dependency>
     <groupId>org.openlinktoken</groupId>
     <artifactId>openlinktoken</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -85,6 +85,7 @@ The automatic version check can also be disabled permanently by setting the envi
 | `--exchange-config` |       | Default mode only | `./openlinktoken-YYYY-MM-DD.exchange.json` | Exchange config JSON path. Defaults to `./openlinktoken-YYYY-MM-DD.exchange.json` when omitted.                                                                                                                                |
 | `--private-key`     |       | No\*              |                                            | Private key PEM used to decrypt the exchange config                                                                                                                                                                            |
 | `--private-key-env` |       | No\*              |                                            | Environment variable containing the private key PEM                                                                                                                                                                            |
+| `--config`          |       | No                |                                            | YAML config file for custom input field mapping and token-rule definitions. See [Tokenization Configuration Reference](tokenization-config.md). Supported for CSV and Parquet input.                                           |
 | `--mode`            |       | No                | `default`                                  | Mode selector: `default`, `hash-only`, or `demo`. `hash-only` cannot be combined with exchange-config, private-key options, or `--hash-record-ids`; `demo` cannot be combined with `--exchange-config` or `--hash-record-ids`. |
 | `--hash-record-ids` |       | No                |                                            | SHA-256 hash each input `RecordId` before writing to output (one-way, no traceability; default tokenize mode only)                                                                                                             |
 
@@ -284,6 +285,17 @@ olt tokenize \
 ```
 Signature → SHA-256 → HMAC-SHA256 → Base64
 ```
+
+## Custom Tokenization Configuration (`tokenize --config`)
+
+Use `--config` to decouple tokenization from built-in column aliases.
+
+For complete details, see [Tokenization Configuration Reference](tokenization-config.md), including:
+
+- unusual-field input examples
+- full YAML configuration examples
+- configuration-file specification
+- CLI validation rules and constraints
 
 ### Hash-only Mode (`tokenize --mode hash-only`)
 

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -416,7 +416,7 @@ Every run generates a `.metadata.json` file:
 {
   "Platform": "Python",
   "PythonVersion": "3.11.0",
-  "Version": "2.0.0",
+  "Version": "2.1.0",
   "TotalRows": 100,
   "TotalRowsWithInvalidAttributes": 3,
   "InvalidAttributesByType": {

--- a/pages/reference/index.md
+++ b/pages/reference/index.md
@@ -36,13 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.openlinktoken.attributes.Attribute;
-import org.openlinktoken.attributes.person.BirthDateAttribute;
-import org.openlinktoken.attributes.person.FirstNameAttribute;
-import org.openlinktoken.attributes.person.LastNameAttribute;
-import org.openlinktoken.attributes.person.PostalCodeAttribute;
-import org.openlinktoken.attributes.person.SexAttribute;
-import org.openlinktoken.attributes.person.SocialSecurityNumberAttribute;
 import org.openlinktoken.tokens.TokenDefinition;
 import org.openlinktoken.tokens.TokenGenerator;
 import org.openlinktoken.tokens.TokenGeneratorResult;
@@ -61,17 +54,19 @@ TokenGenerator tokenGenerator = new TokenGenerator(
   new SHA256Tokenizer(transformers)
 );
 
-Map<Class<? extends Attribute>, String> personAttributes = new HashMap<>();
-personAttributes.put(FirstNameAttribute.class, "Elena");
-personAttributes.put(LastNameAttribute.class, "Vasquez");
-personAttributes.put(BirthDateAttribute.class, "1992-07-14");
-personAttributes.put(SexAttribute.class, "Female");
-personAttributes.put(PostalCodeAttribute.class, "30301");
-personAttributes.put(SocialSecurityNumberAttribute.class, "452-38-7291");
+Map<String, String> personAttributes = new HashMap<>();
+personAttributes.put("FirstName", "Elena");
+personAttributes.put("LastName", "Vasquez");
+personAttributes.put("BirthDate", "1992-07-14");
+personAttributes.put("Sex", "Female");
+personAttributes.put("PostalCode", "30301");
+personAttributes.put("SocialSecurityNumber", "452-38-7291");
 
-TokenGeneratorResult result = tokenGenerator.getAllTokens(personAttributes);
+TokenGeneratorResult result = tokenGenerator.getAllTokensViaFieldId(personAttributes);
 result.getTokens().forEach((ruleId, token) -> System.out.println(ruleId + ": " + token));
 ```
+
+> Field IDs (e.g. `"FirstName"`, `"LastName"`) are resolved to attribute behavior through `FieldRegistry`, which also supports registering multiple person fields under the same attribute type (e.g. `MotherLastName` and `FatherLastName`). See the [Java API Reference](java-api.md) for details.
 
 **Full reference:** [Java API Reference](java-api.md)
 
@@ -91,12 +86,6 @@ The Python API mirrors the Java API for cross-language parity.
 **Quick example:**
 
 ```python
-from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
-from openlinktoken.attributes.person.sex_attribute import SexAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
 from openlinktoken.tokens.tokenizer.sha256_tokenizer import SHA256Tokenizer
@@ -111,18 +100,20 @@ tokenizer = SHA256Tokenizer([
 token_generator = TokenGenerator(token_definition, tokenizer)
 
 person_attributes = {
-  FirstNameAttribute: "Elena",
-  LastNameAttribute: "Vasquez",
-  BirthDateAttribute: "1992-07-14",
-  SexAttribute: "Female",
-  PostalCodeAttribute: "30301",
-  SocialSecurityNumberAttribute: "452-38-7291",
+  "FirstName": "Elena",
+  "LastName": "Vasquez",
+  "BirthDate": "1992-07-14",
+  "Sex": "Female",
+  "PostalCode": "30301",
+  "SocialSecurityNumber": "452-38-7291",
 }
 
-result = token_generator.get_all_tokens(person_attributes)
+result = token_generator.get_all_tokens_via_field_id(person_attributes)
 for rule_id, token in result.tokens.items():
   print(f"{rule_id}: {token}")
 ```
+
+> Field IDs (e.g. `"FirstName"`, `"LastName"`) are resolved to attribute behavior through `FieldRegistry`, which also supports registering multiple person fields under the same attribute type (e.g. `MotherLastName` and `FatherLastName`). See the [Python API Reference](python-api.md) for details.
 
 **Full reference:** [Python API Reference](python-api.md)
 

--- a/pages/reference/java-api.md
+++ b/pages/reference/java-api.md
@@ -186,7 +186,7 @@ for (Map<String, String> personAttributes : persons) {
 <dependency>
     <groupId>org.openlinktoken</groupId>
     <artifactId>openlinktoken</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 

--- a/pages/reference/java-api.md
+++ b/pages/reference/java-api.md
@@ -13,13 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.openlinktoken.attributes.Attribute;
-import org.openlinktoken.attributes.person.BirthDateAttribute;
-import org.openlinktoken.attributes.person.FirstNameAttribute;
-import org.openlinktoken.attributes.person.LastNameAttribute;
-import org.openlinktoken.attributes.person.PostalCodeAttribute;
-import org.openlinktoken.attributes.person.SexAttribute;
-import org.openlinktoken.attributes.person.SocialSecurityNumberAttribute;
 import org.openlinktoken.tokens.TokenDefinition;
 import org.openlinktoken.tokens.TokenGenerator;
 import org.openlinktoken.tokens.TokenGeneratorResult;
@@ -31,19 +24,19 @@ import org.openlinktoken.tokentransformer.TokenTransformer;
 
 ## Person Attribute Map
 
-Open Link Token's Java library represents a person's values as a map keyed by attribute class:
+Open Link Token's Java library represents a person's values as a map keyed by field ID:
 
 ```java
-Map<Class<? extends Attribute>, String> personAttributes = new HashMap<>();
-personAttributes.put(FirstNameAttribute.class, "John");
-personAttributes.put(LastNameAttribute.class, "Doe");
-personAttributes.put(BirthDateAttribute.class, "1980-01-15");
-personAttributes.put(SexAttribute.class, "Male");
-personAttributes.put(PostalCodeAttribute.class, "98004");
-personAttributes.put(SocialSecurityNumberAttribute.class, "123-45-6789");
+Map<String, String> personAttributes = new HashMap<>();
+personAttributes.put("FirstName", "John");
+personAttributes.put("LastName", "Doe");
+personAttributes.put("BirthDate", "1980-01-15");
+personAttributes.put("Sex", "Male");
+personAttributes.put("PostalCode", "98004");
+personAttributes.put("SocialSecurityNumber", "123-45-6789");
 ```
 
-Normalization and validation are handled internally by `TokenGenerator` using the attribute implementations loaded via `AttributeLoader`.
+Field IDs like `"FirstName"` and `"LastName"` are resolved to attribute behavior (normalization and validation) through `FieldRegistry`. Built-in field IDs work out of the box via `FieldRegistry.createDefault()`, which `TokenGenerator` uses internally. To register custom field IDs — for example, when multiple person fields share the same underlying attribute type — see [FieldRegistry and Field IDs](token-registration.md#fieldregistry-and-field-ids).
 
 ## TokenDefinition
 
@@ -59,11 +52,10 @@ TokenDefinition tokenDefinition = new TokenDefinition();
 
 ### Methods
 
-| Method                                                                | Return Type            | Description                                                    |
-| --------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------- |
-| `getAllTokenSignatures(Map<Class<? extends Attribute>, String>)`      | `Map<String, String>`  | Generates signatures for all rules (debug/logging)             |
-| `getAllTokens(Map<Class<? extends Attribute>, String>)`               | `TokenGeneratorResult` | Generates tokens for all rules and captures invalid/blank info |
-| `getInvalidPersonAttributes(Map<Class<? extends Attribute>, String>)` | `Set<String>`          | Validates all provided attribute values                        |
+| Method                                                 | Return Type            | Description                                                                               |
+| ------------------------------------------------------ | ---------------------- | ----------------------------------------------------------------------------------------- |
+| `getAllTokenSignaturesViaFieldId(Map<String, String>)` | `Map<String, String>`  | Generates signatures for all rules using a field-ID-keyed map (debug/logging)             |
+| `getAllTokensViaFieldId(Map<String, String>)`          | `TokenGeneratorResult` | Generates tokens for all rules using a field-ID-keyed map and captures invalid/blank info |
 
 ### Example
 
@@ -78,12 +70,7 @@ TokenGenerator generator = new TokenGenerator(
     new SHA256Tokenizer(transformers)
 );
 
-var invalid = generator.getInvalidPersonAttributes(personAttributes);
-if (!invalid.isEmpty()) {
-    System.out.println("Invalid attributes: " + invalid);
-}
-
-TokenGeneratorResult result = generator.getAllTokens(personAttributes);
+TokenGeneratorResult result = generator.getAllTokensViaFieldId(personAttributes);
 result.getTokens().forEach((ruleId, token) -> System.out.println(ruleId + ": " + token));
 ```
 
@@ -124,13 +111,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.openlinktoken.attributes.Attribute;
-import org.openlinktoken.attributes.person.BirthDateAttribute;
-import org.openlinktoken.attributes.person.FirstNameAttribute;
-import org.openlinktoken.attributes.person.LastNameAttribute;
-import org.openlinktoken.attributes.person.PostalCodeAttribute;
-import org.openlinktoken.attributes.person.SexAttribute;
-import org.openlinktoken.attributes.person.SocialSecurityNumberAttribute;
 import org.openlinktoken.tokens.TokenDefinition;
 import org.openlinktoken.tokens.TokenGenerator;
 import org.openlinktoken.tokens.TokenGeneratorResult;
@@ -143,13 +123,13 @@ public class TokenGenerator {
     public static void main(String[] args) {
         String recordId = "patient_001";
 
-        Map<Class<? extends Attribute>, String> personAttributes = new HashMap<>();
-        personAttributes.put(FirstNameAttribute.class, "John");
-        personAttributes.put(LastNameAttribute.class, "Doe");
-        personAttributes.put(BirthDateAttribute.class, "1980-01-15");
-        personAttributes.put(SexAttribute.class, "Male");
-        personAttributes.put(PostalCodeAttribute.class, "98004");
-        personAttributes.put(SocialSecurityNumberAttribute.class, "123-45-6789");
+        Map<String, String> personAttributes = new HashMap<>();
+        personAttributes.put("FirstName", "John");
+        personAttributes.put("LastName", "Doe");
+        personAttributes.put("BirthDate", "1980-01-15");
+        personAttributes.put("Sex", "Male");
+        personAttributes.put("PostalCode", "98004");
+        personAttributes.put("SocialSecurityNumber", "123-45-6789");
 
         List<TokenTransformer> transformers = List.of(
             new HashTokenTransformer("HashingSecret"),
@@ -161,13 +141,7 @@ public class TokenGenerator {
             new SHA256Tokenizer(transformers)
         );
 
-        var invalid = generator.getInvalidPersonAttributes(personAttributes);
-        if (!invalid.isEmpty()) {
-            System.err.println("Invalid attributes: " + invalid);
-            return;
-        }
-
-        TokenGeneratorResult result = generator.getAllTokens(personAttributes);
+        TokenGeneratorResult result = generator.getAllTokensViaFieldId(personAttributes);
         result.getTokens().forEach((ruleId, token) ->
             System.out.printf("%s,%s,%s%n", recordId, ruleId, token)
         );
@@ -179,15 +153,15 @@ public class TokenGenerator {
 
 The Java library focuses on in-memory token generation. It does not include CSV, Parquet, or other file I/O helper classes.
 
-Use your application's reader or writer layer to map each record into `Map<Class<? extends Attribute>, String>`, then pass that map to `TokenGenerator`.
+Use your application's reader or writer layer to map each record into `Map<String, String>` keyed by field ID, then pass that map to `TokenGenerator`.
 
 ```java
-Map<Class<? extends Attribute>, String> personAttributes = new HashMap<>();
-personAttributes.put(FirstNameAttribute.class, row.get("FirstName"));
-personAttributes.put(LastNameAttribute.class, row.get("LastName"));
-// ...populate the remaining attributes needed for your token rules
+Map<String, String> personAttributes = new HashMap<>();
+personAttributes.put("FirstName", row.get("FirstName"));
+personAttributes.put("LastName", row.get("LastName"));
+// ...populate the remaining fields needed for your token rules
 
-TokenGeneratorResult result = generator.getAllTokens(personAttributes);
+TokenGeneratorResult result = generator.getAllTokensViaFieldId(personAttributes);
 ```
 
 ## Thread Safety
@@ -198,9 +172,9 @@ All transformer classes are thread-safe and can be shared across threads:
 // Token generation is safe to parallelize across independent records.
 // For best clarity, create the per-record attribute map inside the task.
 ExecutorService executor = Executors.newFixedThreadPool(4);
-for (Map<Class<? extends Attribute>, String> personAttributes : persons) {
+for (Map<String, String> personAttributes : persons) {
     executor.submit(() -> {
-        TokenGeneratorResult result = generator.getAllTokens(personAttributes);
+        TokenGeneratorResult result = generator.getAllTokensViaFieldId(personAttributes);
         // ...
     });
 }

--- a/pages/reference/metadata-format.md
+++ b/pages/reference/metadata-format.md
@@ -126,7 +126,7 @@ Extension: .metadata.json
 {
   "Platform": "Java",
   "JavaVersion": "21.0.0",
-  "Version": "2.0.0",
+  "Version": "2.1.0",
   "TotalRows": 101,
   "TotalRowsWithInvalidAttributes": 9,
   "InvalidAttributesByType": {
@@ -154,7 +154,7 @@ Extension: .metadata.json
 {
   "Platform": "Python",
   "PythonVersion": "3.11.5",
-  "Version": "2.0.0",
+  "Version": "2.1.0",
   "TotalRows": 50,
   "TotalRowsWithInvalidAttributes": 2,
   "InvalidAttributesByType": {

--- a/pages/reference/python-api.md
+++ b/pages/reference/python-api.md
@@ -9,12 +9,6 @@ Document the Python modules and functions for programmatic token generation.
 ## Core Modules
 
 ```python
-from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
-from openlinktoken.attributes.person.sex_attribute import SexAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
 from openlinktoken.tokens.tokenizer.sha256_tokenizer import SHA256Tokenizer
@@ -24,20 +18,20 @@ from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTrans
 
 ## Person Attribute Dict
 
-Open Link Token's Python library represents a person's values as a dict keyed by attribute class:
+Open Link Token's Python library represents a person's values as a dict keyed by field ID:
 
 ```python
 person_attributes = {
-    FirstNameAttribute: "John",
-    LastNameAttribute: "Doe",
-    BirthDateAttribute: "1980-01-15",
-    SexAttribute: "Male",
-    PostalCodeAttribute: "98004",
-    SocialSecurityNumberAttribute: "123-45-6789",
+    "FirstName": "John",
+    "LastName": "Doe",
+    "BirthDate": "1980-01-15",
+    "Sex": "Male",
+    "PostalCode": "98004",
+    "SocialSecurityNumber": "123-45-6789",
 }
 ```
 
-Normalization and validation are handled internally by `TokenGenerator` using the attribute implementations loaded via `AttributeLoader`.
+Field IDs like `"FirstName"` and `"LastName"` are resolved to attribute behavior (normalization and validation) through `FieldRegistry`. Built-in field IDs work out of the box via `FieldRegistry.create_default()`, which `TokenGenerator` uses internally. To register custom field IDs — for example, when multiple person fields share the same underlying attribute type — see [FieldRegistry and Field IDs](token-registration.md#fieldregistry-and-field-ids-1).
 
 ## TokenDefinition
 
@@ -53,11 +47,10 @@ token_definition = TokenDefinition()
 
 ### Methods
 
-| Method                                             | Return Type            | Description                                                    |
-| -------------------------------------------------- | ---------------------- | -------------------------------------------------------------- |
-| `get_all_token_signatures(person_attributes)`      | `Dict[str, str]`       | Generates signatures for all rules (debug/logging)             |
-| `get_all_tokens(person_attributes)`                | `TokenGeneratorResult` | Generates tokens for all rules and captures invalid/blank info |
-| `get_invalid_person_attributes(person_attributes)` | `Set[str]`             | Validates all provided attribute values                        |
+| Method                                                     | Return Type            | Description                                                                                |
+| ---------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| `get_all_token_signatures_via_field_id(person_attributes)` | `Dict[str, str]`       | Generates signatures for all rules using a field-ID-keyed dict (debug/logging)             |
+| `get_all_tokens_via_field_id(person_attributes)`           | `TokenGeneratorResult` | Generates tokens for all rules using a field-ID-keyed dict and captures invalid/blank info |
 
 ### Example
 
@@ -69,11 +62,7 @@ tokenizer = SHA256Tokenizer([
 
 generator = TokenGenerator(TokenDefinition(), tokenizer)
 
-invalid = generator.get_invalid_person_attributes(person_attributes)
-if invalid:
-    print(f"Invalid attributes: {sorted(invalid)}")
-
-result = generator.get_all_tokens(person_attributes)
+result = generator.get_all_tokens_via_field_id(person_attributes)
 for rule_id, token in result.tokens.items():
     print(f"{rule_id}: {token}")
 ```
@@ -111,12 +100,6 @@ encrypted_token = encryptor.transform(signature)
 ## Complete Example
 
 ```python
-from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
-from openlinktoken.attributes.person.sex_attribute import SexAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
 from openlinktoken.tokens.tokenizer.sha256_tokenizer import SHA256Tokenizer
@@ -127,12 +110,12 @@ def generate_tokens():
     record_id = "patient_001"
 
     person_attributes = {
-        FirstNameAttribute: "John",
-        LastNameAttribute: "Doe",
-        BirthDateAttribute: "1980-01-15",
-        SexAttribute: "Male",
-        PostalCodeAttribute: "98004",
-        SocialSecurityNumberAttribute: "123-45-6789",
+        "FirstName": "John",
+        "LastName": "Doe",
+        "BirthDate": "1980-01-15",
+        "Sex": "Male",
+        "PostalCode": "98004",
+        "SocialSecurityNumber": "123-45-6789",
     }
 
     tokenizer = SHA256Tokenizer([
@@ -141,12 +124,7 @@ def generate_tokens():
     ])
     generator = TokenGenerator(TokenDefinition(), tokenizer)
 
-    invalid = generator.get_invalid_person_attributes(person_attributes)
-    if invalid:
-        print(f"Invalid attributes: {sorted(invalid)}")
-        return
-
-    result = generator.get_all_tokens(person_attributes)
+    result = generator.get_all_tokens_via_field_id(person_attributes)
     for rule_id, token in result.tokens.items():
         print(f"{record_id},{rule_id},{token}")
 
@@ -160,12 +138,6 @@ For processing multiple records:
 
 ```python
 import csv
-from openlinktoken.attributes.person.birth_date_attribute import BirthDateAttribute
-from openlinktoken.attributes.person.first_name_attribute import FirstNameAttribute
-from openlinktoken.attributes.person.last_name_attribute import LastNameAttribute
-from openlinktoken.attributes.person.postal_code_attribute import PostalCodeAttribute
-from openlinktoken.attributes.person.sex_attribute import SexAttribute
-from openlinktoken.attributes.person.social_security_number_attribute import SocialSecurityNumberAttribute
 from openlinktoken.tokens.token_definition import TokenDefinition
 from openlinktoken.tokens.token_generator import TokenGenerator
 from openlinktoken.tokens.tokenizer.sha256_tokenizer import SHA256Tokenizer
@@ -188,19 +160,15 @@ def process_csv(input_path, output_path, hashing_secret, encryption_key):
             record_id = row.get('RecordId', '')
 
             person_attributes = {
-                FirstNameAttribute: row.get('FirstName', ''),
-                LastNameAttribute: row.get('LastName', ''),
-                BirthDateAttribute: row.get('BirthDate', ''),
-                SexAttribute: row.get('Sex', ''),
-                PostalCodeAttribute: row.get('PostalCode', ''),
-                SocialSecurityNumberAttribute: row.get('SSN', ''),
+                "FirstName": row.get('FirstName', ''),
+                "LastName": row.get('LastName', ''),
+                "BirthDate": row.get('BirthDate', ''),
+                "Sex": row.get('Sex', ''),
+                "PostalCode": row.get('PostalCode', ''),
+                "SocialSecurityNumber": row.get('SSN', ''),
             }
 
-            invalid = generator.get_invalid_person_attributes(person_attributes)
-            if invalid:
-                continue
-
-            result = generator.get_all_tokens(person_attributes)
+            result = generator.get_all_tokens_via_field_id(person_attributes)
             for rule_id, token in result.tokens.items():
                 writer.writerow([record_id, rule_id, token])
 ```
@@ -243,12 +211,12 @@ Open Link Token guarantees identical output between Java and Python:
 ```python
 # This Python code produces the exact same tokens as equivalent Java code
 person_attributes = {
-    FirstNameAttribute: "John",
-    LastNameAttribute: "Doe",
-    BirthDateAttribute: "1980-01-15",
-    SexAttribute: "Male",
-    PostalCodeAttribute: "98004",
-    SocialSecurityNumberAttribute: "123-45-6789",
+    "FirstName": "John",
+    "LastName": "Doe",
+    "BirthDate": "1980-01-15",
+    "Sex": "Male",
+    "PostalCode": "98004",
+    "SocialSecurityNumber": "123-45-6789",
 }
 ```
 
@@ -270,17 +238,17 @@ try:
     generator = TokenGenerator(TokenDefinition(), tokenizer)
 
     person_attributes = {
-        FirstNameAttribute: "",  # Empty - will be invalid
-        LastNameAttribute: "Doe",
-        BirthDateAttribute: "invalid-date",  # Bad format
-        SexAttribute: "Unknown",  # Not Male/Female
-        PostalCodeAttribute: "98004",
-        SocialSecurityNumberAttribute: "123-45-6789",
+        "FirstName": "",  # Empty - will be invalid
+        "LastName": "Doe",
+        "BirthDate": "invalid-date",  # Bad format
+        "Sex": "Unknown",  # Not Male/Female
+        "PostalCode": "98004",
+        "SocialSecurityNumber": "123-45-6789",
     }
 
-    invalid = generator.get_invalid_person_attributes(person_attributes)
-    if invalid:
-        raise ValueError(f"Invalid attributes: {sorted(invalid)}")
+    result = generator.get_all_tokens_via_field_id(person_attributes)
+    if result.invalid_attributes:
+        raise ValueError(f"Invalid attributes: {sorted(result.invalid_attributes)}")
 
 except ValueError as e:
     print(f"Validation error: {e}")

--- a/pages/reference/token-registration.md
+++ b/pages/reference/token-registration.md
@@ -112,10 +112,10 @@ public class T6Token implements Token {
     private final ArrayList<AttributeExpression> definition = new ArrayList<>();
 
     public T6Token() {
-        definition.add(new AttributeExpression(LastNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(FirstNameAttribute.class, "T|U"));
-        definition.add(new AttributeExpression(BirthDateAttribute.class, "T|D"));
-        definition.add(new AttributeExpression(PostalCodeAttribute.class, "T|S(0,3)"));
+        definition.add(new AttributeExpression("LastName", LastNameAttribute.class, "T|U"));
+        definition.add(new AttributeExpression("FirstName", FirstNameAttribute.class, "T|U"));
+        definition.add(new AttributeExpression("BirthDate", BirthDateAttribute.class, "T|D"));
+        definition.add(new AttributeExpression("PostalCode", PostalCodeAttribute.class, "T|S(0,3)"));
     }
 
     @Override
@@ -130,6 +130,8 @@ public class T6Token implements Token {
 }
 ```
 
+Each `AttributeExpression` takes the field ID (`"LastName"`, `"FirstName"`, etc.) as its first argument — the string key used to look up the value in the person-attributes map at token generation time. For built-in attributes, use the attribute's canonical name as the field ID so it resolves automatically; see [FieldRegistry and Field IDs](#fieldregistry-and-field-ids) below.
+
 2. **Register in service file** at [lib/java/openlinktoken/src/main/resources/META-INF/services/org.openlinktoken.tokens.Token](https://github.com/TruvetaPublic/OpenLinkToken/blob/main/lib/java/openlinktoken/src/main/resources/META-INF/services/org.openlinktoken.tokens.Token):
 
 ```
@@ -140,6 +142,40 @@ org.openlinktoken.tokens.definitions.T4Token
 org.openlinktoken.tokens.definitions.T5Token
 org.openlinktoken.tokens.definitions.T6Token
 ```
+
+### FieldRegistry and Field IDs
+
+`FieldRegistry` is the resolution layer that maps a field ID string (the key used in the person-attributes map) to the `Attribute` instance that provides normalization and validation for it.
+
+- `FieldRegistry.createDefault()` auto-populates a registry using every built-in attribute's canonical name (`Attribute.getName()`) as its field ID — this is why field IDs like `"LastName"`, `"FirstName"`, `"Sex"`, `"BirthDate"`, `"PostalCode"`, and `"SocialSecurityNumber"` work with no extra registration.
+- `TokenGenerator(tokenDefinition, tokenizer)` uses `FieldRegistry.createDefault()` internally, so no setup is required for built-in fields.
+- For custom fields — for example, a token that needs both `MotherLastName` and `FatherLastName` — use `FieldRegistry.Builder` to register additional field IDs, then pass the registry explicitly to `TokenGenerator`:
+
+```java
+import org.openlinktoken.attributes.FieldRegistry;
+import org.openlinktoken.attributes.general.StringAttribute;
+import org.openlinktoken.tokens.TokenGenerator;
+
+var stringAttribute = new StringAttribute();
+
+FieldRegistry fieldRegistry = FieldRegistry.Builder.fromDefaults()
+    .register("MotherLastName", StringAttribute.class, stringAttribute)
+    .register("FatherLastName", StringAttribute.class, stringAttribute)
+    .build();
+
+TokenGenerator generator = new TokenGenerator(new TokenDefinition(), new SHA256Tokenizer(transformers), fieldRegistry);
+```
+
+Then reference the new field IDs in a token definition, both backed by the same `StringAttribute` class:
+
+```java
+definition.add(new AttributeExpression("MotherLastName", StringAttribute.class, "T|U"));
+definition.add(new AttributeExpression("FatherLastName", StringAttribute.class, "T|U"));
+```
+
+Because entries are looked up by field ID string, `"MotherLastName"` and `"FatherLastName"` stay distinct even though both resolve to `StringAttribute` behavior — any number of fields can share the same attribute class this way.
+
+To generate tokens with a custom `FieldRegistry`, use `getAllTokensViaFieldId(Map<String, String>)` and `getAllTokenSignaturesViaFieldId(Map<String, String>)` on `TokenGenerator`, passing a person-attributes map keyed by field ID string. See [Java API Reference](java-api.md) for full method signatures.
 
 ## Python Registration (Explicit Imports)
 
@@ -227,10 +263,10 @@ class T6Token(Token):
 
     def __init__(self):
         self._definition = [
-            AttributeExpression(LastNameAttribute, "T|U"),
-            AttributeExpression(FirstNameAttribute, "T|U"),
-            AttributeExpression(BirthDateAttribute, "T|D"),
-            AttributeExpression(PostalCodeAttribute, "T|S(0,3)"),
+            AttributeExpression(LastNameAttribute, "T|U", field_id="LastName"),
+            AttributeExpression(FirstNameAttribute, "T|U", field_id="FirstName"),
+            AttributeExpression(BirthDateAttribute, "T|D", field_id="BirthDate"),
+            AttributeExpression(PostalCodeAttribute, "T|S(0,3)", field_id="PostalCode"),
         ]
 
     def get_identifier(self) -> str:
@@ -240,9 +276,49 @@ class T6Token(Token):
         return self._definition
 ```
 
+Each `AttributeExpression` takes `field_id` — the string key used to look up the value in the person-attributes dict at token generation time. For built-in attributes, use the attribute's canonical name as the field ID so it resolves automatically; see [FieldRegistry and Field IDs](#fieldregistry-and-field-ids-1) below.
+
 2. **No registry edit needed for tokens**:
 
 The Python `TokenRegistry.load_all_tokens()` implementation discovers `Token` subclasses by scanning modules in `openlinktoken.tokens.definitions`. As long as your new token lives under that package (for example `t6_token.py`), it will be picked up automatically.
+
+### FieldRegistry and Field IDs
+
+`FieldRegistry` is the resolution layer that maps a field ID string (the key used in the person-attributes dict) to the `Attribute` instance that provides normalization and validation for it.
+
+- `FieldRegistry.create_default()` auto-populates a registry using every built-in attribute's canonical name (`get_name()`) as its field ID — this is why field IDs like `"LastName"`, `"FirstName"`, `"Sex"`, `"BirthDate"`, `"PostalCode"`, and `"SocialSecurityNumber"` work with no extra registration.
+- `TokenGenerator(token_definition, tokenizer)` defaults to `FieldRegistry.create_default()` internally (via the optional `field_registry=` keyword argument), so no setup is required for built-in fields.
+- For custom fields — for example, a token that needs both `MotherLastName` and `FatherLastName` — use `FieldRegistry.Builder` to register additional field IDs, then pass the registry explicitly to `TokenGenerator`:
+
+```python
+from openlinktoken.attributes.field_registry import FieldRegistry
+from openlinktoken.attributes.general.string_attribute import StringAttribute
+from openlinktoken.tokens.token_generator import TokenGenerator
+
+string_attribute = StringAttribute()
+
+field_registry = (
+    FieldRegistry.Builder.from_defaults()
+    .register("MotherLastName", StringAttribute, string_attribute)
+    .register("FatherLastName", StringAttribute, string_attribute)
+    .build()
+)
+
+generator = TokenGenerator(TokenDefinition(), tokenizer, field_registry=field_registry)
+```
+
+Then reference the new field IDs in a token definition, both backed by the same `StringAttribute` class:
+
+```python
+AttributeExpression(StringAttribute, "T|U", field_id="MotherLastName"),
+AttributeExpression(StringAttribute, "T|U", field_id="FatherLastName"),
+```
+
+Because entries are looked up by field ID string, `"MotherLastName"` and `"FatherLastName"` stay distinct even though both resolve to `StringAttribute` behavior — any number of fields can share the same attribute class this way.
+
+To generate tokens with a custom `FieldRegistry`, use `get_all_tokens_via_field_id(person_attributes)` and `get_all_token_signatures_via_field_id(person_attributes)` on `TokenGenerator`, passing a person-attributes dict keyed by field ID string. See [Python API Reference](python-api.md) for full method signatures.
+
+> **Note:** The `openlinktoken_pyspark` bridge package (`TokenBuilder`, `CustomTokenDefinition`) uses the class-keyed API and continues to work unchanged.
 
 ## Cross-Language Sync Verification
 

--- a/pages/reference/tokenization-config.md
+++ b/pages/reference/tokenization-config.md
@@ -32,27 +32,27 @@ A-1002,Marcus,Nguyen,1979-11-05,M,10001,234-56-7890
 ## Example Configuration File
 
 ```yaml
-attributes:
-  member_id:
-    field: RecordId
+column_mappings:
+  RecordId:
+    column_name: "member_id"
     type: RecordId
-  given_nm:
-    field: GivenName
+  GivenName:
+    column_name: "given nm"
     type: FirstName
-  surname_txt:
-    field: FamilyName
+  FamilyName:
+    column_name: "surname_txt"
     type: LastName
-  dob_iso:
-    field: DateOfBirth
+  DateOfBirth:
+    column_name: "dob_iso"
     type: BirthDate
-  gender_code:
-    field: SexAtBirth
+  SexAtBirth:
+    column_name: "gender_code"
     type: Sex
-  zip_5:
-    field: HomeZip
+  HomeZip:
+    column_name: "zip_5"
     type: PostalCode
-  national_id:
-    field: NationalId
+  NationalId:
+    column_name: "national_id"
     type: SocialSecurityNumber
 
 token_rules:
@@ -71,35 +71,35 @@ token_rules:
 
 Top-level keys:
 
-| Key           | Required | Type    | Description                                                                  |
-| ------------- | -------- | ------- | ---------------------------------------------------------------------------- |
-| `attributes`  | Yes      | Mapping | Maps input column names to logical field IDs and attribute types.            |
-| `token_rules` | Yes      | Mapping | Defines each token rule as an ordered list of `{field, expression}` entries. |
+| Key               | Required | Type    | Description                                                                  |
+| ----------------- | -------- | ------- | ---------------------------------------------------------------------------- |
+| `column_mappings` | Yes      | Mapping | Maps logical field IDs to source column names and attribute types.           |
+| `token_rules`     | Yes      | Mapping | Defines each token rule as an ordered list of `{field, expression}` entries. |
 
-`attributes` entry schema:
+`column_mappings` entry schema:
 
-| Field           | Required | Type    | Description                                                                                                                                                                                                                                         |
-| --------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<column_name>` | Yes      | Mapping | Input column name from the CSV or Parquet schema (for example `given_nm`).                                                                                                                                                                          |
-| `field`         | Yes      | String  | Logical field identifier used by token rules (for example `GivenName`).                                                                                                                                                                             |
-| `type`          | Yes      | String  | Open Link Token attribute type/alias. See [Attribute Types](#attribute-types) for all accepted values. Each type applies its own normalization and validation rules — see [Normalization and Validation](../concepts/normalization-and-validation). |
+| Field         | Required | Type    | Description                                                                                                                                                                                                                                   |
+| ------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<field_id>`  | Yes      | Mapping | Logical field identifier used by token rules (for example `GivenName`).                                                                                                                                                                       |
+| `column_name` | Yes      | String  | Source column name in the CSV or Parquet file (for example `"given_nm"`).                                                                                                                                                                     |
+| `type`        | Yes      | String  | Open Link Token attribute type. See [Attribute Types](#attribute-types) for all accepted values. Each type applies its own normalization and validation rules — see [Normalization and Validation](../concepts/normalization-and-validation). |
 
 `token_rules` entry schema:
 
 | Field        | Required | Type   | Description                                                                                                                 |
 | ------------ | -------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `<rule_id>`  | Yes      | List   | Token rule identifier (`T1`, `T2`, `T3`, `T4`, `T5`, or custom).                                                            |
-| `field`      | Yes      | String | Must match one of the `attributes.*.field` values.                                                                          |
+| `field`      | Yes      | String | Must match one of the `column_mappings` field IDs.                                                                          |
 | `expression` | Yes      | String | Attribute-expression pipeline used by token generation. See [Expression Syntax](../concepts/token-rules#expression-syntax). |
 
 ## Validation Rules
 
 Validation enforced by the CLI:
 
-- `attributes` must be present and non-empty.
+- `column_mappings` must be present and non-empty.
 - `token_rules` must be present and non-empty.
 - Every token-rule entry must contain non-empty `field` and `expression`.
-- Every token-rule `field` must reference a declared `attributes.*.field` value.
+- Every token-rule `field` must reference a declared `column_mappings` field ID.
 - Every declared `type` must resolve to a known Open Link Token attribute class/alias.
 - Token-rule entry order is preserved and used as-is during token construction.
 

--- a/pages/reference/tokenization-config.md
+++ b/pages/reference/tokenization-config.md
@@ -1,0 +1,133 @@
+---
+layout: default
+---
+
+# Tokenization Configuration Reference
+
+Complete reference for `tokenize --config`: field mapping, token-rule definitions, examples, and validation behavior.
+
+## Overview
+
+`tokenize --config` lets you map non-standard input column names to Open Link Token attribute types and define token rules explicitly.
+
+Use this when source data does not use built-in aliases (for example `given_nm` instead of `FirstName`) or when custom token rules are required.
+
+## Example Command
+
+```bash
+olt tokenize \
+  -i unusual-input.csv -o output.csv \
+  --exchange-config ./partner.exchange.json \
+  --config ./tokenization-config.yaml
+```
+
+## Example Input (Unusual Fields)
+
+```csv
+member_id,given_nm,surname_txt,dob_iso,gender_code,zip_5,national_id
+A-1001,Ana,Lopez,1988-03-12,F,98052,123-45-6789
+A-1002,Marcus,Nguyen,1979-11-05,M,10001,234-56-7890
+```
+
+## Example Configuration File
+
+```yaml
+attributes:
+  member_id:
+    field: RecordId
+    type: RecordId
+  given_nm:
+    field: GivenName
+    type: FirstName
+  surname_txt:
+    field: FamilyName
+    type: LastName
+  dob_iso:
+    field: DateOfBirth
+    type: BirthDate
+  gender_code:
+    field: SexAtBirth
+    type: Sex
+  zip_5:
+    field: HomeZip
+    type: PostalCode
+  national_id:
+    field: NationalId
+    type: SocialSecurityNumber
+
+token_rules:
+  T1:
+    - field: FamilyName
+      expression: T|U
+    - field: GivenName
+      expression: T|S(0,1)|U
+    - field: DateOfBirth
+      expression: T|D
+    - field: SexAtBirth
+      expression: T|S(0,1)|U
+```
+
+## File Specification
+
+Top-level keys:
+
+| Key           | Required | Type    | Description                                                                  |
+| ------------- | -------- | ------- | ---------------------------------------------------------------------------- |
+| `attributes`  | Yes      | Mapping | Maps input column names to logical field IDs and attribute types.            |
+| `token_rules` | Yes      | Mapping | Defines each token rule as an ordered list of `{field, expression}` entries. |
+
+`attributes` entry schema:
+
+| Field           | Required | Type    | Description                                                                                                                                                                                                                                         |
+| --------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<column_name>` | Yes      | Mapping | Input column name from the CSV or Parquet schema (for example `given_nm`).                                                                                                                                                                          |
+| `field`         | Yes      | String  | Logical field identifier used by token rules (for example `GivenName`).                                                                                                                                                                             |
+| `type`          | Yes      | String  | Open Link Token attribute type/alias. See [Attribute Types](#attribute-types) for all accepted values. Each type applies its own normalization and validation rules — see [Normalization and Validation](../concepts/normalization-and-validation). |
+
+`token_rules` entry schema:
+
+| Field        | Required | Type   | Description                                                                                                                 |
+| ------------ | -------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `<rule_id>`  | Yes      | List   | Token rule identifier (`T1`, `T2`, `T3`, `T4`, `T5`, or custom).                                                            |
+| `field`      | Yes      | String | Must match one of the `attributes.*.field` values.                                                                          |
+| `expression` | Yes      | String | Attribute-expression pipeline used by token generation. See [Expression Syntax](../concepts/token-rules#expression-syntax). |
+
+## Validation Rules
+
+Validation enforced by the CLI:
+
+- `attributes` must be present and non-empty.
+- `token_rules` must be present and non-empty.
+- Every token-rule entry must contain non-empty `field` and `expression`.
+- Every token-rule `field` must reference a declared `attributes.*.field` value.
+- Every declared `type` must resolve to a known Open Link Token attribute class/alias.
+- Token-rule entry order is preserved and used as-is during token construction.
+
+## Expression Syntax
+
+See [Expression Syntax](../concepts/token-rules#expression-syntax) in the Token Rules concept page.
+
+## Notes
+
+- `--config` works with `tokenize` for both CSV and Parquet input.
+- Built-in aliases continue to work when `--config` is omitted.
+
+## Attribute Types
+
+Accepted values for the field `type`. Each type applies its own normalization and validation rules — see [Normalization and Validation](../concepts/normalization-and-validation). |
+
+| `type` value           | Description                    |
+| ---------------------- | ------------------------------ |
+| `Age`                  | Age (numeric)                  |
+| `BirthDate`            | Date of birth                  |
+| `BirthYear`            | Year of birth                  |
+| `Date`                 | Generic date                   |
+| `Decimal`              | Decimal number                 |
+| `FirstName`            | Given / first name             |
+| `Integer`              | Integer number                 |
+| `LastName`             | Family / last name             |
+| `PostalCode`           | Postal or ZIP code             |
+| `Sex`                  | Biological sex                 |
+| `SocialSecurityNumber` | National identification number |
+| `String`               | Generic string                 |
+| `Year`                 | Generic year                   |

--- a/pages/running-openlinktoken/index.md
+++ b/pages/running-openlinktoken/index.md
@@ -134,7 +134,7 @@ record1,T2,pUxPgYL9+cMxkA+8928Pil+9W+dm9kISwHYPdkZS+I2nQ/bQ/8HyL3FOVf3NYPW5NKZZO
 ```json
 {
   "JavaVersion": "21.0.0",
-  "Version": "2.0.0",
+  "Version": "2.1.0",
   "Platform": "Java",
   "TotalRows": 1,
   "TotalRowsWithInvalidAttributes": 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = [
    "cryptography==49.0.0",
    "jwcrypto==1.5.7",
    "csv2parquet==0.0.9",
-   "pytest==9.0.3",
+   "pytest==9.1.1",
    "pytest-cov==7.1.0",
    "ruff==0.15.20",
    "pycryptodome==3.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
    "csv2parquet==0.0.9",
    "pytest==9.0.3",
    "pytest-cov==7.1.0",
-   "ruff==0.15.17",
+   "ruff==0.15.20",
    "pycryptodome==3.23.0",
    "jupyter==1.1.1",
    "notebook==7.5.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ openlinktoken = { workspace = true }
 
 [dependency-groups]
 dev = [
-   "cryptography==48.0.1",
+   "cryptography==49.0.0",
    "jwcrypto==1.5.7",
    "csv2parquet==0.0.9",
    "pytest==9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
    "csv2parquet==0.0.9",
    "pytest==9.1.1",
    "pytest-cov==7.1.0",
-   "ruff==0.15.20",
+   "ruff==0.15.21",
    "pycryptodome==3.23.0",
    "jupyter==1.1.1",
    "notebook==7.5.7",

--- a/resources/output.metadata.json
+++ b/resources/output.metadata.json
@@ -1,7 +1,7 @@
 {
   "PythonVersion": "3.11.2",
   "Platform": "Python",
-  "Version": "2.0.0",
+  "Version": "2.1.0",
   "HashingSecretHash": "26ce1637d4a1e514cbf90ce0d73d7ea257342009083ab6f6e06cb434fb3a9d99",
   "EncryptionSecretHash": "05f0825275cb54bdf4cde58ef6875d24acb75f84ec0187a26d45d626f57f189b",
   "TotalRows": 105,

--- a/resources/sample-custom-tokenization-config-nonstandard.yaml
+++ b/resources/sample-custom-tokenization-config-nonstandard.yaml
@@ -1,0 +1,53 @@
+attributes:
+  encounter_id:
+    field: RecordId
+    type: RecordId
+  birth_year:
+    field: BirthYear
+    type: LastName
+  age_at_encounter:
+    field: AgeAtEncounter
+    type: PostalCode
+  encounter_date:
+    field: EncounterDate
+    type: BirthDate
+  encounter_type:
+    field: EncounterType
+    type: FirstName
+  patient_gender:
+    field: Gender
+    type: Sex
+  ssn:
+    field: PatientSSN
+    type: SocialSecurityNumber
+
+token_rules:
+  T_ALL_BASE:
+    - field: BirthYear
+      expression: "T"
+    - field: EncounterType
+      expression: "T|U"
+    - field: EncounterDate
+      expression: "T|D"
+    - field: Gender
+      expression: "T|S(0,1)|U"
+    - field: AgeAtEncounter
+      expression: "T"
+    - field: PatientSSN
+      expression: "T|M(\\d+)"
+  T_INITIALS_PLUS_AGE:
+    - field: BirthYear
+      expression: "T"
+    - field: EncounterType
+      expression: "T|S(0,2)|U"
+    - field: EncounterDate
+      expression: "T|D"
+    - field: AgeAtEncounter
+      expression: "T"
+  T_IDENTITY_LIGHT:
+    - field: EncounterType
+      expression: "T|S(0,2)|U"
+    - field: EncounterDate
+      expression: "T|D"
+    - field: Gender
+      expression: "T|U"

--- a/resources/sample-custom-tokenization-config-nonstandard.yaml
+++ b/resources/sample-custom-tokenization-config-nonstandard.yaml
@@ -1,24 +1,24 @@
-attributes:
-  encounter_id:
-    field: RecordId
+column_mappings:
+  RecordId:
+    column_name: "encounter_id"
     type: RecordId
-  birth_year:
-    field: BirthYear
-    type: LastName
-  age_at_encounter:
-    field: AgeAtEncounter
-    type: PostalCode
-  encounter_date:
-    field: EncounterDate
+  BirthYear:
+    column_name: "birth_year"
+    type: BirthYear
+  AgeAtEncounter:
+    column_name: "age_at_encounter"
+    type: Age
+  EncounterDate:
+    column_name: "encounter_date"
     type: BirthDate
-  encounter_type:
-    field: EncounterType
+  EncounterType:
+    column_name: "encounter type"
     type: FirstName
-  patient_gender:
-    field: Gender
+  Gender:
+    column_name: "patient_gender"
     type: Sex
-  ssn:
-    field: PatientSSN
+  PatientSSN:
+    column_name: "ssn"
     type: SocialSecurityNumber
 
 token_rules:

--- a/resources/sample-custom-tokenization-config.yaml
+++ b/resources/sample-custom-tokenization-config.yaml
@@ -1,0 +1,65 @@
+attributes:
+  RecordId:
+    field: RecordId
+    type: RecordId
+  BirthDate:
+    field: BirthDate
+    type: BirthDate
+  FirstName:
+    field: FirstName
+    type: FirstName
+  LastName:
+    field: LastName
+    type: LastName
+  PostalCode:
+    field: PostalCode
+    type: PostalCode
+  Sex:
+    field: Sex
+    type: Sex
+  SocialSecurityNumber:
+    field: SocialSecurityNumber
+    type: SocialSecurityNumber
+
+token_rules:
+  T1:
+    - field: LastName
+      expression: "T|U"
+    - field: FirstName
+      expression: "T|S(0,1)|U"
+    - field: Sex
+      expression: "T|U"
+    - field: BirthDate
+      expression: "T|D"
+  T2:
+    - field: LastName
+      expression: "T|U"
+    - field: FirstName
+      expression: "T|U"
+    - field: BirthDate
+      expression: "T|D"
+    - field: PostalCode
+      expression: "T|S(0,3)|U"
+  T3:
+    - field: LastName
+      expression: "T|U"
+    - field: FirstName
+      expression: "T|U"
+    - field: Sex
+      expression: "T|U"
+    - field: BirthDate
+      expression: "T|D"
+  T4:
+    - field: SocialSecurityNumber
+      expression: "T|M(\\d+)"
+    - field: Sex
+      expression: "T|U"
+    - field: BirthDate
+      expression: "T|D"
+  T5:
+    - field: LastName
+      expression: "T|U"
+    - field: FirstName
+      expression: "T|S(0,3)|U"
+    - field: Sex
+      expression: "T|U"

--- a/resources/sample-custom-tokenization-config.yaml
+++ b/resources/sample-custom-tokenization-config.yaml
@@ -1,24 +1,24 @@
-attributes:
+column_mappings:
   RecordId:
-    field: RecordId
+    column_name: "RecordId"
     type: RecordId
   BirthDate:
-    field: BirthDate
+    column_name: "BirthDate"
     type: BirthDate
   FirstName:
-    field: FirstName
+    column_name: "FirstName"
     type: FirstName
   LastName:
-    field: LastName
+    column_name: "LastName"
     type: LastName
   PostalCode:
-    field: PostalCode
+    column_name: "PostalCode"
     type: PostalCode
   Sex:
-    field: Sex
+    column_name: "Sex"
     type: Sex
   SocialSecurityNumber:
-    field: SocialSecurityNumber
+    column_name: "SocialSecurityNumber"
     type: SocialSecurityNumber
 
 token_rules:

--- a/resources/sample-nonstandard-input.csv
+++ b/resources/sample-nonstandard-input.csv
@@ -1,0 +1,4 @@
+encounter_id,birth_year,age_at_encounter,encounter_date,encounter_type,patient_gender,ssn
+ENC-2024-0015,1969,54.2,2024-01-15,Clinical Visit,M,123456789
+ENC-2024-0031,1978,45.8,2024-03-22,Lab Work,F,987654321
+ENC-2024-0047,1992,31.5,2024-05-10,Surgical Procedure,M,456789123

--- a/resources/sample-nonstandard-input.csv
+++ b/resources/sample-nonstandard-input.csv
@@ -1,4 +1,4 @@
-encounter_id,birth_year,age_at_encounter,encounter_date,encounter_type,patient_gender,ssn
+encounter_id,birth_year,age_at_encounter,encounter_date,encounter type,patient_gender,ssn
 ENC-2024-0015,1969,54.2,2024-01-15,Clinical Visit,M,123456789
 ENC-2024-0031,1978,45.8,2024-03-22,Lab Work,F,987654321
 ENC-2024-0047,1992,31.5,2024-05-10,Surgical Procedure,M,456789123

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,2 @@
-faker==40.23.0
+faker==40.28.1
 pycryptodome==3.23.0


### PR DESCRIPTION
This pull request introduces support for custom tokenization configuration, allowing users to map non-standard input fields to Open Link Token attribute types and define explicit token rules. The changes include new documentation, enhancements to the CLI and README, and a refactoring of the Java attribute and token generation system to support field-identifier-based attribute mapping and registration.

**Custom Tokenization Configuration Support**

* Added `docs/tokenization-config-format.md` with a full specification and examples for custom tokenization configuration files, detailing how to map input columns and define token rules.
* Updated the `README.md` to document the new `--config` option for the `tokenize` command, added a section on custom tokenization configuration, and linked to the new reference documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R137) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R154-R159)

**CLI and Workflow Enhancements**

* Updated the CI workflow (`.github/workflows/ci.yml`) to test the CLI with both standard and nonstandard data using custom tokenization configs.

**Java Attribute System Refactoring**

* Introduced the `AttributeField` class to separate field identity from attribute behavior, enabling multiple fields to share the same attribute type while remaining distinct in person attribute maps.
* Added the `FieldRegistry` class as a registry mapping field identifiers to attribute instances and definitions, supporting both built-in and config-driven fields.
* Updated `AttributeExpression` to support field-ID-based construction and deprecated the old constructor, preparing for config-driven tokenization.
* Refactored `TokenGenerator` to support initialization with a custom `FieldRegistry` and added new methods for field-ID-based token generation, deprecating class-based methods. [[1]](diffhunk://#diff-9e975af6b15ab94a3f9bb6b7d8a75f4d0f4dcd9d607c5f7797ccf789b65a55dfR23) [[2]](diffhunk://#diff-9e975af6b15ab94a3f9bb6b7d8a75f4d0f4dcd9d607c5f7797ccf789b65a55dfR42) [[3]](diffhunk://#diff-9e975af6b15ab94a3f9bb6b7d8a75f4d0f4dcd9d607c5f7797ccf789b65a55dfR69-R84) [[4]](diffhunk://#diff-9e975af6b15ab94a3f9bb6b7d8a75f4d0f4dcd9d607c5f7797ccf789b65a55dfR102) [[5]](diffhunk://#diff-9e975af6b15ab94a3f9bb6b7d8a75f4d0f4dcd9d607c5f7797ccf789b65a55dfR147-R149) [[6]](diffhunk://#diff-9e975af6b15ab94a3f9bb6b7d8a75f4d0f4dcd9d607c5f7797ccf789b65a55dfR178)

These changes lay the foundation for flexible, user-driven field mapping and token rule definition, making the system more extensible and suitable for diverse data sources.