### PR TITLE
fix: align workspace notebook dependency and validate uv resolution (…

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -78,6 +78,12 @@ runs:
       run: |
         set -euo pipefail
         echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
+        gpg_keyname="$(gpg --batch --list-secret-keys --with-colons | awk -F: '$1 == "fpr" { print $10; exit }')"
+        if [[ -z "$gpg_keyname" ]]; then
+          echo "::error::No GPG secret key fingerprint found after import"
+          exit 1
+        fi
+        echo "MAVEN_GPG_KEYNAME=$gpg_keyname" >> "$GITHUB_ENV"
         echo "Imported GPG signing key"
       env:
         GPG_PRIVATE_KEY: ${{ inputs.gpg-private-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,23 @@ env:
   MIN_COVERAGE_CHANGED_FILES_RATIO: 0.8
 
 jobs:
+  workspace-resolution:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup toolchain (Python)
+        uses: ./.github/actions/setup-toolchain
+        with:
+          enable-java: false
+          enable-python: true
+          python-version: "3.11"
+
+      - name: Validate uv workspace resolution
+        run: uv lock
+
   java-tests:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -106,8 +106,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=openlinktoken-docker-${{ github.event_name }}
+          cache-to: type=gha,scope=openlinktoken-docker-${{ github.event_name }},mode=min,ignore-error=true
           platforms: linux/amd64,linux/arm64/v8
 
       # Sign the resulting Docker image digest

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -105,7 +105,7 @@ The composite action then:
 
 1. Lets `actions/setup-java@v4` generate `settings.xml` with the `github` server entry (for GitHub Packages).
 2. Inserts a `central` server entry (Portal user token) and a `gpg.passphrase` server entry into that same `settings.xml`, referencing environment variables that are supplied at `mvn deploy` time (never written to disk in plaintext).
-3. Imports the GPG private key into the runner's keyring with `gpg --batch --import`.
+3. Imports the GPG private key into the runner's keyring with `gpg --batch --import` and records its full fingerprint as `MAVEN_GPG_KEYNAME`, so Maven signs with the imported key explicitly instead of relying on GPG's default-key selection.
 
 The publish step in `maven-publish.yml` then runs:
 

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -338,6 +338,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <keyname>${env.MAVEN_GPG_KEYNAME}</keyname>
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>
                                 <arg>loopback</arg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
    "ruff==0.15.21",
    "pycryptodome==3.23.0",
    "jupyter==1.1.1",
-   "notebook==7.5.7",
+   "notebook==7.6.0",
    "ipykernel==7.3.0",
    "prek==0.4.4",
    "autoflake==2.3.3",


### PR DESCRIPTION
This pull request introduces several improvements across the CI/CD pipeline and supporting documentation. The main focus is on enhancing the reliability and reproducibility of build and publish processes, especially for Maven and Docker, and adding validation for Python workspace resolution. Notably, it ensures explicit GPG key selection for Maven signing, improves Docker build caching, and adds a new CI job for Python dependency locking.

**CI/CD Pipeline Improvements:**

* The `setup-toolchain` action now extracts and exports the GPG key fingerprint as `MAVEN_GPG_KEYNAME`, ensuring Maven signs artifacts with the correct key instead of relying on GPG's default selection.
* The Maven build configuration (`pom.xml`) is updated to explicitly use the `MAVEN_GPG_KEYNAME` environment variable for artifact signing.
* Documentation is updated to clarify that the GPG key fingerprint is now recorded and used for explicit Maven signing.

**Docker Build Optimization:**

* Docker build caching is improved by scoping cache keys to the event name and making cache-to operations more robust with `ignore-error=true`.

**Python Toolchain and Dependency Management:**

* A new `workspace-resolution` job is added to CI to validate Python dependency resolution with `uv lock`, ensuring reproducible Python environments.
* The `notebook` development dependency is updated from version `7.5.7` to `7.6.0` in `pyproject.toml`.