### PR TITLE
fix(ci): stabilize Maven Central publishing

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -78,7 +78,19 @@ runs:
       run: |
         set -euo pipefail
         echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
-        gpg_keyname="$(gpg --batch --list-secret-keys --with-colons | awk -F: '$1 == "fpr" { print $10; exit }')"
+        gpg_keyname="$(
+          gpg --batch --list-secret-keys --with-colons |
+            awk -F: '
+              ($1 == "sec" || $1 == "ssb") {
+                signing_candidate = ($12 ~ /s/)
+                next
+              }
+              $1 == "fpr" && signing_candidate {
+                print $10
+                exit
+              }
+            '
+        )"
         if [[ -z "$gpg_keyname" ]]; then
           echo "::error::No GPG secret key fingerprint found after import"
           exit 1

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -81,13 +81,31 @@ runs:
         gpg_keyname="$(
           gpg --batch --list-secret-keys --with-colons |
             awk -F: '
-              ($1 == "sec" || $1 == "ssb") {
-                signing_candidate = ($12 ~ /s/)
+              $1 == "sec" {
+                primary_signing = ($12 ~ /s/)
+                primary_fingerprint = ""
                 next
               }
-              $1 == "fpr" && signing_candidate {
-                print $10
-                exit
+              $1 == "ssb" {
+                signing_subkey = ($12 ~ /s/)
+                next
+              }
+              $1 == "fpr" {
+                if (signing_subkey) {
+                  print $10
+                  found = 1
+                  exit
+                }
+                if (primary_signing) {
+                  primary_fingerprint = $10
+                }
+                signing_subkey = 0
+                primary_signing = 0
+              }
+              END {
+                if (!found && primary_fingerprint != "") {
+                  print primary_fingerprint
+                }
               }
             '
         )"

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          cd lib/java/openlinktoken
+          cd lib/java
           mvn deploy \
             -s "$GITHUB_WORKSPACE/settings.xml" \
             -Pcentral-release \


### PR DESCRIPTION
## Summary

Fix Maven Central publishing failures caused by unusable GPG key selection and publishing from the child Maven module instead of the reactor root.

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [ ] Java
- [ ] Python
- [ ] CLI
- [ ] PySpark
- [ ] Docs / GitHub Pages
- [x] CI / workflows / agent instructions
- [x] Release process

## What changed

- Select a signing-capable GPG fingerprint, preferring the signing subkey when available.
- Run Maven Central publishing from `lib/java` so parent and child artifacts are staged together with complete metadata.
- The publishing workflow was validated successfully after the key rotation and reactor-root correction.