### PR TITLE
fix(ci): stabilize Maven Central publishing (#414)

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -78,7 +78,37 @@ runs:
       run: |
         set -euo pipefail
         echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
-        gpg_keyname="$(gpg --batch --list-secret-keys --with-colons | awk -F: '$1 == "fpr" { print $10; exit }')"
+        gpg_keyname="$(
+          gpg --batch --list-secret-keys --with-colons |
+            awk -F: '
+              $1 == "sec" {
+                primary_signing = ($12 ~ /s/)
+                primary_fingerprint = ""
+                next
+              }
+              $1 == "ssb" {
+                signing_subkey = ($12 ~ /s/)
+                next
+              }
+              $1 == "fpr" {
+                if (signing_subkey) {
+                  print $10
+                  found = 1
+                  exit
+                }
+                if (primary_signing) {
+                  primary_fingerprint = $10
+                }
+                signing_subkey = 0
+                primary_signing = 0
+              }
+              END {
+                if (!found && primary_fingerprint != "") {
+                  print primary_fingerprint
+                }
+              }
+            '
+        )"
         if [[ -z "$gpg_keyname" ]]; then
           echo "::error::No GPG secret key fingerprint found after import"
           exit 1

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Publish to Maven Central
         run: |
-          cd lib/java/openlinktoken
+          cd lib/java
           mvn deploy \
             -s "$GITHUB_WORKSPACE/settings.xml" \
             -Pcentral-release \


### PR DESCRIPTION
## Summary

Fix Maven Central publishing failures caused by unusable GPG key selection and publishing from the child Maven module instead of the reactor root.

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [ ] Java
- [ ] Python
- [ ] CLI
- [ ] PySpark
- [ ] Docs / GitHub Pages
- [x] CI / workflows / agent instructions
- [x] Release process

## What changed

- Select a signing-capable GPG fingerprint, preferring the signing subkey when available.
- Run Maven Central publishing from `lib/java` so parent and child artifacts are staged together with complete metadata.
- The publishing workflow was validated successfully after the key rotation and reactor-root correction.

---------

## Summary

- Briefly describe the user-visible or developer-visible change.
- Call out the main reason for the change or the problem it solves.

## Related issues

- Fixes #
- Related to #

## Affected surfaces

- [ ] Java
- [ ] Python
- [ ] CLI
- [ ] PySpark
- [ ] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Highlight the most important implementation changes.
- Note any intentional trade-offs or follow-up work.
