### PR TITLE
chore: consolidate Dependabot dependency updates

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.22.0</version>
+                <version>1.22.1</version>
             </dependency>
 
             <!-- Commons Lang3 (string utilities) -->
@@ -327,7 +327,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/lib/python/dev-requirements.txt
+++ b/lib/python/dev-requirements.txt
@@ -4,7 +4,7 @@
 pytest>=9.1.1
 
 # Code quality and linting
-ruff==0.16.0
+ruff==0.16.1
 
 # Cryptography for core library tests
 pycryptodome>=3.18.0

--- a/lib/python/openlinktoken-cli/pyproject.toml
+++ b/lib/python/openlinktoken-cli/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pandas==3.0.3; python_version >= '3.11'",
   "pyarrow==25.0.0",
   "csv2parquet==0.0.9",
-  "cryptography==49.0.0",
+  "cryptography==50.0.0",
   "urllib3==2.7.0",
   "jwcrypto==1.5.8",
   "packaging==26.2",

--- a/lib/python/openlinktoken-cli/requirements.txt
+++ b/lib/python/openlinktoken-cli/requirements.txt
@@ -5,7 +5,7 @@
 -e ./lib/python/openlinktoken-cli
 cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
-cryptography==49.0.0
+cryptography==50.0.0
     # via
     #   jwcrypto
     #   openlinktoken

--- a/lib/python/openlinktoken/pyproject.toml
+++ b/lib/python/openlinktoken/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
   "urls",
 ]
 dependencies = [
-  "cryptography==49.0.0",
+  "cryptography==50.0.0",
   "jwcrypto==1.5.8",
   "PyYAML==6.0.3",
 ]

--- a/lib/python/openlinktoken/requirements.txt
+++ b/lib/python/openlinktoken/requirements.txt
@@ -1,5 +1,5 @@
 # Cryptography - mandate secure version to address CVE-2026-44432
-cryptography==49.0.0
+cryptography==50.0.0
 
 # JOSE/JWE for match token format
 jwcrypto==1.5.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,19 +19,19 @@ openlinktoken = { workspace = true }
 
 [dependency-groups]
 dev = [
-   "cryptography==49.0.0",
+   "cryptography==50.0.0",
    "jwcrypto==1.5.8",
    "csv2parquet==0.0.9",
    "pytest==9.1.1",
    "pytest-cov==7.1.0",
-   "ruff==0.16.0",
+   "ruff==0.16.1",
    "pycryptodome==3.23.0",
    "jupyter==1.1.1",
    "notebook==7.6.1",
    "ipykernel==7.3.0",
    "prek==0.4.4",
    "autoflake==2.3.3",
-   "pyinstaller==6.19.0",
+   "pyinstaller==6.21.0",
 ]
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary

Combine Dependabot PRs #424-#430 and update dependency pins across Java and Python manifests.

## Related issues

- Fixes N/A

## Affected surfaces

- [x] Java
- [x] Python

## What changed

Updated commons-codec, maven-gpg-plugin, cryptography, ruff, and pyinstaller.