### PR TITLE
feat: improve standalone CLI startup speed

### DIFF
--- a/.github/workflows/build-olt-cli.yml
+++ b/.github/workflows/build-olt-cli.yml
@@ -90,9 +90,9 @@ jobs:
         run: |
           mkdir -p smoke
           cp resources/sample.csv smoke/input.csv
-          ./dist/olt generate-key-pair --name recipient --force
-          ./dist/olt initiate-exchange --name smoke --public-key "$HOME/.openlinktoken/recipient.public.pem" --output smoke/smoke.exchange.json --hashingsecret secret
-          ./dist/olt tokenize -i smoke/input.csv -o smoke/out.csv --exchange-config smoke/smoke.exchange.json --private-key "$HOME/.openlinktoken/smoke.private.pem"
+          ./dist/olt/olt generate-key-pair --name recipient --force
+          ./dist/olt/olt initiate-exchange --name smoke --public-key "$HOME/.openlinktoken/recipient.public.pem" --output smoke/smoke.exchange.json --hashingsecret secret
+          ./dist/olt/olt tokenize -i smoke/input.csv -o smoke/out.csv --exchange-config smoke/smoke.exchange.json --private-key "$HOME/.openlinktoken/smoke.private.pem"
 
       - name: Smoke test (Windows)
         if: runner.os == 'Windows'
@@ -100,9 +100,25 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path smoke | Out-Null
           Copy-Item resources\sample.csv smoke\input.csv
-          .\dist\olt.exe generate-key-pair --name recipient --force
-          .\dist\olt.exe initiate-exchange --name smoke --public-key "$HOME/.openlinktoken/recipient.public.pem" --output smoke\smoke.exchange.json --hashingsecret secret
-          .\dist\olt.exe tokenize -i smoke\input.csv -o smoke\out.csv --exchange-config smoke\smoke.exchange.json --private-key "$HOME/.openlinktoken/smoke.private.pem"
+          .\dist\olt\olt.exe generate-key-pair --name recipient --force
+          .\dist\olt\olt.exe initiate-exchange --name smoke --public-key "$HOME/.openlinktoken/recipient.public.pem" --output smoke\smoke.exchange.json --hashingsecret secret
+          .\dist\olt\olt.exe tokenize -i smoke\input.csv -o smoke\out.csv --exchange-config smoke\smoke.exchange.json --private-key "$HOME/.openlinktoken/smoke.private.pem"
+
+      - name: Measure standalone startup
+        shell: bash
+        run: |
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            uv run python tools/cli/measure_startup.py --executable dist/olt/olt.exe --output startup-measurements.json
+          else
+            uv run python tools/cli/measure_startup.py --executable dist/olt/olt --output startup-measurements.json
+          fi
+
+      - name: Upload startup measurements
+        uses: actions/upload-artifact@v7
+        with:
+          name: olt-cli-startup-${{ matrix.os }}
+          path: startup-measurements.json
+          if-no-files-found: error
 
       - name: Prepare release assets
         shell: bash
@@ -148,6 +164,15 @@ jobs:
             }
 
             const files = fs.readdirSync(assetDir)
+              .sort((left, right) => {
+                const rank = (name) => {
+                  if (name.endsWith('.zip.sha256')) return 3;
+                  if (name.endsWith('.zip')) return 2;
+                  if (name.endsWith('.sha256')) return 1;
+                  return 0;
+                };
+                return rank(left) - rank(right) || left.localeCompare(right);
+              })
               .map((name) => path.join(assetDir, name))
               .filter((filePath) => fs.statSync(filePath).isFile());
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ Perfect for understanding privacy-preserving record linkage concepts before divi
 
 Download the binary for your platform from the [latest release](https://github.com/TruvetaPublic/OpenLinkToken/releases):
 
-| Platform                      | Asset                           |
-| ----------------------------- | ------------------------------- |
-| Linux                         | `olt-vX.Y.Z-linux-x86_64`       |
-| macOS (Intel + Apple Silicon) | `olt-vX.Y.Z-macos-universal`    |
-| Windows                       | `olt-vX.Y.Z-windows-x86_64.exe` |
+| Platform                      | Asset                               |
+| ----------------------------- | ----------------------------------- |
+| Linux                         | `olt-cli-X.Y.Z-linux-x64.zip`       |
+| macOS (Intel + Apple Silicon) | `olt-cli-X.Y.Z-macos-universal.zip` |
+| Windows                       | `olt-cli-X.Y.Z-windows-x64.zip`     |
 
-Each asset has a matching `.sha256` file you can use to verify the download.
+Each ZIP contains the executable and its runtime files. Each asset has a matching
+`.sha256` file you can use to verify the download.
 
 **One-line installers:**
 
@@ -84,33 +85,24 @@ irm https://github.com/TruvetaPublic/OpenLinkToken/releases/latest/download/inst
 & ([scriptblock]::Create((irm https://github.com/TruvetaPublic/OpenLinkToken/releases/latest/download/install.ps1))) -Version v2.1.1
 ```
 
-```bash
-# Linux
-chmod +x olt-v*-linux-x86_64
-mv olt-v*-linux-x86_64 olt
-
-# macOS — make executable, clear Gatekeeper quarantine, and rename
-chmod +x olt-v*-macos-universal
-xattr -d com.apple.quarantine olt-v*-macos-universal
-mv olt-v*-macos-universal olt
-```
+Extract the ZIP, then run the executable inside its `olt` directory.
 
 Then run:
 
 ```bash
 # Linux/macOS
 # Simulate receiving the recipient's public key (in practice, your partner provides this)
-./olt generate-key-pair --name recipient
+./olt/olt generate-key-pair --name recipient
 # Create the exchange config using the recipient's public key
-./olt initiate-exchange --public-key "$HOME/.openlinktoken/recipient.public.pem"
-./olt package -i ./resources/sample.csv
+./olt/olt initiate-exchange --public-key "$HOME/.openlinktoken/recipient.public.pem"
+./olt/olt package -i ./resources/sample.csv
 
 # Windows
 # Simulate receiving the recipient's public key (in practice, your partner provides this)
-.\olt.exe generate-key-pair --name recipient
+.\olt\olt.exe generate-key-pair --name recipient
 # Create the exchange config using the recipient's public key
-.\olt.exe initiate-exchange --public-key "$HOME/.openlinktoken/recipient.public.pem"
-.\olt.exe package -i .\resources\sample.csv
+.\olt\olt.exe initiate-exchange --public-key "$HOME/.openlinktoken/recipient.public.pem"
+.\olt\olt.exe package -i .\resources\sample.csv
 ```
 
 **Docker convenience scripts (Linux/macOS and Windows):**

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -236,7 +236,7 @@ Smoke-test the local build before packaging it:
 ```shell
 mkdir -p smoke
 cp resources/sample.csv smoke/input.csv
-./dist/olt/olt tokenize -i smoke/input.csv -o smoke/out.csv -h secret
+./dist/olt/olt tokenize -i smoke/input.csv -o smoke/out.csv --mode hash-only --disable-inferencing
 ```
 
 On Windows PowerShell:
@@ -244,7 +244,7 @@ On Windows PowerShell:
 ```powershell
 New-Item -ItemType Directory -Force -Path smoke | Out-Null
 Copy-Item resources\sample.csv smoke\input.csv
-.\dist\olt\olt.exe tokenize -i smoke\input.csv -o smoke\out.csv -h secret
+.\dist\olt\olt.exe tokenize -i smoke\input.csv -o smoke\out.csv --mode hash-only --disable-inferencing
 ```
 
 If you also want the same ZIP and checksum bundle produced by the release workflow, run:

--- a/docs/dev-guide-development.md
+++ b/docs/dev-guide-development.md
@@ -227,7 +227,8 @@ pyinstaller --clean --noconfirm lib/python/openlinktoken-cli/openlinktoken-cli.s
 pyinstaller --clean --noconfirm --target-arch universal2 lib/python/openlinktoken-cli/openlinktoken-cli.spec
 ```
 
-The built executable is written to `dist/olt` (`dist/olt.exe` on Windows). Intermediate files are written
+The one-folder bundle is written to `dist/olt/` with the executable at
+`dist/olt/olt` (`dist/olt/olt.exe` on Windows). Intermediate files are written
 to `build/`.
 
 Smoke-test the local build before packaging it:
@@ -235,7 +236,7 @@ Smoke-test the local build before packaging it:
 ```shell
 mkdir -p smoke
 cp resources/sample.csv smoke/input.csv
-./dist/olt tokenize -i smoke/input.csv -o smoke/out.csv -h secret
+./dist/olt/olt tokenize -i smoke/input.csv -o smoke/out.csv -h secret
 ```
 
 On Windows PowerShell:
@@ -243,7 +244,7 @@ On Windows PowerShell:
 ```powershell
 New-Item -ItemType Directory -Force -Path smoke | Out-Null
 Copy-Item resources\sample.csv smoke\input.csv
-.\dist\olt.exe tokenize -i smoke\input.csv -o smoke\out.csv -h secret
+.\dist\olt\olt.exe tokenize -i smoke\input.csv -o smoke\out.csv -h secret
 ```
 
 If you also want the same ZIP and checksum bundle produced by the release workflow, run:

--- a/install.ps1
+++ b/install.ps1
@@ -66,6 +66,9 @@ $Archive = Join-Path $TempDir $Asset
 $ChecksumFile = "$Archive.sha256"
 $DownloadUrl = "$ReleasesUrl/download/$Tag/$Asset"
 
+$StagedDir = $null
+$PreviousDir = $null
+$MovedPrevious = $false
 try {
     New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
     Write-Host "Downloading Open Link Token $Tag..."
@@ -90,8 +93,31 @@ try {
     }
 
     $InstallDir = [System.IO.Path]::GetFullPath($InstallDir)
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    Copy-Item -LiteralPath $Binary.FullName -Destination (Join-Path $InstallDir "olt.exe") -Force
+    $InstallParent = Split-Path -Parent $InstallDir
+    New-Item -ItemType Directory -Path $InstallParent -Force | Out-Null
+    $StagedDir = Join-Path $InstallParent (".olt-staged-" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $StagedDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $Binary.Directory.FullName "*") -Destination $StagedDir -Recurse -Force
+
+    $PreviousDir = "$InstallDir.previous"
+    if (Test-Path -LiteralPath $PreviousDir) {
+        Remove-Item -LiteralPath $PreviousDir -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $InstallDir) {
+        Move-Item -LiteralPath $InstallDir -Destination $PreviousDir
+        $MovedPrevious = $true
+    }
+    try {
+        Move-Item -LiteralPath $StagedDir -Destination $InstallDir
+    } catch {
+        if ($MovedPrevious -and -not (Test-Path -LiteralPath $InstallDir)) {
+            Move-Item -LiteralPath $PreviousDir -Destination $InstallDir
+        }
+        throw
+    }
+    if (Test-Path -LiteralPath $PreviousDir) {
+        Remove-Item -LiteralPath $PreviousDir -Recurse -Force
+    }
 
     $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
     $PathEntries = if ($UserPath) { @($UserPath -split ";") } else { @() }
@@ -102,6 +128,9 @@ try {
 
     Write-Host "Installed olt $Tag to $(Join-Path $InstallDir 'olt.exe')"
 } finally {
+    if ($StagedDir -and (Test-Path -LiteralPath $StagedDir)) {
+        Remove-Item -LiteralPath $StagedDir -Recurse -Force
+    }
     if (Test-Path -LiteralPath $TempDir) {
         Remove-Item -LiteralPath $TempDir -Recurse -Force
     }

--- a/install.sh
+++ b/install.sh
@@ -121,9 +121,27 @@ mkdir -p "$extract_dir"
 unzip -q "$archive" -d "$extract_dir"
 binary=$(find "$extract_dir" -type f -name olt -print -quit)
 [[ -n "$binary" ]] || fail "Release archive does not contain the olt executable"
+bundle_source=$(dirname "$binary")
 
 mkdir -p "$install_dir"
-install -m 0755 "$binary" "$install_dir/olt"
+bundle_dir="$install_dir/.olt"
+staged_bundle="$tmp_dir/staged-bundle"
+cp -R "$bundle_source/." "$staged_bundle"
+chmod 0755 "$staged_bundle/olt"
+
+old_bundle="$install_dir/.olt.previous.$$"
+if [[ -e "$bundle_dir" || -L "$bundle_dir" ]]; then
+    mv "$bundle_dir" "$old_bundle"
+fi
+if ! mv "$staged_bundle" "$bundle_dir"; then
+    [[ -e "$old_bundle" ]] && mv "$old_bundle" "$bundle_dir"
+    fail "Unable to install the CLI bundle into $bundle_dir"
+fi
+rm -rf "$old_bundle"
+
+launcher_tmp="$install_dir/.olt-launcher.$$"
+ln -s "$bundle_dir/olt" "$launcher_tmp"
+mv -f "$launcher_tmp" "$install_dir/olt"
 
 printf 'Installed olt %s to %s/olt\n' "$tag" "$install_dir"
 case ":${PATH:-}:" in

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -176,6 +176,15 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.15.0</version>
+                    <configuration>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>1.18.46</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>

--- a/lib/python/openlinktoken-cli/openlinktoken-cli.spec
+++ b/lib/python/openlinktoken-cli/openlinktoken-cli.spec
@@ -13,16 +13,23 @@ base_dir = os.path.abspath(SPECPATH)
 # (e.g. "universal2" for macOS universal binaries) without passing --target-arch,
 # which is invalid when a .spec file is used directly.
 target_arch = os.environ.get("OLT_TARGET_ARCH") or None
+core_ai_source = os.path.join(base_dir, "..", "openlinktoken-core-ai", "src", "main")
+inferencing_assets_source = os.path.join(base_dir, "..", "..", "..", "resources", "inferencing", "ml1")
 
 datas = []
 binaries = []
 hiddenimports = []
 
-for package_name in ("openlinktoken", "pyarrow", "pandas", "csv2parquet", "cryptography"):
+for package_name in ("openlinktoken", "openlinktoken.core", "pyarrow", "pandas", "csv2parquet", "cryptography"):
     package_datas, package_binaries, package_hiddenimports = collect_all(package_name)
     datas += package_datas
     binaries += package_binaries
     hiddenimports += package_hiddenimports
+
+datas += [
+    (os.path.join(inferencing_assets_source, filename), "openlinktoken/core/ai/tokens")
+    for filename in ("model.onnx", "model.onnx.data", "tokenizer.json")
+]
 
 a = Analysis(
     [os.path.join(base_dir, "src", "main", "openlinktoken_cli", "main.py")],
@@ -30,6 +37,7 @@ a = Analysis(
         base_dir,
         os.path.join(base_dir, "src", "main"),
         os.path.join(base_dir, "..", "openlinktoken", "src", "main"),
+        core_ai_source,
     ],
     binaries=binaries,
     datas=datas,

--- a/lib/python/openlinktoken-cli/openlinktoken-cli.spec
+++ b/lib/python/openlinktoken-cli/openlinktoken-cli.spec
@@ -44,9 +44,6 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
     name="olt",
     debug=False,
@@ -56,4 +53,15 @@ exe = EXE(
     upx_exclude=[],
     runtime_tmpdir=None,
     console=True,
+    exclude_binaries=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="olt",
 )

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/decrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/decrypt_command.py
@@ -1,20 +1,13 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import logging
 import sys
+from typing import TYPE_CHECKING
 
-from openlinktoken.tokentransformer.decrypt_token_transformer import DecryptTokenTransformer
-from openlinktoken_cli.io.csv.token_csv_reader import TokenCSVReader
-from openlinktoken_cli.io.csv.token_csv_writer import TokenCSVWriter
-from openlinktoken_cli.io.parquet.token_parquet_reader import TokenParquetReader
-from openlinktoken_cli.io.parquet.token_parquet_writer import TokenParquetWriter
-from openlinktoken_cli.processor.token_decryption_processor import TokenDecryptionProcessor
-from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
-from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
-from openlinktoken_cli.util.file_type_detector import FileTypeDetector
-from openlinktoken_cli.util.path_utils import get_auto_output_path
+if TYPE_CHECKING:
+    from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 
 logger = logging.getLogger(__name__)
 
@@ -84,13 +77,19 @@ class DecryptCommand:
             action="store_true",
             default=False,
             help="Suppress interactive progress indicator (e.g. for non-interactive / CI environments)",
-            )
+        )
 
         parser.set_defaults(func=DecryptCommand.execute)
 
     @staticmethod
     def execute(args):
         """Execute the decrypt command."""
+        from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+        from openlinktoken_cli.util.path_utils import get_auto_output_path
+
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -162,6 +161,9 @@ class DecryptCommand:
         progress_callback=None,
     ) -> TokenTransformationSummary:
         """Decrypt tokens from input file."""
+        from openlinktoken.tokentransformer.decrypt_token_transformer import DecryptTokenTransformer
+        from openlinktoken_cli.processor.token_decryption_processor import TokenDecryptionProcessor
+
         try:
             decryptor = DecryptTokenTransformer(encryption_key)
 
@@ -192,6 +194,10 @@ class DecryptCommand:
     @staticmethod
     def _create_token_reader(path: str, file_type: str):
         """Create a TokenReader based on file type."""
+        from openlinktoken_cli.io.csv.token_csv_reader import TokenCSVReader
+        from openlinktoken_cli.io.parquet.token_parquet_reader import TokenParquetReader
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:
             return TokenCSVReader(path)
@@ -203,6 +209,10 @@ class DecryptCommand:
     @staticmethod
     def _create_token_writer(path: str, file_type: str):
         """Create a TokenWriter based on file type."""
+        from openlinktoken_cli.io.csv.token_csv_writer import TokenCSVWriter
+        from openlinktoken_cli.io.parquet.token_parquet_writer import TokenParquetWriter
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:
             return TokenCSVWriter(path)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/decrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/decrypt_command.py
@@ -4,12 +4,25 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
 logger = logging.getLogger(__name__)
+
+
+def resolve_exchange_config(
+    exchange_config_path: str | None,
+    private_key_path: str | None = None,
+    private_key_env: str | None = None,
+) -> Any:
+    """Resolve exchange configuration without importing crypto dependencies at startup."""
+    from openlinktoken_cli.util.exchange_config import resolve_exchange_config as implementation
+
+    return implementation(exchange_config_path, private_key_path, private_key_env)
 
 
 class DecryptCommand:
@@ -85,8 +98,7 @@ class DecryptCommand:
     def execute(args):
         """Execute the decrypt command."""
         from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
+        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key
         from openlinktoken_cli.util.file_type_detector import FileTypeDetector
         from openlinktoken_cli.util.path_utils import get_auto_output_path
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -1,27 +1,17 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import contextlib
 import logging
 import sys
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from openlinktoken.tokens.token import Token
-from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
-from openlinktoken.tokentransformer.jwe_match_token_formatter import JweMatchTokenFormatter
-from openlinktoken_cli.io.csv.token_csv_reader import TokenCSVReader
-from openlinktoken_cli.io.csv.token_csv_writer import TokenCSVWriter
-from openlinktoken_cli.io.parquet.token_parquet_reader import TokenParquetReader
-from openlinktoken_cli.io.parquet.token_parquet_writer import TokenParquetWriter
-from openlinktoken_cli.processor.token_constants import TokenConstants
-from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
-from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
-from openlinktoken_cli.util.file_type_detector import FileTypeDetector
-from openlinktoken_cli.util.path_utils import get_auto_output_path
-from openlinktoken_cli.util.ring_id_utils import resolve_ring_id
-from openlinktoken_cli.util.zip_utils import bundle_into_zip
+if TYPE_CHECKING:
+    from openlinktoken.tokentransformer.jwe_match_token_formatter import JweMatchTokenFormatter
+    from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +97,14 @@ class EncryptCommand:
     @staticmethod
     def execute(args):
         """Execute the encrypt command."""
+        from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+        from openlinktoken_cli.util.path_utils import get_auto_output_path
+        from openlinktoken_cli.util.ring_id_utils import resolve_ring_id
+        from openlinktoken_cli.util.zip_utils import bundle_into_zip
+
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -208,6 +206,11 @@ class EncryptCommand:
         progress_callback=None,
     ) -> TokenTransformationSummary:
         """Encrypt tokens from input file."""
+        from openlinktoken.tokens.token import Token
+        from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
+        from openlinktoken_cli.processor.token_constants import TokenConstants
+        from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
+
         try:
             encryptor = EncryptTokenTransformer(encryption_key)
             jwe_formatters: dict[str, JweMatchTokenFormatter] = {}
@@ -283,6 +286,9 @@ class EncryptCommand:
         ring_id: str,
         jwe_formatters: dict[str, JweMatchTokenFormatter],
     ) -> str:
+        from openlinktoken.tokentransformer.jwe_match_token_formatter import JweMatchTokenFormatter
+        from openlinktoken_cli.processor.token_constants import TokenConstants
+
         rule_id = row.get(TokenConstants.RULE_ID)
         if not rule_id:
             return encrypted_token
@@ -297,6 +303,10 @@ class EncryptCommand:
     @staticmethod
     def _create_token_reader(path: str, file_type: str):
         """Create a TokenReader based on file type."""
+        from openlinktoken_cli.io.csv.token_csv_reader import TokenCSVReader
+        from openlinktoken_cli.io.parquet.token_parquet_reader import TokenParquetReader
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:
             return TokenCSVReader(path)
@@ -308,6 +318,10 @@ class EncryptCommand:
     @staticmethod
     def _create_token_writer(path: str, file_type: str):
         """Create a TokenWriter based on file type."""
+        from openlinktoken_cli.io.csv.token_csv_writer import TokenCSVWriter
+        from openlinktoken_cli.io.parquet.token_parquet_writer import TokenParquetWriter
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:
             return TokenCSVWriter(path)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/encrypt_command.py
@@ -7,13 +7,26 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from openlinktoken.tokentransformer.jwe_match_token_formatter import JweMatchTokenFormatter
     from openlinktoken_cli.processor.token_transformation_processor import TokenTransformationSummary
 
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
 logger = logging.getLogger(__name__)
+
+
+def resolve_exchange_config(
+    exchange_config_path: str | None,
+    private_key_path: str | None = None,
+    private_key_env: str | None = None,
+) -> Any:
+    """Resolve exchange configuration without importing crypto dependencies at startup."""
+    from openlinktoken_cli.util.exchange_config import resolve_exchange_config as implementation
+
+    return implementation(exchange_config_path, private_key_path, private_key_env)
 
 
 class EncryptCommand:
@@ -98,8 +111,7 @@ class EncryptCommand:
     def execute(args):
         """Execute the encrypt command."""
         from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
+        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key
         from openlinktoken_cli.util.file_type_detector import FileTypeDetector
         from openlinktoken_cli.util.path_utils import get_auto_output_path
         from openlinktoken_cli.util.ring_id_utils import resolve_ring_id

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/generate_key_pair_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/generate_key_pair_command.py
@@ -1,20 +1,14 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
-from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-from openlinktoken_cli.util.ec_key_utils import (
-    SUPPORTED_CURVES,
-    ensure_directory,
-    generate_key_pair,
-    resolve_key_name,
-    write_key,
-)
-
 logger = logging.getLogger(__name__)
+SUPPORTED_CURVES = ["P-256", "P-384", "P-521"]
 
 
 class GenerateKeyPairCommand:
@@ -76,6 +70,15 @@ class GenerateKeyPairCommand:
         Returns:
             Exit code (0 for success, non-zero for errors).
         """
+        from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+        from openlinktoken_cli.util.ec_key_utils import (
+            SUPPORTED_CURVES,
+            ensure_directory,
+            generate_key_pair,
+            resolve_key_name,
+            write_key,
+        )
+
         name: Optional[str] = getattr(args, "name", None)
         curve: str = getattr(args, "curve", "P-256")
         force: bool = getattr(args, "force", False)
@@ -127,6 +130,8 @@ class GenerateKeyPairCommand:
     @staticmethod
     def _resolve_key_name(name: Optional[str]) -> str:
         """Resolve and validate the requested key basename."""
+        from openlinktoken_cli.util.ec_key_utils import resolve_key_name
+
         return resolve_key_name(name)
 
     @staticmethod
@@ -137,14 +142,20 @@ class GenerateKeyPairCommand:
             Call ``openlinktoken_cli.util.ec_key_utils.generate_key_pair`` directly.
             This shim exists only for backward compatibility.
         """
+        from openlinktoken_cli.util.ec_key_utils import generate_key_pair
+
         return generate_key_pair(curve)
 
     @staticmethod
     def _ensure_directory(directory: Path) -> None:
         """Ensure the directory exists, is not a symlink, and has 700 permissions."""
+        from openlinktoken_cli.util.ec_key_utils import ensure_directory
+
         return ensure_directory(directory)
 
     @staticmethod
     def _write_key(path: Path, pem_bytes: bytes, mode: int, overwrite: bool = True) -> None:
         """Write PEM bytes to a file using secure creation flags and set the specified permissions."""
+        from openlinktoken_cli.util.ec_key_utils import write_key
+
         return write_key(path, pem_bytes, mode, overwrite=overwrite)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/help_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/help_command.py
@@ -30,7 +30,11 @@ class HelpCommand:
         """Execute the help command."""
         from openlinktoken_cli.commands import OpenLinkTokenCommand
 
-        parser = OpenLinkTokenCommand.create_parser()
+        parser = OpenLinkTokenCommand.create_parser(
+            OpenLinkTokenCommand._should_load_extensions(
+                ["help", args.subcommand] if args.subcommand else ["help"],
+            )
+        )
 
         if args.subcommand:
             # Show help for specific subcommand

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/initiate_exchange_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/initiate_exchange_command.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
@@ -11,21 +13,11 @@ from pathlib import Path
 from typing import Optional
 from uuid import uuid4
 
-from openlinktoken.exchange_jwe import EXCHANGE_JWE_VERSION, build_exchange_envelope
-from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-from openlinktoken_cli.util.ec_key_utils import (
-    SUPPORTED_CURVES,
-    derive_public_key_from_private_pem,
-    ensure_directory,
-    generate_key_pair,
-    resolve_key_name,
-    write_key,
-)
 from openlinktoken_cli.util.stdin_utils import read_required_env_bytes, read_required_stdin_bytes
 
 logger = logging.getLogger(__name__)
 
-EXCHANGE_CONFIG_VERSION = EXCHANGE_JWE_VERSION
+EXCHANGE_CONFIG_VERSION = 1
 DEFAULT_ROTATION_COUNT = 50
 DEFAULT_BIN_WIDTH = 0.05
 DEFAULT_EMBEDDING_DIMENSION = 1024
@@ -233,6 +225,17 @@ class InitiateExchangeCommand:
         Returns:
             Exit code (0 for success, non-zero for errors).
         """
+        from openlinktoken.exchange_jwe import build_exchange_envelope
+        from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+        from openlinktoken_cli.util.ec_key_utils import (
+            SUPPORTED_CURVES,
+            derive_public_key_from_private_pem,
+            ensure_directory,
+            generate_key_pair,
+            resolve_key_name,
+            write_key,
+        )
+
         name: Optional[str] = getattr(args, "name", None)
         public_key_path_str: str = getattr(args, "public_key", "")
         public_key_stdin: bool = getattr(args, "public_key_stdin", False)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/open_link_token_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/open_link_token_command.py
@@ -6,8 +6,6 @@ import os
 import sys
 
 from openlinktoken.metadata import Metadata
-from openlinktoken_cli.util.cli_error_reporter import archive_unexpected_error, format_unexpected_error_message
-from openlinktoken_cli.util.cli_run_reporter import configure_default_logging
 from openlinktoken_cli.util.version_checker import start_version_check
 
 logger = logging.getLogger(__name__)
@@ -60,7 +58,7 @@ class OpenLinkTokenCommand:
         )
 
     @staticmethod
-    def create_parser():
+    def create_parser(load_extensions: bool = True):
         """Create the main argument parser with subcommands."""
         parser = argparse.ArgumentParser(
             prog="olt",
@@ -100,7 +98,9 @@ class OpenLinkTokenCommand:
         from openlinktoken_cli.commands.package_command import PackageCommand
         from openlinktoken_cli.commands.tokenize_command import TokenizeCommand
         from openlinktoken_cli.commands.update_command import UpdateCommand
-        from openlinktoken_cli.extension.extension_loader import BUILTIN_COMMANDS, ExtensionLoader
+
+        if load_extensions:
+            from openlinktoken_cli.extension.extension_loader import BUILTIN_COMMANDS, ExtensionLoader
 
         # Register subcommands in alphabetical order by command name
         DecryptCommand.register_subcommand(subparsers)
@@ -113,9 +113,9 @@ class OpenLinkTokenCommand:
         TokenizeCommand.register_subcommand(subparsers)
         UpdateCommand.register_subcommand(subparsers)
 
-        # Load installed extensions (entry points or registry).
-        # BUILTIN_COMMANDS is the authoritative set of reserved command names.
-        ExtensionLoader.load_extensions(subparsers, BUILTIN_COMMANDS)
+        if load_extensions:
+            # Load installed extensions only when the selected command needs them.
+            ExtensionLoader.load_extensions(subparsers, BUILTIN_COMMANDS)
 
         # Sort all subcommands (built-ins and extensions) alphabetically.
         # Uses private argparse internals that may not exist in all Python versions;
@@ -136,9 +136,12 @@ class OpenLinkTokenCommand:
     @staticmethod
     def main(args=None):
         """Main entry point for the command-line application."""
+        from openlinktoken_cli.util.cli_error_reporter import archive_unexpected_error, format_unexpected_error_message
+        from openlinktoken_cli.util.cli_run_reporter import configure_default_logging
+
         configure_default_logging()
-        parser = OpenLinkTokenCommand.create_parser()
         raw_args = list(sys.argv[1:] if args is None else args)
+        parser = OpenLinkTokenCommand.create_parser(OpenLinkTokenCommand._should_load_extensions(raw_args))
 
         # Show banner for help-oriented entry points, bare invocation, and bare subcommand.
         if OpenLinkTokenCommand._should_show_banner(raw_args):
@@ -273,3 +276,25 @@ class OpenLinkTokenCommand:
     def _should_start_version_check(parsed_args: argparse.Namespace) -> bool:
         """Return whether startup version checks should run for the parsed command."""
         return getattr(parsed_args, "command", None) != "update"
+
+    @staticmethod
+    def _should_load_extensions(args: list[str]) -> bool:
+        """Return whether parsing requires loading a non-built-in extension."""
+        built_in_commands = {
+            "help",
+            "tokenize",
+            "encrypt",
+            "decrypt",
+            "package",
+            "generate-key-pair",
+            "initiate-exchange",
+            "update",
+            "extension",
+        }
+        commands = [arg for arg in args if not arg.startswith("-")]
+        if not commands:
+            return False
+        command = commands[0]
+        if command == "help":
+            return len(commands) > 1 and commands[1] not in built_in_commands
+        return command not in built_in_commands

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -1,36 +1,17 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import contextlib
 import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from openlinktoken.core.ai.tokens.ml1_inference_config import ML1InferenceConfig
-from openlinktoken.core.ai.tokens.rotation_config import RotationConfig
-from openlinktoken.exchange_config import rotation_iv_to_text
-from openlinktoken.metadata import Metadata
-from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
-from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
-from openlinktoken.tokentransformer.token_transformer import TokenTransformer
-from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
-from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
-from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
-from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
-from openlinktoken_cli.processor.person_attributes_processor import (
-    PersonAttributesProcessingSummary,
-    PersonAttributesProcessor,
-)
-from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
-from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
-from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
-from openlinktoken_cli.util.file_type_detector import FileTypeDetector
-from openlinktoken_cli.util.path_utils import get_auto_output_path
-from openlinktoken_cli.util.ring_id_utils import resolve_ring_id
-from openlinktoken_cli.util.zip_utils import bundle_into_zip
+if TYPE_CHECKING:
+    from openlinktoken.tokentransformer.token_transformer import TokenTransformer
+    from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessingSummary
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +119,7 @@ class PackageCommand:
             "--inferencing-batch-size",
             dest="inferencing_batch_size",
             type=int,
-            default=ML1InferenceConfig.DEFAULT_BATCH_SIZE,
+            default=64,
             help="ML1 ONNX inference batch size (default: 64)",
         )
 
@@ -164,6 +145,18 @@ class PackageCommand:
     @staticmethod
     def execute(args):
         """Execute the package command."""
+        from openlinktoken.core.ai.tokens.ml1_inference_config import ML1InferenceConfig
+        from openlinktoken.core.ai.tokens.rotation_config import RotationConfig
+        from openlinktoken.exchange_config import rotation_iv_to_text
+        from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+        from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+        from openlinktoken_cli.util.path_utils import get_auto_output_path
+        from openlinktoken_cli.util.ring_id_utils import resolve_ring_id
+        from openlinktoken_cli.util.zip_utils import bundle_into_zip
+
         input_type = FileTypeDetector.detect_input_type(args.input_path)
         if not input_type:
             logger.error("Unable to auto-detect input type. Supported input formats: csv, parquet")
@@ -334,6 +327,15 @@ class PackageCommand:
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens from person attributes."""
+        from openlinktoken.metadata import Metadata
+        from openlinktoken.tokentransformer.encrypt_token_transformer import EncryptTokenTransformer
+        from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
+        from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
+        from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
+        from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+        from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+        from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
+
         token_transformer_list: List[TokenTransformer] = []
 
         try:
@@ -388,6 +390,8 @@ class PackageCommand:
         hash_record_ids: bool,
     ) -> list[str]:
         """Build the human-readable completion summary for a package run."""
+        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
         lines = [
             f"Output: {output_path}",
         ]
@@ -410,6 +414,11 @@ class PackageCommand:
     @staticmethod
     def _create_writer(path: str, file_type: str):
         """Create a PersonAttributesWriter based on file type."""
+        from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
+        from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
+        from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:
             return PersonAttributesCSVWriter(path)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -9,6 +9,8 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional
 
+from openlinktoken.core.ai.tokens.ml1_inference_config import ML1InferenceConfig
+
 if TYPE_CHECKING:
     from openlinktoken.tokentransformer.token_transformer import TokenTransformer
     from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessingSummary
@@ -139,8 +141,8 @@ class PackageCommand:
             "--inferencing-batch-size",
             dest="inferencing_batch_size",
             type=int,
-            default=64,
-            help="ML1 ONNX inference batch size (default: 64)",
+            default=ML1InferenceConfig.DEFAULT_BATCH_SIZE,
+            help=f"ML1 ONNX inference batch size (default: {ML1InferenceConfig.DEFAULT_BATCH_SIZE})",
         )
 
         parser.add_argument(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/package_command.py
@@ -7,13 +7,33 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
     from openlinktoken.tokentransformer.token_transformer import TokenTransformer
     from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessingSummary
 
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
 logger = logging.getLogger(__name__)
+
+
+def resolve_exchange_config(
+    exchange_config_path: str | None,
+    private_key_path: str | None = None,
+    private_key_env: str | None = None,
+) -> Any:
+    """Resolve exchange configuration without importing crypto dependencies at startup."""
+    from openlinktoken_cli.util.exchange_config import resolve_exchange_config as implementation
+
+    return implementation(exchange_config_path, private_key_path, private_key_env)
+
+
+def derive_transport_encryption_key(exchange: Any) -> bytes:
+    """Derive the transport key without importing crypto dependencies at startup."""
+    from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key as implementation
+
+    return implementation(exchange)
 
 
 class PackageCommand:
@@ -150,8 +170,6 @@ class PackageCommand:
         from openlinktoken.exchange_config import rotation_iv_to_text
         from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
         from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-        from openlinktoken_cli.util.exchange_config import derive_transport_encryption_key, resolve_exchange_config
         from openlinktoken_cli.util.file_type_detector import FileTypeDetector
         from openlinktoken_cli.util.path_utils import get_auto_output_path
         from openlinktoken_cli.util.ring_id_utils import resolve_ring_id

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
@@ -4,13 +4,26 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
     from openlinktoken.tokentransformer.token_transformer import TokenTransformer
     from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessingSummary
 
+from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
 logger = logging.getLogger(__name__)
+
+
+def resolve_exchange_config(
+    exchange_config_path: str | None,
+    private_key_path: str | None = None,
+    private_key_env: str | None = None,
+) -> Any:
+    """Resolve exchange configuration without importing crypto dependencies at startup."""
+    from openlinktoken_cli.util.exchange_config import resolve_exchange_config as implementation
+
+    return implementation(exchange_config_path, private_key_path, private_key_env)
 
 
 class TokenizeCommand:
@@ -178,8 +191,6 @@ class TokenizeCommand:
         from openlinktoken.core.ai.tokens.rotation_config import RotationConfig
         from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
         from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-        from openlinktoken_cli.util.exchange_config import resolve_exchange_config
         from openlinktoken_cli.util.file_type_detector import FileTypeDetector
         from openlinktoken_cli.util.path_utils import get_auto_output_path
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
@@ -1,33 +1,14 @@
 # SPDX-License-Identifier: MIT
 
+from __future__ import annotations
+
 import logging
 import sys
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from openlinktoken.core.ai.tokens.ml1_inference_config import ML1InferenceConfig
-from openlinktoken.core.ai.tokens.rotation_config import RotationConfig
-from openlinktoken.exchange_config import rotation_iv_to_text
-from openlinktoken.metadata import Metadata
-from openlinktoken.tokens.tokenizer.passthrough_tokenizer import PassthroughTokenizer
-from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
-from openlinktoken.tokentransformer.token_transformer import TokenTransformer
-from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
-from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
-from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import (
-    PersonAttributesParquetWriter,
-)
-from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
-from openlinktoken_cli.processor.person_attributes_processor import (
-    PersonAttributesProcessingSummary,
-    PersonAttributesProcessor,
-)
-from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
-from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
-from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
-from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
-from openlinktoken_cli.util.exchange_config import resolve_exchange_config
-from openlinktoken_cli.util.file_type_detector import FileTypeDetector
-from openlinktoken_cli.util.path_utils import get_auto_output_path
+if TYPE_CHECKING:
+    from openlinktoken.tokentransformer.token_transformer import TokenTransformer
+    from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessingSummary
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +147,7 @@ class TokenizeCommand:
             "--inferencing-batch-size",
             dest="inferencing_batch_size",
             type=int,
-            default=ML1InferenceConfig.DEFAULT_BATCH_SIZE,
+            default=64,
             help="ML1 ONNX inference batch size (default: 64)",
         )
 
@@ -193,6 +174,15 @@ class TokenizeCommand:
     @staticmethod
     def execute(args):
         """Execute the tokenize command."""
+        from openlinktoken.core.ai.tokens.ml1_inference_config import ML1InferenceConfig
+        from openlinktoken.core.ai.tokens.rotation_config import RotationConfig
+        from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+        from openlinktoken_cli.util.cli_error_reporter import archive_cli_error, format_error_reference_message
+        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+        from openlinktoken_cli.util.exchange_config import resolve_exchange_config
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+        from openlinktoken_cli.util.path_utils import get_auto_output_path
+
         mode = getattr(args, "mode", TokenizeCommand._MODE_DEFAULT)
         hash_record_ids = getattr(args, "hash_record_ids", False)
         tokenization_config_path = getattr(args, "tokenization_config", None)
@@ -387,6 +377,9 @@ class TokenizeCommand:
     @staticmethod
     def _configure_rotation(exchange) -> None:
         """Apply an exchange's rotation settings."""
+        from openlinktoken.core.ai.tokens.rotation_config import RotationConfig
+        from openlinktoken.exchange_config import rotation_iv_to_text
+
         if not exchange.rotation_iv:
             return
 
@@ -412,6 +405,14 @@ class TokenizeCommand:
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in normal mode using SHA-256 + HMAC-SHA256."""
+        from openlinktoken.metadata import Metadata
+        from openlinktoken.tokentransformer.hash_token_transformer import HashTokenTransformer
+        from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
+        from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
+        from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+        from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+        from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
+
         token_transformer_list: List[TokenTransformer] = []
 
         try:
@@ -463,6 +464,13 @@ class TokenizeCommand:
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in hash-only mode using SHA-256 only (no HMAC, no secret)."""
+        from openlinktoken.metadata import Metadata
+        from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
+        from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
+        from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+        from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+        from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
+
         try:
             config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(
                 tokenization_config_path
@@ -506,6 +514,14 @@ class TokenizeCommand:
         progress_callback=None,
     ) -> tuple[PersonAttributesProcessingSummary, str]:
         """Process tokens in demo mode using PassthroughTokenizer (no hashing)."""
+        from openlinktoken.metadata import Metadata
+        from openlinktoken.tokens.tokenizer.passthrough_tokenizer import PassthroughTokenizer
+        from openlinktoken_cli.io.json.metadata_json_writer import MetadataJsonWriter
+        from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
+        from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessor
+        from openlinktoken_cli.tokens.config.tokenization_config_helper import TokenizationConfigHelper
+        from openlinktoken_cli.tokens.config.tokenization_config_loader import TokenizationConfigLoader
+
         try:
             config, resolver, token_definition = TokenizationConfigLoader.load_runtime_components(
                 tokenization_config_path
@@ -547,6 +563,8 @@ class TokenizeCommand:
         hash_record_ids: bool,
     ) -> list[str]:
         """Build the human-readable completion summary for a tokenize run."""
+        from openlinktoken_cli.util.cli_run_reporter import CliRunReporter
+
         mode_labels = {
             TokenizeCommand._MODE_DEFAULT: "default HMAC-SHA256",
             TokenizeCommand._MODE_HASH_ONLY: "hash-only SHA-256",
@@ -570,6 +588,11 @@ class TokenizeCommand:
     @staticmethod
     def _create_writer(path: str, file_type: str):
         """Create a PersonAttributesWriter based on file type."""
+        from openlinktoken_cli.io.csv.person_attributes_csv_writer import PersonAttributesCSVWriter
+        from openlinktoken_cli.io.parquet.person_attributes_parquet_writer import PersonAttributesParquetWriter
+        from openlinktoken_cli.io.zip.person_attributes_zip_writer import PersonAttributesZipWriter
+        from openlinktoken_cli.util.file_type_detector import FileTypeDetector
+
         file_type_lower = file_type.lower()
         if file_type_lower == FileTypeDetector.TYPE_CSV:
             return PersonAttributesCSVWriter(path)

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/tokenize_command.py
@@ -6,6 +6,8 @@ import logging
 import sys
 from typing import TYPE_CHECKING, Any, List, Optional
 
+from openlinktoken.core.ai.tokens.ml1_inference_config import ML1InferenceConfig
+
 if TYPE_CHECKING:
     from openlinktoken.tokentransformer.token_transformer import TokenTransformer
     from openlinktoken_cli.processor.person_attributes_processor import PersonAttributesProcessingSummary
@@ -160,8 +162,8 @@ class TokenizeCommand:
             "--inferencing-batch-size",
             dest="inferencing_batch_size",
             type=int,
-            default=64,
-            help="ML1 ONNX inference batch size (default: 64)",
+            default=ML1InferenceConfig.DEFAULT_BATCH_SIZE,
+            help=f"ML1 ONNX inference batch size (default: {ML1InferenceConfig.DEFAULT_BATCH_SIZE})",
         )
 
         parser.add_argument(

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/update_command.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/commands/update_command.py
@@ -7,8 +7,10 @@ import os
 import platform
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 from typing import Optional
 from urllib.error import URLError
@@ -163,12 +165,13 @@ class UpdateCommand:
                         tmp_path.unlink(missing_ok=True)
                         return 1
 
-            # Replace current installation
-            # Derive a likely entrypoint name (e.g. "olt" from
-            # "olt-linux-amd64") so we are not tightly coupled to the
-            # full release asset filename.
+            # Replace the complete bundle when available. Keep the raw binary path
+            # for older releases and older installations.
             expected_entrypoint_name = asset_name.split("-", 1)[0] if asset_name else ""
-            result = UpdateCommand._replace_binary(tmp_path, expected_entrypoint_name)
+            if asset_name.lower().endswith(".zip"):
+                result = UpdateCommand._replace_bundle(tmp_path, expected_entrypoint_name)
+            else:
+                result = UpdateCommand._replace_binary(tmp_path, expected_entrypoint_name)
             if result != 0:
                 tmp_path.unlink(missing_ok=True)
                 return result
@@ -219,31 +222,54 @@ class UpdateCommand:
         system = _OS_SYSTEM_ALIASES.get(raw_system, raw_system)
         machine = platform.machine().lower()
 
-        # Normalise common machine names
-        arch_aliases = {
-            "x86_64": ["x86_64", "amd64", "x64"],
-            "aarch64": ["aarch64", "arm64"],
-            "arm64": ["aarch64", "arm64"],
+        version = str(release_info.get("tag_name", "")).lstrip("v")
+        expected_names = UpdateCommand._expected_asset_names(version, system, machine)
+        assets_by_name = {
+            asset.get("name", "").lower(): asset
+            for asset in assets
+            if not asset.get("name", "").lower().endswith((".sha256", ".sha256sum"))
         }
-        archs = arch_aliases.get(machine, [machine])
-
-        for asset in assets:
-            name_lower = asset["name"].lower()
-            # Skip checksum files
-            if name_lower.endswith(".sha256") or name_lower.endswith(".sha256sum"):
-                continue
-            if system in name_lower and any(a in name_lower for a in archs):
+        for expected_name in expected_names:
+            asset = assets_by_name.get(expected_name.lower())
+            if asset is not None:
                 return asset
 
-        # Fallback: try just system match
+        # Keep compatibility with pre-bundle releases whose versioned asset
+        # names did not match the release tag exactly.
+        legacy_suffixes = {
+            "linux": ("-linux-x86_64",),
+            "macos": ("-macos-arm64", "-macos-x86_64", "-macos-universal"),
+            "windows": ("-windows-x86_64.exe",),
+        }
         for asset in assets:
-            name_lower = asset["name"].lower()
-            if name_lower.endswith(".sha256") or name_lower.endswith(".sha256sum"):
-                continue
-            if system in name_lower:
+            name = asset.get("name", "").lower()
+            if name.startswith("openlinktoken-v") and name.endswith(legacy_suffixes.get(system, ())):
                 return asset
 
         return None
+
+    @staticmethod
+    def _expected_asset_names(version: str, system: str, machine: str) -> tuple[str, ...]:
+        """Return exact bundle-first asset names for a platform."""
+        if system == "linux" and machine in {"x86_64", "amd64"}:
+            return (
+                f"olt-cli-{version}-linux-x64.zip",
+                f"olt-v{version}-linux-x86_64",
+                f"openlinktoken-v{version}-linux-x86_64",
+            )
+        if system == "macos" and machine in {"x86_64", "amd64", "arm64", "aarch64"}:
+            return (
+                f"olt-cli-{version}-macos-universal.zip",
+                f"olt-v{version}-macos-universal",
+                f"openlinktoken-v{version}-macos-universal",
+            )
+        if system == "windows" and machine in {"x86_64", "amd64", "x64"}:
+            return (
+                f"olt-cli-{version}-windows-x64.zip",
+                f"olt-v{version}-windows-x86_64.exe",
+                f"openlinktoken-v{version}-windows-x86_64.exe",
+            )
+        return ()
 
     @staticmethod
     def _find_checksum_asset(release_info: dict, asset_name: str) -> Optional[dict]:
@@ -304,41 +330,35 @@ class UpdateCommand:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _resolve_target_binary(expected_entrypoint_name: str) -> Optional[Path]:
+        """Locate the installed CLI entry point without selecting the interpreter."""
+        python_interpreter = Path(sys.executable).resolve()
+        target = UpdateCommand._find_target_binary()
+        if target is not None:
+            return target
+
+        argv0: Optional[Path] = None
+        if sys.argv and sys.argv[0]:
+            argv0 = Path(sys.argv[0]).resolve()
+        if (
+            argv0 is not None
+            and argv0.is_file()
+            and argv0.name == expected_entrypoint_name
+            and argv0 != python_interpreter
+        ):
+            return argv0
+        return None
+
+    @staticmethod
     def _replace_binary(src: Path, expected_entrypoint_name: str) -> int:
         """
         Replace the current executable with *src*.
 
         Returns 0 on success, non-zero on failure.
         """
-        python_interpreter = Path(sys.executable).resolve()
-        # Determine target path: for a wheel-installed script the executable is
-        # the Python interpreter; we instead look for the "olt" script on PATH.
-        target = UpdateCommand._find_target_binary()
+        target = UpdateCommand._resolve_target_binary(expected_entrypoint_name)
         if target is None:
-            # Fallback: try to infer the CLI entrypoint from sys.argv[0], but only
-            # if it is a real file, matches the expected entrypoint name, and is not
-            # the Python interpreter itself.
-            argv0: Optional[Path] = None
-            if sys.argv and sys.argv[0]:
-                argv0 = Path(sys.argv[0]).resolve()
-            if (
-                argv0 is not None
-                and argv0.is_file()
-                and argv0.name == expected_entrypoint_name
-                and argv0 != python_interpreter
-            ):
-                target = argv0
-            else:
-                print(
-                    "Error: Unable to locate the olt executable to update.\n"
-                    "The updater could not find an 'olt' binary on PATH and\n"
-                    "cannot safely determine which file to overwrite.\n"
-                    "Please reinstall olt via your package manager or download\n"
-                    "the latest release from:\n"
-                    "  https://github.com/TruvetaPublic/OpenLinkToken/releases",
-                    file=sys.stderr,
-                )
-                return 1
+            return UpdateCommand._print_target_not_found_error()
 
         if not os.access(str(target.parent), os.W_OK):
             print(
@@ -360,6 +380,134 @@ class UpdateCommand:
             return 1
 
         return 0
+
+    @staticmethod
+    def _replace_bundle(src: Path, expected_entrypoint_name: str) -> int:
+        """Extract and install a complete PyInstaller bundle."""
+        target = UpdateCommand._resolve_target_binary(expected_entrypoint_name)
+        if target is None:
+            return UpdateCommand._print_target_not_found_error()
+        if not os.access(str(target.parent), os.W_OK):
+            print(f"Error: Insufficient permissions to write to {target.parent}.", file=sys.stderr)
+            return 1
+
+        entrypoint_name = "olt.exe" if platform.system().lower() == "windows" else "olt"
+        try:
+            with tempfile.TemporaryDirectory(prefix="olt-update-") as temp_dir:
+                extracted_dir = Path(temp_dir) / "extracted"
+                extracted_dir.mkdir()
+                with zipfile.ZipFile(src) as archive:
+                    UpdateCommand._extract_bundle(archive, extracted_dir)
+
+                executable = next(extracted_dir.rglob(entrypoint_name), None)
+                if executable is None or not executable.is_file():
+                    print(
+                        f"Error: Release bundle does not contain {entrypoint_name}.",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+                if platform.system().lower() == "windows":
+                    return UpdateCommand._schedule_windows_bundle_replacement(executable.parent, target)
+                return UpdateCommand._replace_posix_bundle(executable.parent, target, entrypoint_name)
+        except (OSError, zipfile.BadZipFile, ValueError) as exc:
+            print(f"Error: Could not install CLI bundle: {exc}", file=sys.stderr)
+            return 1
+
+    @staticmethod
+    def _extract_bundle(archive: zipfile.ZipFile, destination: Path) -> None:
+        """Extract a bundle after rejecting unsafe archive paths."""
+        destination_root = destination.resolve()
+        for member in archive.infolist():
+            member_path = Path(member.filename)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise ValueError(f"Unsafe path in release bundle: {member.filename}")
+            resolved_path = (destination / member_path).resolve()
+            if os.path.commonpath((str(destination_root), str(resolved_path))) != str(destination_root):
+                raise ValueError(f"Unsafe path in release bundle: {member.filename}")
+            archive.extract(member, destination)
+
+    @staticmethod
+    def _replace_posix_bundle(source_bundle: Path, target: Path, entrypoint_name: str) -> int:
+        """Atomically switch the POSIX launcher to a staged bundle."""
+        bundle_dir = target.resolve().parent if target.is_symlink() else target.parent / ".olt"
+        staged_bundle = bundle_dir.parent / f".olt-staged-{os.getpid()}"
+        old_bundle = bundle_dir.parent / f".olt-previous-{os.getpid()}"
+        launcher_tmp = target.parent / f".olt-launcher-{os.getpid()}"
+        shutil.copytree(source_bundle, staged_bundle)
+
+        try:
+            if bundle_dir.exists() or bundle_dir.is_symlink():
+                os.replace(bundle_dir, old_bundle)
+            os.replace(staged_bundle, bundle_dir)
+            launcher_tmp.symlink_to(bundle_dir / entrypoint_name)
+            os.replace(launcher_tmp, target)
+        except OSError as exc:
+            if launcher_tmp.exists() or launcher_tmp.is_symlink():
+                launcher_tmp.unlink()
+            if not bundle_dir.exists() and old_bundle.exists():
+                os.replace(old_bundle, bundle_dir)
+            print(f"Error: Could not replace CLI bundle: {exc}", file=sys.stderr)
+            return 1
+        finally:
+            if old_bundle.is_symlink():
+                old_bundle.unlink()
+            elif old_bundle.exists():
+                shutil.rmtree(old_bundle)
+            if staged_bundle.exists():
+                shutil.rmtree(staged_bundle)
+        return 0
+
+    @staticmethod
+    def _schedule_windows_bundle_replacement(source_bundle: Path, target: Path) -> int:
+        """Schedule replacement after the running Windows executable exits."""
+        stage_dir = Path(tempfile.mkdtemp(prefix="olt-update-"))
+        script = Path(tempfile.gettempdir()) / f"olt-update-{os.getpid()}.cmd"
+        backup_dir = Path(tempfile.gettempdir()) / f"olt-update-previous-{os.getpid()}"
+        try:
+            shutil.copytree(source_bundle, stage_dir, dirs_exist_ok=True)
+            target_dir = target.parent
+            script.write_text(
+                "@echo off\r\n"
+                "setlocal\r\n"
+                f'set "STAGED={stage_dir}"\r\n'
+                f'set "TARGET={target_dir}"\r\n'
+                f'set "BACKUP={backup_dir}"\r\n'
+                ":wait\r\n"
+                'move "%TARGET%" "%BACKUP%" >nul 2>&1\r\n'
+                "if errorlevel 1 (timeout /t 1 /nobreak >nul & goto wait)\r\n"
+                'move "%STAGED%" "%TARGET%" >nul 2>&1\r\n'
+                'if errorlevel 1 (move "%BACKUP%" "%TARGET%" >nul 2>&1 & goto fail)\r\n'
+                'rmdir /s /q "%BACKUP%" >nul 2>&1\r\n'
+                "goto done\r\n"
+                ":fail\r\n"
+                'rmdir /s /q "%STAGED%" >nul 2>&1\r\n'
+                ":done\r\n"
+                'del /q "%~f0" >nul 2>&1\r\n',
+                encoding="utf-8",
+            )
+            creation_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(subprocess, "DETACHED_PROCESS", 0)
+            subprocess.Popen(["cmd.exe", "/d", "/c", str(script)], creationflags=creation_flags)
+        except (OSError, shutil.Error) as exc:
+            shutil.rmtree(stage_dir, ignore_errors=True)
+            script.unlink(missing_ok=True)
+            print(f"Error: Could not schedule Windows CLI update: {exc}", file=sys.stderr)
+            return 1
+        return 0
+
+    @staticmethod
+    def _print_target_not_found_error() -> int:
+        """Report that the active standalone executable could not be located."""
+        print(
+            "Error: Unable to locate the olt executable to update.\n"
+            "The updater could not find an 'olt' binary on PATH and\n"
+            "cannot safely determine which file to overwrite.\n"
+            "Please reinstall olt via your package manager or download\n"
+            "the latest release from:\n"
+            "  https://github.com/TruvetaPublic/OpenLinkToken/releases",
+            file=sys.stderr,
+        )
+        return 1
 
     @staticmethod
     def _find_target_binary() -> Optional[Path]:

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/main.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/main.py
@@ -3,15 +3,13 @@
 import logging
 import sys
 
-from openlinktoken_cli.commands import OpenLinkTokenCommand
-from openlinktoken_cli.util.cli_run_reporter import configure_default_logging
-
-configure_default_logging()
 logger = logging.getLogger(__name__)
 
 
 def main():
     """Main entry point for the Open Link Token application."""
+    from openlinktoken_cli.commands import OpenLinkTokenCommand
+
     exit_code = OpenLinkTokenCommand.main(sys.argv[1:])
     sys.exit(exit_code)
 

--- a/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/release_assets.py
+++ b/lib/python/openlinktoken-cli/src/main/openlinktoken_cli/util/release_assets.py
@@ -47,6 +47,10 @@ def create_release_assets(version: str, runner_os: str, dist_dir: Path, output_d
     output_dir.mkdir(parents=True, exist_ok=True)
 
     built_executable = dist_dir / spec.executable_name
+    bundle_root = dist_dir
+    if not built_executable.is_file():
+        bundle_root = dist_dir / "olt"
+        built_executable = bundle_root / spec.executable_name
     if not built_executable.is_file():
         raise FileNotFoundError(f"Expected built executable at {built_executable}")
 
@@ -54,7 +58,7 @@ def create_release_assets(version: str, runner_os: str, dist_dir: Path, output_d
     shutil.copy2(built_executable, raw_binary_path)
 
     zip_path = output_dir / f"{spec.package_name}.zip"
-    _create_zip_archive(built_executable, spec.executable_name, spec.package_name, zip_path)
+    _create_zip_archive(bundle_root, spec.package_name, zip_path)
 
     binary_checksum_path = _write_checksum_file(raw_binary_path)
     zip_checksum_path = _write_checksum_file(zip_path)
@@ -120,16 +124,22 @@ def _normalize_version(version: str) -> str:
     return normalized_version
 
 
-def _create_zip_archive(binary_path: Path, executable_name: str, package_name: str, zip_path: Path) -> None:
-    """Create the downloadable ZIP bundle for manual installation."""
+def _create_zip_archive(bundle_root: Path, package_name: str, zip_path: Path) -> None:
+    """Create a ZIP containing the complete one-folder bundle."""
     with tempfile.TemporaryDirectory() as temp_dir:
         package_root = Path(temp_dir) / package_name
         package_root.mkdir(parents=True, exist_ok=True)
-        packaged_binary = package_root / executable_name
-        shutil.copy2(binary_path, packaged_binary)
+        for source_path in bundle_root.rglob("*"):
+            if source_path.is_file():
+                relative_path = source_path.relative_to(bundle_root)
+                packaged_path = package_root / relative_path
+                packaged_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, packaged_path)
 
         with zipfile.ZipFile(zip_path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-            archive.write(packaged_binary, arcname=f"{package_name}/{executable_name}")
+            for packaged_path in sorted(package_root.rglob("*")):
+                if packaged_path.is_file():
+                    archive.write(packaged_path, arcname=packaged_path.relative_to(Path(temp_dir)))
 
 
 def _write_checksum_file(asset_path: Path) -> Path:

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/main_test.py
@@ -7,6 +7,7 @@ Tests the end-to-end workflows for token generation and decryption using new sub
 import json
 import os
 import re
+import subprocess
 import sys
 import zipfile
 from pathlib import Path
@@ -23,6 +24,28 @@ class TestOpenLinkTokenCommand:
 
     HASHING_SECRET = "TestHashingSecret"
     ENCRYPTION_KEY = "TestEncryptionKeyValue1234567890"  # Must be exactly 32 chars
+
+    def test_help_path_keeps_heavy_dependencies_lazy(self):
+        """Standalone help should not import data-processing or crypto dependencies."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "from openlinktoken_cli.commands import OpenLinkTokenCommand; "
+                    "assert OpenLinkTokenCommand.execute(['--help']) == 0; "
+                    "assert not any(name in sys.modules for name in ('pandas', 'pyarrow', 'cryptography')); "
+                    "assert 'openlinktoken_cli.extension.extension_loader' not in sys.modules"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
 
     @pytest.fixture
     def temp_dir(self, tmp_path):

--- a/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/util/release_assets_test.py
+++ b/lib/python/openlinktoken-cli/src/test/openlinktoken_cli/util/release_assets_test.py
@@ -24,6 +24,22 @@ def _expected_checksum(content: bytes, file_name: str) -> str:
 class TestCreateReleaseAssets:
     """Unit tests for release asset preparation."""
 
+    def test_zips_complete_one_folder_bundle(self, tmp_path):
+        """One-folder builds should include the executable and its dependency files."""
+        bundle_dir = tmp_path / "dist" / "olt"
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "olt").write_bytes(b"bundle executable")
+        (bundle_dir / "_internal").mkdir()
+        (bundle_dir / "_internal" / "runtime.dat").write_bytes(b"runtime")
+
+        create_release_assets("2.1.0", "Linux", tmp_path / "dist", tmp_path / "release-assets")
+
+        with zipfile.ZipFile(tmp_path / "release-assets" / "olt-cli-2.1.0-linux-x64.zip") as archive:
+            assert archive.namelist() == [
+                "olt-cli-2.1.0-linux-x64/_internal/runtime.dat",
+                "olt-cli-2.1.0-linux-x64/olt",
+            ]
+
     def test_creates_linux_release_assets_and_checksums(self, tmp_path):
         """Linux builds should emit updater binary, zip package, and checksum sidecars."""
         dist_dir = tmp_path / "dist"

--- a/pages/quickstarts/cli-quickstart.md
+++ b/pages/quickstarts/cli-quickstart.md
@@ -24,9 +24,9 @@ The easiest way to get started. No Docker, Java, or Python installation required
 
 Download the appropriate executable for your platform from the [latest release](https://github.com/TruvetaPublic/OpenLinkToken/releases):
 
-- **Linux**: `openlinktoken-cli-{version}-linux-x64.zip`
-- **macOS**: `openlinktoken-cli-{version}-macos-universal.zip` (works on both Intel and Apple Silicon)
-- **Windows**: `openlinktoken-cli-{version}-windows-x64.zip`
+- **Linux**: `olt-cli-{version}-linux-x64.zip`
+- **macOS**: `olt-cli-{version}-macos-universal.zip` (works on both Intel and Apple Silicon)
+- **Windows**: `olt-cli-{version}-windows-x64.zip`
 
 Each downloadable ZIP is also published with a matching `.sha256` sidecar for manual verification.
 
@@ -59,11 +59,12 @@ Both installers detect the platform, install to a user-writable directory, and v
 
 ```bash
 # Extract the zip file
-unzip openlinktoken-cli-2.1.2-macos-universal.zip
-cd openlinktoken-cli-2.1.2-macos-universal
+unzip olt-cli-2.1.2-macos-universal.zip
+cd olt-cli-2.1.2-macos-universal
+cd olt
 
-# Make executable (if needed)
-chmod +x openlinktoken
+# The bundle keeps the executable and its runtime files together.
+chmod +x olt
 
 # Simulate receiving the recipient's public key (in practice, your partner provides this)
 ./olt generate-key-pair --name recipient
@@ -77,8 +78,9 @@ chmod +x openlinktoken
 
 ```powershell
 # Extract the zip file
-Expand-Archive openlinktoken-cli-2.1.2-windows-x64.zip
-cd openlinktoken-cli-2.1.2-windows-x64
+Expand-Archive olt-cli-2.1.2-windows-x64.zip
+cd olt-cli-2.1.2-windows-x64
+cd olt
 
 # Simulate receiving the recipient's public key (in practice, your partner provides this)
 .\olt.exe generate-key-pair --name recipient

--- a/pages/reference/cli.md
+++ b/pages/reference/cli.md
@@ -12,11 +12,13 @@ Complete reference for Open Link Token CLI arguments, modes, and examples. This 
 
 Download the pre-built executable from [releases](https://github.com/TruvetaPublic/OpenLinkToken/releases):
 
-- **Linux**: `openlinktoken-cli-{version}-linux-x64.zip`
-- **macOS**: `openlinktoken-cli-{version}-macos-universal.zip` (Intel + Apple Silicon)
-- **Windows**: `openlinktoken-cli-{version}-windows-x64.zip`
+- **Linux**: `olt-cli-{version}-linux-x64.zip`
+- **macOS**: `olt-cli-{version}-macos-universal.zip` (Intel + Apple Silicon)
+- **Windows**: `olt-cli-{version}-windows-x64.zip`
 
-No dependencies required. Extract and run.
+No dependencies required. Extract the ZIP and run `olt/olt` on Linux/macOS or
+`olt\olt.exe` on Windows. The `olt` directory contains the executable and its
+runtime files.
 
 ### Other Options
 

--- a/tools/cli/measure_startup.py
+++ b/tools/cli/measure_startup.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Measure standalone CLI time to first output and command completion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+def _measure_once(executable: Path, arguments: list[str], environment: dict[str, str]) -> dict[str, float | None]:
+    """Run one CLI command and record first output and completion timings."""
+    started = time.perf_counter()
+    process = subprocess.Popen(
+        [str(executable), *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=environment,
+    )
+    first_line = process.stdout.readline() if process.stdout is not None else ""
+    first_output_ms = (time.perf_counter() - started) * 1000 if first_line else None
+    remaining_output, _ = process.communicate()
+    completed_ms = (time.perf_counter() - started) * 1000
+    if process.returncode:
+        raise RuntimeError(f"{executable} {' '.join(arguments)} failed with exit code {process.returncode}")
+    return {
+        "first_output_ms": first_output_ms,
+        "completed_ms": completed_ms,
+    }
+
+
+def measure(executable: Path, arguments: list[str], environment: dict[str, str], repeats: int = 3) -> dict[str, object]:
+    """Measure cold startup and repeated invocations of one CLI command."""
+    return {
+        "arguments": arguments,
+        "runs": [_measure_once(executable, arguments, environment) for _ in range(repeats)],
+    }
+
+
+def main() -> int:
+    """Measure the supported startup commands and write JSON results."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--executable", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("startup-measurements.json"))
+    args = parser.parse_args()
+
+    environment = os.environ.copy()
+    environment["OLT_DISABLE_UPDATE_CHECK"] = "1"
+    with tempfile.TemporaryDirectory(prefix="olt-startup-") as home:
+        environment["HOME"] = home
+        environment["USERPROFILE"] = home
+        commands = [["--help"], ["--version"], ["generate-key-pair", "--help"]]
+        measurements = [measure(args.executable, command, environment) for command in commands]
+
+    result = {"executable": str(args.executable), "measurements": measurements}
+    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Standalone CLI startup was slow for two independent reasons:

1. The PyInstaller one-file executable had to unpack its full runtime to a temporary directory on every launch, even for `olt --help` or `olt --version`.
2. CLI startup imported command modules that pulled in heavy data, cryptography, ONNX, tokenization, and extension-discovery dependencies before the user selected a command.

This PR removes both costs from the common startup path. The standalone build is now a one-folder bundle, so its runtime is already unpacked and can be reused across launches. The CLI also defers heavy imports and extension loading until the selected command needs them. The result is faster first output for lightweight commands and faster repeated launches, while full processing commands keep the same behavior once their dependencies are loaded.

## Related issues

- Fixes #434
- Stacked on #446 (`dev/mattwise-42/enable-macos-coreml-inference`)

## Affected surfaces

- [ ] Java
- [x] Python
- [x] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [x] CI / workflows / agent instructions
- [x] Release process

## What changed

### Startup and imports

- Kept `main.py`, parser setup, help, and version handling on lightweight imports.
- Moved pandas, PyArrow, cryptography, ONNX Runtime, tokenization processors, and extension discovery behind command-specific execution paths.
- Preserved the module-level compatibility names used by existing tests and integrations, without restoring eager imports.
- Added startup measurement tooling for first output, process completion, cold launches, and repeated launches.

### Standalone packaging

- Changed the PyInstaller spec from a one-file executable to a one-folder `dist/olt` bundle containing `olt`/`olt.exe` and its runtime files.
- Kept the user-facing executable name as `olt` on POSIX and `olt.exe` on Windows.
- Updated release asset generation to produce complete bundle ZIPs with checksums while retaining raw legacy binaries for older clients.
- Updated CI to build, measure, and publish the new bundle layout.

### Installation and updates

- POSIX installation stores the bundle in `.olt` and exposes `olt` through a launcher symlink.
- Windows installation stages the complete bundle, preserves rollback behavior, and updates the user `PATH`.
- `olt update` now selects exact bundle or legacy assets, verifies checksums and ZIP paths, atomically switches POSIX bundles, and schedules Windows replacement after the running process exits.
- Existing legacy one-file installations remain supported during the transition.

### Documentation and verification

- Updated the README, CLI reference, quickstart, operations guide, and developer guide for the bundle layout and startup behavior.
- Added focused tests for lightweight startup and complete bundle release assets.

The branch contains the six CoreML/CUDA commits from #446 because this PR is stacked on that branch. Those commits provide the base for this PR and are not additional startup changes. After #446 merges, this PR can be retargeted to `develop` with the dependency commits removed from the displayed diff.

Intentional trade-off: the bundle uses more installed disk space than a one-file executable, but it avoids repeated extraction and supports faster launches.