### PR TITLE
feat: normalize compound first names

### DIFF
--- a/lib/java/openlinktoken-core-ai/pom.xml
+++ b/lib/java/openlinktoken-core-ai/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.openlinktoken</groupId>
         <artifactId>openlinktoken-parent</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>openlinktoken-core-ai</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <name>openlinktoken-core-ai</name>
     <description>Open Link Token Core AI — ONNX-based ML1 inference and rotation token generation</description>

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
@@ -58,8 +58,8 @@ public class FirstNameAttribute extends BaseAttribute {
      *   $            End of string
      */
     private static final Pattern TRAILING_PERIOD_AND_INITIAL_PATTERN = Pattern.compile("\\s[^\\s]\\.?$");
-    private static final Pattern TWO_PART_NAME_PATTERN = Pattern.compile(
-            "^([A-Za-z]{3,})[\\s./]+[A-Za-z]+(?:[-\\u2010-\\u2015\\u2212][A-Za-z]+)*$");
+    private static final Pattern FIRST_PART_NAME_PATTERN = Pattern.compile(
+            "^([A-Za-z]{3,})[\\s./]+[A-Za-z]+(?:[\\s./\\-\\u2010-\\u2015\\u2212]+[A-Za-z]+)*$");
 
     public FirstNameAttribute() {
         super(List.of(
@@ -129,9 +129,9 @@ public class FirstNameAttribute extends BaseAttribute {
         // remove trailing periods and middle initials
         normalizedValue = TRAILING_PERIOD_AND_INITIAL_PATTERN.matcher(normalizedValue).replaceAll("");
 
-        var twoPartNameMatcher = TWO_PART_NAME_PATTERN.matcher(normalizedValue);
-        if (twoPartNameMatcher.matches()) {
-            normalizedValue = twoPartNameMatcher.group(1);
+        var firstPartNameMatcher = FIRST_PART_NAME_PATTERN.matcher(normalizedValue);
+        if (firstPartNameMatcher.matches()) {
+            normalizedValue = firstPartNameMatcher.group(1);
         }
 
         // remove dashes, spaces and other non-alphanumeric characters

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
@@ -59,7 +59,7 @@ public class FirstNameAttribute extends BaseAttribute {
      */
     private static final Pattern TRAILING_PERIOD_AND_INITIAL_PATTERN = Pattern.compile("\\s[^\\s]\\.?$");
     private static final Pattern TWO_PART_NAME_PATTERN = Pattern.compile(
-            "^([A-Za-z]{3,})[\\s./]+[A-Za-z]+$");
+            "^([A-Za-z]{3,})[\\s./]+[A-Za-z]+(?:[-\\u2010-\\u2015\\u2212][A-Za-z]+)*$");
 
     public FirstNameAttribute() {
         super(List.of(

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
@@ -29,7 +29,7 @@ public class FirstNameAttribute extends BaseAttribute {
      * This pattern matches (case-insensitive):
      *  - Common titles such as "Mr", "Mrs", "Ms", "Miss", "Dr", "Prof", etc.
      *  - Optional period after the title (e.g., "Dr.")
-     *  - One or more spaces following the title
+     *  - One or more leading titles, each followed by one or more spaces
      *
      * Breakdown of the regex:
      *   (?i)                         Case-insensitive flag
@@ -42,7 +42,7 @@ public class FirstNameAttribute extends BaseAttribute {
      *   \s+                         One or more spaces after the title
      */
     private static final Pattern TITLE_PATTERN = Pattern.compile(
-            "(?i)^(mr|mrs|ms|miss|dr|prof|capt|sir|col|gen|cmdr|lt|rabbi|father|brother|sister|hon|honorable|reverend|rev|doctor)\\.?\\s+");
+            "(?i)^(?:(?:mr|mrs|ms|miss|dr|prof|capt|sir|col|gen|cmdr|lt|rabbi|father|brother|sister|hon|honorable|reverend|rev|doctor)\\.?\\s+)+");
 
     /**
      * Pattern to match trailing periods and middle initials in names.

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
@@ -58,8 +58,8 @@ public class FirstNameAttribute extends BaseAttribute {
      *   $            End of string
      */
     private static final Pattern TRAILING_PERIOD_AND_INITIAL_PATTERN = Pattern.compile("\\s[^\\s]\\.?$");
-    private static final Pattern SPACE_DOT_SLASH_ANNE_PATTERN = Pattern.compile(
-            "^([A-Za-z]{3,})[\\s./]+Anne$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern TWO_PART_NAME_PATTERN = Pattern.compile(
+            "^([A-Za-z]{3,})[\\s./]+[A-Za-z]+$");
 
     public FirstNameAttribute() {
         super(List.of(
@@ -129,9 +129,9 @@ public class FirstNameAttribute extends BaseAttribute {
         // remove trailing periods and middle initials
         normalizedValue = TRAILING_PERIOD_AND_INITIAL_PATTERN.matcher(normalizedValue).replaceAll("");
 
-        var anneMatcher = SPACE_DOT_SLASH_ANNE_PATTERN.matcher(normalizedValue);
-        if (anneMatcher.matches()) {
-            normalizedValue = anneMatcher.group(1);
+        var twoPartNameMatcher = TWO_PART_NAME_PATTERN.matcher(normalizedValue);
+        if (twoPartNameMatcher.matches()) {
+            normalizedValue = twoPartNameMatcher.group(1);
         }
 
         // remove dashes, spaces and other non-alphanumeric characters

--- a/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
+++ b/lib/java/openlinktoken/src/main/java/org/openlinktoken/attributes/person/FirstNameAttribute.java
@@ -15,8 +15,8 @@ import org.openlinktoken.attributes.validation.NotInValidator;
  * first name fields. It recognizes "FirstName" and "GivenName" as valid aliases
  * for this attribute type.
  *
- * The attribute performs no normalization on input values, returning them
- * unchanged.
+ * The attribute removes titles, suffixes, initials, and non-alphabetic characters
+ * during normalization.
  */
 public class FirstNameAttribute extends BaseAttribute {
 
@@ -58,6 +58,8 @@ public class FirstNameAttribute extends BaseAttribute {
      *   $            End of string
      */
     private static final Pattern TRAILING_PERIOD_AND_INITIAL_PATTERN = Pattern.compile("\\s[^\\s]\\.?$");
+    private static final Pattern SPACE_DOT_SLASH_ANNE_PATTERN = Pattern.compile(
+            "^([A-Za-z]{3,})[\\s./]+Anne$", Pattern.CASE_INSENSITIVE);
 
     public FirstNameAttribute() {
         super(List.of(
@@ -126,6 +128,11 @@ public class FirstNameAttribute extends BaseAttribute {
         // trim trailing periods
         // remove trailing periods and middle initials
         normalizedValue = TRAILING_PERIOD_AND_INITIAL_PATTERN.matcher(normalizedValue).replaceAll("");
+
+        var anneMatcher = SPACE_DOT_SLASH_ANNE_PATTERN.matcher(normalizedValue);
+        if (anneMatcher.matches()) {
+            normalizedValue = anneMatcher.group(1);
+        }
 
         // remove dashes, spaces and other non-alphanumeric characters
         normalizedValue = AttributeUtilities.NON_ALPHABETIC_PATTERN.matcher(normalizedValue).replaceAll("");

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
@@ -271,7 +271,7 @@ class FirstNameAttributeTest {
     void normalize_ShouldRemoveNonAlphabeticCharacters() {
         // Test removal of dashes, spaces, and other non-alphanumeric characters
         assertEquals("JohnDoe", firstNameAttribute.normalize("John-Doe"));
-        assertEquals("MaryJane", firstNameAttribute.normalize("Mary Jane"));
+        assertEquals("Mary", firstNameAttribute.normalize("Mary Jane"));
         assertEquals("AnnMarie", firstNameAttribute.normalize("Ann-Marie"));
         assertEquals("JeanLuc", firstNameAttribute.normalize("Jean-Luc"));
 
@@ -282,11 +282,12 @@ class FirstNameAttributeTest {
     }
 
     @Test
-    void normalize_ShouldRemoveAnneForThreeCharacterPrefixWithNonDashSeparators() {
+    void normalize_ShouldRemoveSecondPartForThreeCharacterPrefixWithNonDashSeparators() {
+        assertEquals("Eric", firstNameAttribute.normalize("Eric Karl"));
+        assertEquals("Hans", firstNameAttribute.normalize("Hans Peter"));
         assertEquals("Mary", firstNameAttribute.normalize("Mary Anne"));
-        assertEquals("Mary", firstNameAttribute.normalize("Mary anne"));
-        assertEquals("Mary", firstNameAttribute.normalize("Mary.Anne"));
-        assertEquals("Mary", firstNameAttribute.normalize("Mary/Anne"));
+        assertEquals("Eric", firstNameAttribute.normalize("Eric.Karl"));
+        assertEquals("Hans", firstNameAttribute.normalize("Hans/Peter"));
         assertEquals("MaryAnne", firstNameAttribute.normalize("Mary-Anne"));
         assertEquals("MaryAnne", firstNameAttribute.normalize("Mary–Anne"));
         assertEquals("JoAnne", firstNameAttribute.normalize("Jo Anne"));
@@ -451,7 +452,7 @@ class FirstNameAttributeTest {
 
         // Test unusual but valid combinations
         assertEquals("JohnPaul", firstNameAttribute.normalize("Dr. John-Paul Jr."));
-        assertEquals("MaryEllen", firstNameAttribute.normalize("Mrs. Mary Ellen Sr."));
+        assertEquals("Mary", firstNameAttribute.normalize("Mrs. Mary Ellen Sr."));
         assertEquals("JeanLuc", firstNameAttribute.normalize("Capt. Jean-Luc III"));
 
         // Test with numbers and special characters mixed in
@@ -464,11 +465,11 @@ class FirstNameAttributeTest {
     void normalize_ShouldHandleMultipleTitlesAndSuffixes() {
         // Test multiple titles (should only remove the first valid one)
         assertEquals("DrJohn", firstNameAttribute.normalize("Mr. Dr. John"));
-        assertEquals("MrsJane", firstNameAttribute.normalize("Dr. Mrs. Jane"));
+        assertEquals("Mrs", firstNameAttribute.normalize("Dr. Mrs. Jane"));
 
-        // Test multiple suffixes (should remove only first recognized suffix)
+        // Test multiple suffixes
         assertEquals("JohnJr", firstNameAttribute.normalize("John Jr. Sr.")); // This should remove both
-        assertEquals("JaneIII", firstNameAttribute.normalize("Jane III II")); // This should remove both
+        assertEquals("Jane", firstNameAttribute.normalize("Jane III II"));
 
         // Test edge case: title that looks like a name
         assertEquals("Drew", firstNameAttribute.normalize("Drew")); // Drew is not Dr.

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
@@ -470,9 +470,9 @@ class FirstNameAttributeTest {
 
     @Test
     void normalize_ShouldHandleMultipleTitlesAndSuffixes() {
-        // Test multiple titles (should only remove the first valid one)
-        assertEquals("DrJohn", firstNameAttribute.normalize("Mr. Dr. John"));
-        assertEquals("Mrs", firstNameAttribute.normalize("Dr. Mrs. Jane"));
+        // Test multiple titles
+        assertEquals("John", firstNameAttribute.normalize("Mr. Dr. John"));
+        assertEquals("Jane", firstNameAttribute.normalize("Dr. Mrs. Jane"));
 
         // Test multiple suffixes
         assertEquals("JohnJr", firstNameAttribute.normalize("John Jr. Sr.")); // This should remove both

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
@@ -291,7 +291,7 @@ class FirstNameAttributeTest {
         assertEquals("MaryAnne", firstNameAttribute.normalize("Mary-Anne"));
         assertEquals("MaryAnne", firstNameAttribute.normalize("Mary–Anne"));
         assertEquals("JoAnne", firstNameAttribute.normalize("Jo Anne"));
-        assertEquals("MaryAnneMarie", firstNameAttribute.normalize("Mary Anne-Marie"));
+        assertEquals("Mary", firstNameAttribute.normalize("Mary Anne-Marie"));
     }
 
     void serialization_ShouldPreserveState() throws Exception {

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
@@ -282,16 +282,23 @@ class FirstNameAttributeTest {
     }
 
     @Test
-    void normalize_ShouldRemoveSecondPartForThreeCharacterPrefixWithNonDashSeparators() {
+    void normalize_ShouldKeepFirstPartWithNonDashSeparators() {
         assertEquals("Eric", firstNameAttribute.normalize("Eric Karl"));
         assertEquals("Hans", firstNameAttribute.normalize("Hans Peter"));
+        assertEquals("Anne", firstNameAttribute.normalize("Anne Marie Julie"));
         assertEquals("Mary", firstNameAttribute.normalize("Mary Anne"));
         assertEquals("Eric", firstNameAttribute.normalize("Eric.Karl"));
         assertEquals("Hans", firstNameAttribute.normalize("Hans/Peter"));
+        assertEquals("Eric", firstNameAttribute.normalize("Eric Karl Peter"));
         assertEquals("MaryAnne", firstNameAttribute.normalize("Mary-Anne"));
         assertEquals("MaryAnne", firstNameAttribute.normalize("Mary–Anne"));
-        assertEquals("JoAnne", firstNameAttribute.normalize("Jo Anne"));
         assertEquals("Mary", firstNameAttribute.normalize("Mary Anne-Marie"));
+    }
+
+    @Test
+    void normalize_ShouldRequireThreeLetterFirstPart() {
+        assertEquals("JoAnne", firstNameAttribute.normalize("Jo Anne"));
+        assertEquals("Amy", firstNameAttribute.normalize("Amy Lee"));
     }
 
     void serialization_ShouldPreserveState() throws Exception {

--- a/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
+++ b/lib/java/openlinktoken/src/test/java/org/openlinktoken/attributes/person/FirstNameAttributeTest.java
@@ -281,6 +281,18 @@ class FirstNameAttributeTest {
         assertEquals("RobertSmith", firstNameAttribute.normalize("Robert_Smith"));
     }
 
+    @Test
+    void normalize_ShouldRemoveAnneForThreeCharacterPrefixWithNonDashSeparators() {
+        assertEquals("Mary", firstNameAttribute.normalize("Mary Anne"));
+        assertEquals("Mary", firstNameAttribute.normalize("Mary anne"));
+        assertEquals("Mary", firstNameAttribute.normalize("Mary.Anne"));
+        assertEquals("Mary", firstNameAttribute.normalize("Mary/Anne"));
+        assertEquals("MaryAnne", firstNameAttribute.normalize("Mary-Anne"));
+        assertEquals("MaryAnne", firstNameAttribute.normalize("Mary–Anne"));
+        assertEquals("JoAnne", firstNameAttribute.normalize("Jo Anne"));
+        assertEquals("MaryAnneMarie", firstNameAttribute.normalize("Mary Anne-Marie"));
+    }
+
     void serialization_ShouldPreserveState() throws Exception {
         FirstNameAttribute originalAttribute = new FirstNameAttribute();
 

--- a/lib/python/openlinktoken-core-ai/pyproject.toml
+++ b/lib/python/openlinktoken-core-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlinktoken-core-ai"
-version = "2.1.1"
+version = "2.1.2"
 requires-python = ">=3.10"
 dynamic = [
   "authors",
@@ -10,7 +10,7 @@ dynamic = [
   "urls",
 ]
 dependencies = [
-  "openlinktoken==2.1.1",
+  "openlinktoken==2.1.2",
   "numpy==1.26.4; python_version < '3.14'",
   "numpy==2.3.3; python_version >= '3.14'",
   "onnxruntime==1.23.2; python_version < '3.11'",

--- a/lib/python/openlinktoken-core-ai/setup.py
+++ b/lib/python/openlinktoken-core-ai/setup.py
@@ -51,7 +51,7 @@ with open(os.path.join(THIS_DIR, "requirements.txt"), encoding="utf-8") as f:
 
 setup(
     name="openlinktoken-core-ai",
-    version="2.1.1",
+    version="2.1.2",
     author="Open Link Token Contributors",
     description="Open Link Token Core AI package for ML1/ONNX inference",
     long_description=long_description,

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
@@ -13,8 +13,8 @@ class FirstNameAttribute(BaseAttribute):
     first name fields. It recognizes "FirstName" and "GivenName" as valid aliases
     for this attribute type.
 
-    The attribute performs no normalization on input values, returning them
-    unchanged.
+    The attribute removes titles, suffixes, initials, and non-alphabetic
+    characters during normalization.
     """
 
     NAME = "FirstName"
@@ -39,6 +39,7 @@ class FirstNameAttribute(BaseAttribute):
     #   \.?          Optional period
     #   $            End of string
     TRAILING_PERIOD_AND_INITIAL_PATTERN = re.compile(r"\s[^\s]\.?$")
+    SPACE_DOT_SLASH_ANNE_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+Anne$", re.IGNORECASE)
 
     def __init__(self):
         placeholder_values = AttributeUtilities.COMMON_PLACEHOLDER_NAMES
@@ -85,7 +86,7 @@ class FirstNameAttribute(BaseAttribute):
         return self.ALIASES.copy()
 
     def normalize(self, value: str) -> str:
-        """Returns the value unchanged after removing titles."""
+        """Normalize a first name by removing titles, suffixes, and separators."""
         if not value:
             return value
 
@@ -102,6 +103,10 @@ class FirstNameAttribute(BaseAttribute):
             normalized = without_suffix
 
         normalized = re.sub(self.TRAILING_PERIOD_AND_INITIAL_PATTERN, "", normalized).strip()
+
+        anne_match = re.match(self.SPACE_DOT_SLASH_ANNE_PATTERN, normalized)
+        if anne_match:
+            normalized = anne_match.group(1)
 
         # Remove non-alphabetic characters
         normalized = AttributeUtilities.NON_ALPHABETIC_PATTERN.sub("", normalized)

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
@@ -22,8 +22,8 @@ class FirstNameAttribute(BaseAttribute):
 
     # Pattern to match and remove common titles
     TITLE_PATTERN = re.compile(
-        r"(?i)^\s*(mr|mrs|ms|miss|dr|prof|capt|sir|col|gen|cmdr|lt|"
-        r"rabbi|father|brother|sister|hon|honorable|reverend|rev|doctor)\.?\s+",
+        r"(?i)^\s*(?:(?:mr|mrs|ms|miss|dr|prof|capt|sir|col|gen|cmdr|lt|"
+        r"rabbi|father|brother|sister|hon|honorable|reverend|rev|doctor)\.?\s+)+",
         re.IGNORECASE,
     )
 

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
@@ -39,7 +39,7 @@ class FirstNameAttribute(BaseAttribute):
     #   \.?          Optional period
     #   $            End of string
     TRAILING_PERIOD_AND_INITIAL_PATTERN = re.compile(r"\s[^\s]\.?$")
-    SPACE_DOT_SLASH_ANNE_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+Anne$", re.IGNORECASE)
+    TWO_PART_NAME_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+[A-Za-z]+$")
 
     def __init__(self):
         placeholder_values = AttributeUtilities.COMMON_PLACEHOLDER_NAMES
@@ -104,9 +104,9 @@ class FirstNameAttribute(BaseAttribute):
 
         normalized = re.sub(self.TRAILING_PERIOD_AND_INITIAL_PATTERN, "", normalized).strip()
 
-        anne_match = re.match(self.SPACE_DOT_SLASH_ANNE_PATTERN, normalized)
-        if anne_match:
-            normalized = anne_match.group(1)
+        two_part_name_match = re.match(self.TWO_PART_NAME_PATTERN, normalized)
+        if two_part_name_match:
+            normalized = two_part_name_match.group(1)
 
         # Remove non-alphabetic characters
         normalized = AttributeUtilities.NON_ALPHABETIC_PATTERN.sub("", normalized)

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
@@ -39,7 +39,7 @@ class FirstNameAttribute(BaseAttribute):
     #   \.?          Optional period
     #   $            End of string
     TRAILING_PERIOD_AND_INITIAL_PATTERN = re.compile(r"\s[^\s]\.?$")
-    TWO_PART_NAME_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+[A-Za-z]+(?:[-\u2010-\u2015\u2212][A-Za-z]+)*$")
+    FIRST_PART_NAME_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+[A-Za-z]+(?:[\s./\-\u2010-\u2015\u2212]+[A-Za-z]+)*$")
 
     def __init__(self):
         placeholder_values = AttributeUtilities.COMMON_PLACEHOLDER_NAMES
@@ -104,9 +104,9 @@ class FirstNameAttribute(BaseAttribute):
 
         normalized = re.sub(self.TRAILING_PERIOD_AND_INITIAL_PATTERN, "", normalized).strip()
 
-        two_part_name_match = re.match(self.TWO_PART_NAME_PATTERN, normalized)
-        if two_part_name_match:
-            normalized = two_part_name_match.group(1)
+        first_part_name_match = re.match(self.FIRST_PART_NAME_PATTERN, normalized)
+        if first_part_name_match:
+            normalized = first_part_name_match.group(1)
 
         # Remove non-alphabetic characters
         normalized = AttributeUtilities.NON_ALPHABETIC_PATTERN.sub("", normalized)

--- a/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
+++ b/lib/python/openlinktoken/src/main/openlinktoken/attributes/person/first_name_attribute.py
@@ -39,7 +39,7 @@ class FirstNameAttribute(BaseAttribute):
     #   \.?          Optional period
     #   $            End of string
     TRAILING_PERIOD_AND_INITIAL_PATTERN = re.compile(r"\s[^\s]\.?$")
-    TWO_PART_NAME_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+[A-Za-z]+$")
+    TWO_PART_NAME_PATTERN = re.compile(r"^([A-Za-z]{3,})[\s./]+[A-Za-z]+(?:[-\u2010-\u2015\u2212][A-Za-z]+)*$")
 
     def __init__(self):
         placeholder_values = AttributeUtilities.COMMON_PLACEHOLDER_NAMES

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
@@ -247,19 +247,29 @@ class TestFirstNameAttribute:
         [
             ("Eric Karl", "Eric"),
             ("Hans Peter", "Hans"),
+            ("Anne Marie Julie", "Anne"),
             ("Mary Anne", "Mary"),
             ("Eric.Karl", "Eric"),
             ("Hans/Peter", "Hans"),
+            ("Eric Karl Peter", "Eric"),
             ("Mary-Anne", "MaryAnne"),
             ("Mary–Anne", "MaryAnne"),
-            ("Jo Anne", "JoAnne"),
             ("Mary Anne-Marie", "Mary"),
         ],
     )
-    def test_normalize_should_remove_second_part_for_three_character_prefix_with_non_dash_separators(
-        self, input_name, expected_output
-    ):
-        """Remove the second part only when the prefix has at least three characters."""
+    def test_normalize_should_keep_first_part_with_non_dash_separators(self, input_name, expected_output):
+        """Keep the first part when a name has a non-dash separator."""
+        assert self.first_name_attribute.normalize(input_name) == expected_output
+
+    @pytest.mark.parametrize(
+        ("input_name", "expected_output"),
+        [
+            ("Jo Anne", "JoAnne"),
+            ("Amy Lee", "Amy"),
+        ],
+    )
+    def test_normalize_should_require_three_letter_first_part(self, input_name, expected_output):
+        """Keep two-letter first parts and reduce first parts with at least three letters."""
         assert self.first_name_attribute.normalize(input_name) == expected_output
 
     def test_serialization_should_preserve_state(self):

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
@@ -253,7 +253,7 @@ class TestFirstNameAttribute:
             ("Mary-Anne", "MaryAnne"),
             ("Mary–Anne", "MaryAnne"),
             ("Jo Anne", "JoAnne"),
-            ("Mary Anne-Marie", "MaryAnneMarie"),
+            ("Mary Anne-Marie", "Mary"),
         ],
     )
     def test_normalize_should_remove_second_part_for_three_character_prefix_with_non_dash_separators(

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
@@ -319,9 +319,11 @@ class TestFirstNameAttribute:
         assert self.first_name_attribute.normalize("Mr. ") == "Mr"
         assert self.first_name_attribute.normalize("    Dr.   ") == "Dr"
 
-        # Test multiple titles (should only remove the first one)
+        # Test multiple titles
         assert self.first_name_attribute.normalize("Mr. Smith") == "Smith"
         assert self.first_name_attribute.normalize("Dr. Johnson") == "Johnson"
+        assert self.first_name_attribute.normalize("Mr. Dr. John") == "John"
+        assert self.first_name_attribute.normalize("Dr. Mrs. Jane") == "Jane"
 
         # Test names that start with title-like words but aren't titles
         assert self.first_name_attribute.normalize("Drew") == "Drew"

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
@@ -242,6 +242,25 @@ class TestFirstNameAttribute:
         assert self.first_name_attribute.normalize("Jane@#$") == "Jane"
         assert self.first_name_attribute.normalize("Robert_Smith") == "RobertSmith"
 
+    @pytest.mark.parametrize(
+        ("input_name", "expected_output"),
+        [
+            ("Mary Anne", "Mary"),
+            ("Mary anne", "Mary"),
+            ("Mary.Anne", "Mary"),
+            ("Mary/Anne", "Mary"),
+            ("Mary-Anne", "MaryAnne"),
+            ("Mary–Anne", "MaryAnne"),
+            ("Jo Anne", "JoAnne"),
+            ("Mary Anne-Marie", "MaryAnneMarie"),
+        ],
+    )
+    def test_normalize_should_remove_anne_for_three_character_prefix_with_non_dash_separators(
+        self, input_name, expected_output
+    ):
+        """Remove a trailing space-separated Anne only when the prefix has at least three characters."""
+        assert self.first_name_attribute.normalize(input_name) == expected_output
+
     def test_serialization_should_preserve_state(self):
         """Test serialization and deserialization."""
         original_attribute = FirstNameAttribute()

--- a/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
+++ b/lib/python/openlinktoken/src/test/openlinktoken/attributes/person/first_name_attribute_test.py
@@ -231,9 +231,9 @@ class TestFirstNameAttribute:
         assert self.first_name_attribute.normalize("Dr. François B.") == "Francois"
 
     def test_normalize_should_remove_non_alphabetic_characters(self):
-        """Test removal of dashes, spaces, and other non-alphanumeric characters."""
+        """Test removal of dashes and other non-alphabetic characters."""
         assert self.first_name_attribute.normalize("John-Doe") == "JohnDoe"
-        assert self.first_name_attribute.normalize("Mary Jane") == "MaryJane"
+        assert self.first_name_attribute.normalize("Mary Jane") == "Mary"
         assert self.first_name_attribute.normalize("Ann-Marie") == "AnnMarie"
         assert self.first_name_attribute.normalize("Jean-Luc") == "JeanLuc"
 
@@ -245,20 +245,21 @@ class TestFirstNameAttribute:
     @pytest.mark.parametrize(
         ("input_name", "expected_output"),
         [
+            ("Eric Karl", "Eric"),
+            ("Hans Peter", "Hans"),
             ("Mary Anne", "Mary"),
-            ("Mary anne", "Mary"),
-            ("Mary.Anne", "Mary"),
-            ("Mary/Anne", "Mary"),
+            ("Eric.Karl", "Eric"),
+            ("Hans/Peter", "Hans"),
             ("Mary-Anne", "MaryAnne"),
             ("Mary–Anne", "MaryAnne"),
             ("Jo Anne", "JoAnne"),
             ("Mary Anne-Marie", "MaryAnneMarie"),
         ],
     )
-    def test_normalize_should_remove_anne_for_three_character_prefix_with_non_dash_separators(
+    def test_normalize_should_remove_second_part_for_three_character_prefix_with_non_dash_separators(
         self, input_name, expected_output
     ):
-        """Remove a trailing space-separated Anne only when the prefix has at least three characters."""
+        """Remove the second part only when the prefix has at least three characters."""
         assert self.first_name_attribute.normalize(input_name) == expected_output
 
     def test_serialization_should_preserve_state(self):
@@ -388,7 +389,7 @@ class TestFirstNameAttribute:
             ("Mr. John", "John"),
             ("Dr. Jane B.", "Jane"),
             ("John-Paul", "JohnPaul"),
-            ("Mary Jane", "MaryJane"),
+            ("Mary Jane", "Mary"),
             ("Prof. Robert C", "Robert"),
         ],
     )

--- a/pages/concepts/normalization-and-validation.md
+++ b/pages/concepts/normalization-and-validation.md
@@ -35,10 +35,10 @@ Input → Normalize → Validate → Token Generation
 3. Remove diacritics and transliterate supported Latin Extended letters to ASCII (é → E, Ł → L, Æ → AE)
 4. Remove titles: Dr, Mr, Mrs, Ms, Miss, Prof
 5. Remove suffixes: Jr, Sr, II, III, IV, PhD, MD
-6. For a two-part name with a prefix of at least three letters, remove the
-   second part when it is separated by whitespace, a period, or a slash
-   (for example, `Eric Karl` → `Eric`; `Eric Karl-Peter` → `Eric`;
-   hyphenated `Mary-Anne` remains `MaryAnne`)
+6. For a name with a first part of at least three letters, remove all later
+   parts when the first separator is whitespace, a period, or a slash
+   (for example, `Eric Karl` → `Eric`; `Anne Marie Julie` → `Anne`;
+   `Eric Karl-Peter` → `Eric`; hyphenated `Mary-Anne` remains `MaryAnne`)
 7. Remove non-alphabetic characters (spaces, apostrophes, hyphens, periods)
 
 **Examples:**

--- a/pages/concepts/normalization-and-validation.md
+++ b/pages/concepts/normalization-and-validation.md
@@ -33,7 +33,7 @@ Input → Normalize → Validate → Token Generation
 1. Trim leading/trailing whitespace
 2. Convert to uppercase
 3. Remove diacritics and transliterate supported Latin Extended letters to ASCII (é → E, Ł → L, Æ → AE)
-4. Remove titles: Dr, Mr, Mrs, Ms, Miss, Prof
+4. Remove leading titles, including repeated titles: Dr, Mr, Mrs, Ms, Miss, Prof
 5. Remove suffixes: Jr, Sr, II, III, IV, PhD, MD
 6. For a name with a first part of at least three letters, remove all later
    parts when the first separator is whitespace, a period, or a slash

--- a/pages/concepts/normalization-and-validation.md
+++ b/pages/concepts/normalization-and-validation.md
@@ -35,7 +35,10 @@ Input → Normalize → Validate → Token Generation
 3. Remove diacritics and transliterate supported Latin Extended letters to ASCII (é → E, Ł → L, Æ → AE)
 4. Remove titles: Dr, Mr, Mrs, Ms, Miss, Prof
 5. Remove suffixes: Jr, Sr, II, III, IV, PhD, MD
-6. Remove non-alphabetic characters (spaces, apostrophes, hyphens, periods)
+6. For a prefix of at least three letters, remove a trailing `Anne` when it is
+   separated by whitespace, a period, or a slash (for example, `Mary Anne` →
+   `Mary`; hyphenated `Mary-Anne` remains `MaryAnne`)
+7. Remove non-alphabetic characters (spaces, apostrophes, hyphens, periods)
 
 **Examples:**
 

--- a/pages/concepts/normalization-and-validation.md
+++ b/pages/concepts/normalization-and-validation.md
@@ -37,7 +37,8 @@ Input → Normalize → Validate → Token Generation
 5. Remove suffixes: Jr, Sr, II, III, IV, PhD, MD
 6. For a two-part name with a prefix of at least three letters, remove the
    second part when it is separated by whitespace, a period, or a slash
-   (for example, `Eric Karl` → `Eric`; hyphenated `Mary-Anne` remains `MaryAnne`)
+   (for example, `Eric Karl` → `Eric`; `Eric Karl-Peter` → `Eric`;
+   hyphenated `Mary-Anne` remains `MaryAnne`)
 7. Remove non-alphabetic characters (spaces, apostrophes, hyphens, periods)
 
 **Examples:**

--- a/pages/concepts/normalization-and-validation.md
+++ b/pages/concepts/normalization-and-validation.md
@@ -35,9 +35,9 @@ Input → Normalize → Validate → Token Generation
 3. Remove diacritics and transliterate supported Latin Extended letters to ASCII (é → E, Ł → L, Æ → AE)
 4. Remove titles: Dr, Mr, Mrs, Ms, Miss, Prof
 5. Remove suffixes: Jr, Sr, II, III, IV, PhD, MD
-6. For a prefix of at least three letters, remove a trailing `Anne` when it is
-   separated by whitespace, a period, or a slash (for example, `Mary Anne` →
-   `Mary`; hyphenated `Mary-Anne` remains `MaryAnne`)
+6. For a two-part name with a prefix of at least three letters, remove the
+   second part when it is separated by whitespace, a period, or a slash
+   (for example, `Eric Karl` → `Eric`; hyphenated `Mary-Anne` remains `MaryAnne`)
 7. Remove non-alphabetic characters (spaces, apostrophes, hyphens, periods)
 
 **Examples:**


### PR DESCRIPTION
## Summary

- Generalize first-name normalization for values with multiple parts.
- Reduce non-dash-separated forms to the first component.
- Preserve dash-separated first names as one combined name.

## Related issues

- N/A

## Affected surfaces

- [x] Java
- [x] Python
- [ ] CLI
- [ ] PySpark
- [x] Docs / GitHub Pages
- [ ] CI / workflows / agent instructions
- [ ] Release process

## What changed

- Remove repeated leading titles before normalizing the remaining first-name value.
- Keep the first component when it contains at least three letters and the first separator is whitespace, a period, or a slash.
- Remove all later components when they are separated by whitespace, periods, slashes, or dash characters.
- Treat a dash between the first and second components as part of one combined name, so Jean-Luc remains JeanLuc.
- Run this rule after title, suffix, and middle-initial cleanup.
- Preserve the existing behavior for first components shorter than three letters.
- Keep the Java and Python implementations aligned for cross-language normalization parity.
- Add coverage for repeated titles, two-part and multi-part values, internal hyphens, Unicode dashes, and the three-letter minimum.
- Update the normalization documentation.

Examples: Dr. Mrs. Jane becomes Jane, Eric Karl becomes Eric, Anne Marie Julie becomes Anne, Eric Karl-Peter becomes Eric, and Jean-Luc remains JeanLuc.

Validation: Python first-name tests pass in the Dev Container (87 tests). Java first-name tests pass in the Dev Container. Pre-commit hooks pass on the changed files.